### PR TITLE
bugfix/WATER-1086: Plurals in notifications

### DIFF
--- a/migrations/20180611140259-update-renewal-notification.js
+++ b/migrations/20180611140259-update-renewal-notification.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180611140259-update-renewal-notification-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180611140259-update-renewal-notification-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20180612103140-update-hof-resume-notification.js
+++ b/migrations/20180612103140-update-hof-resume-notification.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180612103140-update-hof-resume-notification-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180612103140-update-hof-resume-notification-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20180612104443-hof-stop-reduce-notification.js
+++ b/migrations/20180612104443-hof-stop-reduce-notification.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180612104443-hof-stop-reduce-notification-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180612104443-hof-stop-reduce-notification-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20180612105605-update-hof-warning-notification.js
+++ b/migrations/20180612105605-update-hof-warning-notification.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180612105605-update-hof-warning-notification-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180612105605-update-hof-warning-notification-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20180611140259-update-renewal-notification-down.sql
+++ b/migrations/sqls/20180611140259-update-renewal-notification-down.sql
@@ -1,0 +1,84 @@
+-- Renewal Notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+  "name": "Expiring licence(s): invitation to renew",
+  "title": "Send an invitation to renew",
+  "variables": [
+      {
+          "mapper": "date",
+          "widget": "date",
+          "name": "application_date",
+          "default": "",
+          "label": "Renewal application deadline",
+          "validation": [
+              "string",
+              "required"
+          ]
+      },
+      {
+          "default": "",
+          "widget": "text",
+          "validation": [
+              "string",
+              "required"
+          ],
+          "name": "sender_name",
+          "label": "Name of sender"
+      },
+      {
+          "default": "",
+          "widget": "text",
+          "validation": [
+              "string",
+              "required"
+          ],
+          "name": "sender_role",
+          "label": "Job title of sender"
+      },
+      {
+      	  "mapper": "address",
+          "default": "",
+          "widget": "textarea",
+          "validation": [
+              "string",
+              "required"
+          ],
+          "name": "sender_address",
+          "label": "Address of sender"
+      }
+  ],
+  "content": {
+  "default": "Dear licence holder,\n\nAll or part of the following abstraction licences will expire soon:\n\n{% for licence in licences %}\n{% for point in licence.points %}\n{{ licence.licenceNumber }} for {{ point.name }}{% if licence.expiryDate %} expires on {{ licence.expiryDate }}{% endif %}\n{% endfor %}\n{% endfor %}\n\n# When to submit your renewal application(s)\n\nIf you want to continue abstracting water after the expiry date(s) included above, please send your renewal application(s) to us by {{ params.application_date }}.\n\nThis will ensure we have enough time to process your application(s) before your current licence(s) expire.\n\n\n# How to apply to renew your licence(s) with different terms\n\nIf you want to change any of the terms of your current licence(s), you need to submit a new licence application.\n\nThe application forms can be found on our website: https://www.gov.uk/guidance/water-management-apply-for-a-water-abstraction-or-impoundment-licence\n\n\n# How to apply to renew your licence(s) with exactly the same terms\n\nPlease complete this online form for each licence: [URL TBC].\n\n# How to complete your renewal form(s)\n\nYou must check that the following details are correct:\n\n* the licence holder''s name and contact details\n* the abstraction point, reach and area you take water from\n* what you use the water for\n* the abstraction period(s)\n\n\nYou must also demonstrate your need to abstract the same quantities of water as your current licence allows. To do this you need to include:\n\n* details about how you use your current abstraction quantities\n* usage information from previous years (if you have this information)\n* if you abstract water for spray irrigation, include the type and area of crops you will grow and irrigate\n\n^We cannot process your renewal application(s) if you do not provide all of this information.\n\n\n# How to submit your renewal form(s)\n\n\nWhen you submit your form, you must also include:\n\n* your £135 application fee\n* a map showing the area of land you have a right of access to, and the point, reach or area you take water from\n\nYour application form(s) must be signed by the correct person, as described below.  If you are:\n\n* an Individual then you need to sign the application\n* a number of individuals then you all need to sign the application\n* a Limited Liability Partnership then a partner, company director or company secretary need to sign the application\n* a Registered Company then the Company Director or Company Secretary need to sign the application\n* a Public Body (such as a local authority or NHS trust) then a person authorised to sign documents on behalf of the organisation needs to sign the application\n* a Partnership then one or more of the partners must sign the application\n* a Trust then all trustees or the chairman, treasurer or secretary must sign the application\n\n\n# What happens after you apply\n\nWe will consider your application and should be able to grant you a new licence provided that:\n\n* you submit the information and payment detailed in this notification\n* your abstraction is environmentally sustainable\n* you have justified the amount of water you need to abstract\n* you demonstrate that you are using water efficiently\n\nWe will contact you if we need any more information to process your renewal application(s).\n\nYou may also receive a letter from your local area team about future changes we may need to make to ensure your abstraction is sustainable.\n\n\n# How to contact us\n\nTo discuss any changes you would like to make please call us on 0114 2898 340.\n\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n"
+  },
+  "prefix": "RENEW-",
+  "steps": [
+      {
+          "widgets": [
+              {
+                  "mapper": "licenceNumbers",
+                  "widget": "textarea",
+                  "name": "system_external_id",
+                  "hint": "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+                  "error_label": "licence number(s)",
+                  "label": "Enter the licence number(s) you want to send a notification about",
+                  "operator": "$in",
+                  "validation": [
+                      "array",
+                      "min:1"
+                  ]
+              }
+          ]
+      }
+  ],
+  "formats": [
+      "email",
+      "letter"
+  ],
+  "permissions": [
+      "admin:defra"
+  ],
+  "subject": "Invitation to apply for a water abstraction licence renewal "
+}'
+WHERE task_config_id = 2;
+

--- a/migrations/sqls/20180611140259-update-renewal-notification-up.sql
+++ b/migrations/sqls/20180611140259-update-renewal-notification-up.sql
@@ -1,0 +1,84 @@
+-- Renewal Notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+  "name": "Expiring licence(s): invitation to renew",
+  "title": "Send an invitation to renew",
+  "variables": [
+      {
+          "mapper": "date",
+          "widget": "date",
+          "name": "application_date",
+          "default": "",
+          "label": "Renewal application deadline",
+          "validation": [
+              "string",
+              "required"
+          ]
+      },
+      {
+          "default": "",
+          "widget": "text",
+          "validation": [
+              "string",
+              "required"
+          ],
+          "name": "sender_name",
+          "label": "Name of sender"
+      },
+      {
+          "default": "",
+          "widget": "text",
+          "validation": [
+              "string",
+              "required"
+          ],
+          "name": "sender_role",
+          "label": "Job title of sender"
+      },
+      {
+      	  "mapper": "address",
+          "default": "",
+          "widget": "textarea",
+          "validation": [
+              "string",
+              "required"
+          ],
+          "name": "sender_address",
+          "label": "Address of sender"
+      }
+  ],
+  "content": {
+  "default": "{% if isPost %}The Water Resources Act 1991  \nOur reference: {{ ref }}\n\n{% endif %}Dear licence holder,\n\nAll or part of the following abstraction licences will expire soon:\n\n{% for licence in licences %}\n{% for point in licence.points %}\n{{ licence.licenceNumber }} for {{ point.name }}{% if licence.expiryDate %} expires on {{ licence.expiryDate }}{% endif %}\n{% endfor %}\n{% endfor %}\n\n# When to submit your renewal application{{ ''s'' if pluralLicence }}\n\nIf you want to continue abstracting water after the expiry date{{ ''s'' if pluralLicence }} included above, please send your renewal application{{ ''s'' if pluralLicence }} to us by {{ params.application_date }}.\n\nThis will ensure we have enough time to process your application{{ ''s'' if pluralLicence }} before your current licence{{ ''s'' if pluralLicence }} expire{{ ''s'' if pluralLicence == false }}.\n\n\n# How to apply to renew your licence{{ ''s'' if pluralLicence }} with different terms\n\nIf you want to change any of the terms of your current licence{{ ''s'' if pluralLicence }}, you need to submit a new licence application.\n\nThe application forms can be found on our website: https://www.gov.uk/guidance/water-management-apply-for-a-water-abstraction-or-impoundment-licence\n\n\n# How to apply to renew your licence{{ ''s'' if pluralLicence }} with exactly the same terms\n\nPlease complete this online form for each licence: [URL TBC].\n\n# How to complete your renewal form{{ ''s'' if pluralLicence }}\n\nYou must check that the following details are correct:\n\n* the licence holder''s name and contact details\n* the abstraction point, reach and area you take water from\n* what you use the water for\n* the abstraction period{{ ''s'' if pluralLicence }}\n\n\nYou must also demonstrate your need to abstract the same quantities of water as your current licence allows. To do this you need to include:\n\n* details about how you use your current abstraction quantities\n* usage information from previous years (if you have this information)\n* if you abstract water for spray irrigation, include the type and area of crops you will grow and irrigate\n\n^We cannot process your renewal application{{ ''s'' if pluralLicence }} if you do not provide all of this information.\n\n\n# How to submit your renewal form{{ ''s'' if pluralLicence }}\n\n\nWhen you submit your form, you must also include:\n\n* your £135 application fee\n* a map showing the area of land you have a right of access to, and the point, reach or area you take water from\n\nYour application form{{ ''s'' if pluralLicence }} must be signed by the correct person, as described below.  If you are:\n\n* an Individual then you need to sign the application\n* a number of individuals then you all need to sign the application\n* a Limited Liability Partnership then a partner, company director or company secretary need to sign the application\n* a Registered Company then the Company Director or Company Secretary need to sign the application\n* a Public Body (such as a local authority or NHS trust) then a person authorised to sign documents on behalf of the organisation needs to sign the application\n* a Partnership then one or more of the partners must sign the application\n* a Trust then all trustees or the chairman, treasurer or secretary must sign the application\n\n\n# What happens after you apply\n\nWe will consider your application and should be able to grant you a new licence provided that:\n\n* you submit the information and payment detailed in this notification\n* your abstraction is environmentally sustainable\n* you have justified the amount of water you need to abstract\n* you demonstrate that you are using water efficiently\n\nWe will contact you if we need any more information to process your renewal application{{ ''s'' if pluralLicence }}.\n\nYou may also receive a letter from your local area team about future changes we may need to make to ensure your abstraction is sustainable.\n\n\n# How to contact us\n\nTo discuss any changes you would like to make please call us on 0114 2898 340.\n\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n"
+  },
+  "prefix": "RENEW-",
+  "steps": [
+      {
+          "widgets": [
+              {
+                  "mapper": "licenceNumbers",
+                  "widget": "textarea",
+                  "name": "system_external_id",
+                  "hint": "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+                  "error_label": "licence number(s)",
+                  "label": "Enter the licence number(s) you want to send a notification about",
+                  "operator": "$in",
+                  "validation": [
+                      "array",
+                      "min:1"
+                  ]
+              }
+          ]
+      }
+  ],
+  "formats": [
+      "email",
+      "letter"
+  ],
+  "permissions": [
+      "admin:defra"
+  ],
+  "subject": "Invitation to apply for a water abstraction licence renewal "
+}'
+WHERE task_config_id = 2;
+

--- a/migrations/sqls/20180612103140-update-hof-resume-notification-down.sql
+++ b/migrations/sqls/20180612103140-update-hof-resume-notification-down.sql
@@ -1,0 +1,124 @@
+-- HOF Resume Notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+    "prefix" : "HOF-",
+    "content" : {
+      "default" : "Our reference: {{ ref }}\n\nWater Resources Act 1991\n\nDear licence holder,\n\n# You can now start or increase your water abstraction, if the terms of your licence(s) allow this.\n\nWe notified you on {{ params.date_of_stop }} that we needed to enforce the hands off flow condition in your licence(s).\n\nWatercourse levels have now risen again, so you can start or increase your water abstraction if the conditions of your licence(s) allow it.\n\n# What happens next\n\nWe will notify you if river levels drop and we need to enforce your hands-off flow condition(s) again.\n\n# How to contact us\n\nIf you have any questions about this notification, please contact {{ params.contact_name }} on {{ params.contact_details }}.\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n\n\n# Your hands off flow details\n\nLicence number: {% for licence in licences %} {{ licence.licenceNumber }} {% endfor %}  \nGauging station: {{ params.gauging_station }}  \nHands off flow threshold: {{ params.hof_threshold }}\n"
+    },
+    "steps" : [
+      {
+        "widgets" : [
+          {
+            "mapper" : "licenceNumbers",
+            "widget" : "textarea",
+            "operator" : "$in",
+            "error_label" : "licence number(s)",
+            "hint" : "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+            "label" : "Enter the licence number(s) you want to send a notification about",
+            "validation" : [
+              "array",
+              "min:1"
+            ],
+            "name" : "system_external_id"
+          }
+        ]
+      }
+    ],
+    "title" : "Send a hands off flow resume notice",
+    "subject" : "Notice of the end of restriction on abstraction",
+    "variables" : [
+      {
+        "mapper" : "date",
+        "label" : "Date of stop notice",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "date_of_stop",
+        "widget" : "date"
+      },
+      {
+        "label" : "Gauging station",
+        "default" : "",
+        "helptext" : "The EA gauging station name",
+        "name" : "gauging_station",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "widget" : "text"
+      },
+      {
+        "label" : "Flow restriction threshold",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "hof_threshold",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact name for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact number or email for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_details",
+        "widget" : "text"
+      },
+      {
+        "label" : "Name of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Job title of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_role",
+        "widget" : "text"
+      },
+      {
+        "label" : "Address of sender",
+        "mapper": "address",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_address",
+        "widget" : "textarea"
+      }
+    ],
+    "formats" : [
+      "email",
+      "letter"
+    ],
+    "permissions" : [
+      "admin:defra"
+    ],
+    "name" : "Hands off flow: resume abstraction"
+  }'
+WHERE task_config_id = 4;

--- a/migrations/sqls/20180612103140-update-hof-resume-notification-up.sql
+++ b/migrations/sqls/20180612103140-update-hof-resume-notification-up.sql
@@ -1,0 +1,124 @@
+-- HOF Resume Notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+    "prefix" : "HOF-",
+    "content" : {
+      "default" : "{% if isPost %}The Water Resources Act 1991  \nOur reference: {{ ref }}\n\n{% endif %}Dear licence holder,\n\n# You can now start or increase your water abstraction, if the terms of your licence{{ ''s'' if pluralLicence }} allow this.\n\nWe notified you on {{ params.date_of_stop }} that we needed to enforce the hands off flow conditions in your licence{{ ''s'' if pluralLicence }}.\n\nWatercourse levels have now risen again, so you can start or increase your water abstraction if the conditions of your licence{{ ''s'' if pluralLicence }} allow it.\n\n# What happens next\n\nWe will notify you if river levels drop and we need to enforce your hands-off flow condition again.\n\n# How to contact us\n\nIf you have any questions about this notification, please contact {{ params.contact_name }} on {{ params.contact_details }}.\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n\n\n# Your hands off flow details\n\nLicence number: {% for licence in licences %} {{ licence.licenceNumber }} {% endfor %}  \nGauging station: {{ params.gauging_station }}  \nHands off flow threshold: {{ params.hof_threshold }}\n"
+    },
+    "steps" : [
+      {
+        "widgets" : [
+          {
+            "mapper" : "licenceNumbers",
+            "widget" : "textarea",
+            "operator" : "$in",
+            "error_label" : "licence number(s)",
+            "hint" : "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+            "label" : "Enter the licence number(s) you want to send a notification about",
+            "validation" : [
+              "array",
+              "min:1"
+            ],
+            "name" : "system_external_id"
+          }
+        ]
+      }
+    ],
+    "title" : "Send a hands off flow resume notice",
+    "subject" : "Notice of the end of restriction on abstraction",
+    "variables" : [
+      {
+        "mapper" : "date",
+        "label" : "Date of stop notice",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "date_of_stop",
+        "widget" : "date"
+      },
+      {
+        "label" : "Gauging station",
+        "default" : "",
+        "helptext" : "The EA gauging station name",
+        "name" : "gauging_station",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "widget" : "text"
+      },
+      {
+        "label" : "Flow restriction threshold",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "hof_threshold",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact name for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact number or email for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_details",
+        "widget" : "text"
+      },
+      {
+        "label" : "Name of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Job title of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_role",
+        "widget" : "text"
+      },
+      {
+        "label" : "Address of sender",
+        "mapper": "address",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_address",
+        "widget" : "textarea"
+      }
+    ],
+    "formats" : [
+      "email",
+      "letter"
+    ],
+    "permissions" : [
+      "admin:defra"
+    ],
+    "name" : "Hands off flow: resume abstraction"
+  }'
+WHERE task_config_id = 4;

--- a/migrations/sqls/20180612104443-hof-stop-reduce-notification-down.sql
+++ b/migrations/sqls/20180612104443-hof-stop-reduce-notification-down.sql
@@ -1,0 +1,123 @@
+-- Stop reduce notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+    "prefix" : "HOF-",
+    "content" : {
+      "default" : "Our reference: {{ ref }}\n\nWater Resources Act 1991\n\nDear licence holder,\n\n# We need to enforce the hands off flow condition of your licence(s) because river levels are very low.\n\n\n # Why you are receiving this notification\n\nYou have a ‘hands off flow’ condition in your water abstraction licence(s). That condition authorises and restricts how much water you can abstract when the flow in the relevant watercourse has fallen below a certain level.\n\nThe effect that the condition has on your abstraction is explained in your licence(s). You must comply with this condition and you should contact us if you are not sure how your abstraction will be affected.\n\n# What happens next\n\nWe will write to you again when the watercourse level is high enough for you to abstract without the hands off flow restriction, if the other conditions of your licence(s) allow this.   \n\n# How to contact us\n\nIf you have any questions about this notification, please contact {{ params.contact_name }} on {{ params.contact_details }}.\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n\n\n# Your hands off flow details\n\nWatercourse: {{ params.watercourse }}  \nGauging station: {{ params.gauging_station }}  \nFlow restriction threshold: {{ params.hof_threshold }}\n\nEffect of restriction:\n{% for licence in licences %}\nLicence number: {{ licence.licenceNumber }}\n{% for condition in licence.conditions %}\n  {% if (condition.code == ''CES'') and (condition.subCode == ''FLOW'' or condition.subCode == ''LEV'') %}\n    {% for point in condition.points %}\n      {% for pointCondition in point.conditions %}\n{{ condition.displayTitle }}\n{{ condition.parameter1Label }}: {{ pointCondition.parameter1 }}\n{{ condition.parameter2Label }}: {{ pointCondition.parameter2 }}\n      {% endfor %}\n    {% endfor %}\n  {% endif %}\n{% endfor %}\n{% endfor %}\n"
+    },
+    "steps" : [
+      {
+        "widgets" : [
+          {
+            "mapper" : "licenceNumbers",
+            "widget" : "textarea",
+            "operator" : "$in",
+            "error_label" : "licence number(s)",
+            "hint" : "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+            "label" : "Enter the licence number(s) you want to send a notification about",
+            "validation" : [
+              "array",
+              "min:1"
+            ],
+            "name" : "system_external_id"
+          }
+        ]
+      }
+    ],
+    "title" : "Send a hands off flow restriction notice",
+    "subject" : "Notice of restriction on abstraction",
+    "variables" : [
+      {
+        "label" : "Watercourse",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "watercourse",
+        "widget" : "text"
+      },
+      {
+        "label" : "Gauging station",
+        "default" : "",
+        "helptext" : "The EA gauging station name",
+        "name" : "gauging_station",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "widget" : "text"
+      },
+      {
+        "label" : "Flow restriction threshold",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "hof_threshold",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact name for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact number or email for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_details",
+        "widget" : "text"
+      },
+      {
+        "label" : "Name of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Job title of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_role",
+        "widget" : "text"
+      },
+      {
+        "label" : "Address of sender",
+        "mapper": "address",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_address",
+        "widget" : "textarea"
+      }
+    ],
+    "formats" : [
+      "email",
+      "letter"
+    ],
+    "permissions" : [
+      "admin:defra"
+    ],
+    "name" : "Hands off flow: stop or reduce abstraction"
+  }'
+WHERE task_config_id = 3;

--- a/migrations/sqls/20180612104443-hof-stop-reduce-notification-up.sql
+++ b/migrations/sqls/20180612104443-hof-stop-reduce-notification-up.sql
@@ -1,0 +1,123 @@
+-- Stop reduce notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+    "prefix" : "HOF-",
+    "content" : {
+      "default" : "{% if isPost %}The Water Resources Act 1991  \nOur reference: {{ ref }}\n\n{% endif %}Dear licence holder,\n\n# We need to enforce the hands off flow condition of your licence{{ ''s'' if pluralLicence }} because river levels are very low.\n\n\n # Why you are receiving this notification\n\nYou have a ‘hands off flow’ condition in your water abstraction licence{{ ''s'' if pluralLicence }}. That condition authorises and restricts how much water you can abstract when the flow in the relevant watercourse has fallen below a certain level.\n\nThe effect that the condition has on your abstraction is explained in your licence{{ ''s'' if pluralLicence }}. You must comply with this condition and you should contact us if you are not sure how your abstraction will be affected.\n\n# What happens next\n\nWe will write to you again when the watercourse level is high enough for you to abstract without the hands off flow restriction, if the other conditions of your licence{{ ''s'' if pluralLicence }} allow this.   \n\n# How to contact us\n\nIf you have any questions about this notification, please contact {{ params.contact_name }} on {{ params.contact_details }}.\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n\n\n# Your hands off flow details\n\nWatercourse: {{ params.watercourse }}  \nGauging station: {{ params.gauging_station }}  \nFlow restriction threshold: {{ params.hof_threshold }}\n\nEffect of restriction:\n{% for licence in licences %}\nLicence number: {{ licence.licenceNumber }}\n{% for condition in licence.conditions %}\n  {% if (condition.code == ''CES'') and (condition.subCode == ''FLOW'' or condition.subCode == ''LEV'') %}\n    {% for point in condition.points %}\n      {% for pointCondition in point.conditions %}\n{{ condition.displayTitle }}\n{{ condition.parameter1Label }}: {{ pointCondition.parameter1 }}\n{{ condition.parameter2Label }}: {{ pointCondition.parameter2 }}\n      {% endfor %}\n    {% endfor %}\n  {% endif %}\n{% endfor %}\n{% endfor %}\n"
+    },
+    "steps" : [
+      {
+        "widgets" : [
+          {
+            "mapper" : "licenceNumbers",
+            "widget" : "textarea",
+            "operator" : "$in",
+            "error_label" : "licence number(s)",
+            "hint" : "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+            "label" : "Enter the licence number(s) you want to send a notification about",
+            "validation" : [
+              "array",
+              "min:1"
+            ],
+            "name" : "system_external_id"
+          }
+        ]
+      }
+    ],
+    "title" : "Send a hands off flow restriction notice",
+    "subject" : "Notice of restriction on abstraction",
+    "variables" : [
+      {
+        "label" : "Watercourse",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "watercourse",
+        "widget" : "text"
+      },
+      {
+        "label" : "Gauging station",
+        "default" : "",
+        "helptext" : "The EA gauging station name",
+        "name" : "gauging_station",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "widget" : "text"
+      },
+      {
+        "label" : "Flow restriction threshold",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "hof_threshold",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact name for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact number or email for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_details",
+        "widget" : "text"
+      },
+      {
+        "label" : "Name of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Job title of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_role",
+        "widget" : "text"
+      },
+      {
+        "label" : "Address of sender",
+        "mapper": "address",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_address",
+        "widget" : "textarea"
+      }
+    ],
+    "formats" : [
+      "email",
+      "letter"
+    ],
+    "permissions" : [
+      "admin:defra"
+    ],
+    "name" : "Hands off flow: stop or reduce abstraction"
+  }'
+WHERE task_config_id = 3;

--- a/migrations/sqls/20180612105605-update-hof-warning-notification-down.sql
+++ b/migrations/sqls/20180612105605-update-hof-warning-notification-down.sql
@@ -1,0 +1,113 @@
+-- HOF Warning Notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+    "prefix" : "HOF-",
+    "content" : {
+      "default" : "Our reference: {{ ref }}\n\nWater Resources Act 1991\n\nDear licence holder,\n\n# This is an advance warning that you may be asked to stop or reduce your water abstraction soon.\n\n# Why you are receiving this notification\n\nYou have a ‘hands off flow’ condition in your water abstraction licence(s). That condition authorises and restricts how much water you can abstract when the flow in the relevant watercourse has fallen below a certain level.\n\n# What you need to do\n\nYou can continue to abstract water until further notice, if the conditions of your licence(s) allow it.\n\nWe will send you a notification if river levels fall further and restrictions on abstraction are applied. You must follow any instructions given in that notification.\n\n# How to contact us\n\nIf you have any questions about this notification, please contact {{ params.contact_name }} on {{ params.contact_details }}.\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n\n# Your hands off flow details\n\nLicence number: {% for licence in licences %} {{ licence.licenceNumber }} {% endfor %}  \nGauging station: {{ params.gauging_station }}  \nHands off flow threshold: {{ params.hof_threshold }}\n"
+    },
+    "steps" : [
+      {
+        "widgets" : [
+          {
+            "mapper" : "licenceNumbers",
+            "widget" : "textarea",
+            "operator" : "$in",
+            "error_label" : "licence number(s)",
+            "hint" : "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+            "label" : "Enter the licence number(s) you want to send a notification about",
+            "validation" : [
+              "array",
+              "min:1"
+            ],
+            "name" : "system_external_id"
+          }
+        ]
+      }
+    ],
+    "title" : "Send a hands off flow warning",
+    "subject" : "Warning: Abstraction restrictions may happen soon",
+    "variables" : [
+      {
+        "label" : "Gauging station",
+        "default" : "",
+        "helptext" : "The EA gauging station name",
+        "name" : "gauging_station",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "widget" : "text"
+      },
+      {
+        "label" : "Hands off flow threshold",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "hof_threshold",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact name for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact number or email for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_details",
+        "widget" : "text"
+      },
+      {
+        "label" : "Name of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Job title of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_role",
+        "widget" : "text"
+      },
+      {
+        "label" : "Address of sender",
+        "mapper": "address",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_address",
+        "widget" : "textarea"
+      }
+    ],
+    "formats" : [
+      "email",
+      "letter"
+    ],
+    "permissions" : [
+      "admin:defra"
+    ],
+    "name" : "Hands off flow: levels warning"
+  }'
+WHERE task_config_id = 1;

--- a/migrations/sqls/20180612105605-update-hof-warning-notification-up.sql
+++ b/migrations/sqls/20180612105605-update-hof-warning-notification-up.sql
@@ -1,0 +1,113 @@
+-- HOF Warning Notification
+UPDATE "water"."task_config"
+SET modified = NOW(),
+  config = '{
+    "prefix" : "HOF-",
+    "content" : {
+      "default" : "{% if isPost %}The Water Resources Act 1991  \nOur reference: {{ ref }}\n\n{% endif %}Dear licence holder,\n\n# This is an advance warning that you may be asked to stop or reduce your water abstraction soon.\n\n# Why you are receiving this notification\n\nYou have a ‘hands off flow’ condition in your water abstraction licence{{ ''s'' if pluralLicence }}. That condition authorises and restricts how much water you can abstract when the flow in the relevant watercourse has fallen below a certain level.\n\n# What you need to do\n\nYou can continue to abstract water until further notice, if the conditions of your licence{{ ''s'' if pluralLicence }} allow it.\n\nWe will send you a notification if river levels fall further and restrictions on abstraction are applied. You must follow any instructions given in that notification.\n\n# How to contact us\n\nIf you have any questions about this notification, please contact {{ params.contact_name }} on {{ params.contact_details }}.\n\n\nYours faithfully\n\n{{ params.sender_name }}  \n{{ params.sender_role }}  \n{{ params.sender_address }}\n\n# Your hands off flow details\n\nLicence number: {% for licence in licences %} {{ licence.licenceNumber }} {% endfor %}  \nGauging station: {{ params.gauging_station }}  \nHands off flow threshold: {{ params.hof_threshold }}\n"
+    },
+    "steps" : [
+      {
+        "widgets" : [
+          {
+            "mapper" : "licenceNumbers",
+            "widget" : "textarea",
+            "operator" : "$in",
+            "error_label" : "licence number(s)",
+            "hint" : "You can separate licence numbers using spaces, commas, or by entering them on different lines.",
+            "label" : "Enter the licence number(s) you want to send a notification about",
+            "validation" : [
+              "array",
+              "min:1"
+            ],
+            "name" : "system_external_id"
+          }
+        ]
+      }
+    ],
+    "title" : "Send a hands off flow warning",
+    "subject" : "Warning: Abstraction restrictions may happen soon",
+    "variables" : [
+      {
+        "label" : "Gauging station",
+        "default" : "",
+        "helptext" : "The EA gauging station name",
+        "name" : "gauging_station",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "widget" : "text"
+      },
+      {
+        "label" : "Hands off flow threshold",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "hof_threshold",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact name for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Contact number or email for questions",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "contact_details",
+        "widget" : "text"
+      },
+      {
+        "label" : "Name of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_name",
+        "widget" : "text"
+      },
+      {
+        "label" : "Job title of sender",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_role",
+        "widget" : "text"
+      },
+      {
+        "label" : "Address of sender",
+        "mapper": "address",
+        "default" : "",
+        "validation" : [
+          "string",
+          "required"
+        ],
+        "name" : "sender_address",
+        "widget" : "textarea"
+      }
+    ],
+    "formats" : [
+      "email",
+      "letter"
+    ],
+    "permissions" : [
+      "admin:defra"
+    ],
+    "name" : "Hands off flow: levels warning"
+  }'
+WHERE task_config_id = 1;

--- a/src/modules/notifications/lib/index.js
+++ b/src/modules/notifications/lib/index.js
@@ -1,6 +1,5 @@
 const getContactList = require('./contact-list');
 const licenceLoader = require('./licence-loader');
-const taskConfigLoader = require('./task-config-loader');
 const templateRenderer = require('./template-renderer');
 const eventFactory = require('./event-factory');
 const notificationFactory = require('./notification-factory');

--- a/src/modules/notifications/lib/template-renderer.js
+++ b/src/modules/notifications/lib/template-renderer.js
@@ -61,8 +61,10 @@ function renderTemplates (taskConfig, params, contacts, licences, context = {}) 
       params,
       contact,
       licences: licenceList,
+      pluralLicence: licenceList.length !== 1,
       date,
-      ...context
+      ...context,
+      isPost: contact.method === 'post'
     };
 
     // Get the correct Nunjucks template for the message type

--- a/test/modules/notifications/lib/template-renderer.js
+++ b/test/modules/notifications/lib/template-renderer.js
@@ -1,0 +1,65 @@
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const { expect } = require('code');
+
+const renderTemplates = require('../../../../src/modules/notifications/lib/template-renderer');
+
+lab.experiment('Plurals', () => {
+  const getContacts = multiLicence => {
+    const contact = { method: 'post' };
+    contact.licences = multiLicence ? ['one', 'two'] : ['one'];
+    return [contact];
+  };
+  const licences = { one: {}, two: {} };
+  const template = '{{ \'Plural\' if pluralLicence }}{{ \'Singular\' if pluralLicence == false }}';
+  const task = {
+    config: {
+      content: { default: template }
+    }
+  };
+
+  lab.test('When one licence the pluralLicence value is false', async () => {
+    const rendered = renderTemplates(task, {}, getContacts(false), licences);
+    expect(rendered[0].output).to.equal('Singular');
+  });
+
+  lab.test('When zero licences the pluralLicence value is true', async () => {
+    const contacts = getContacts();
+    contacts[0].licences = [];
+
+    const rendered = renderTemplates(task, {}, contacts, {});
+    expect(rendered[0].output).to.equal('Plural');
+  });
+
+  lab.test('When two licences the pluralLicence value is true', async () => {
+    const rendered = renderTemplates(task, {}, getContacts(true), licences);
+    expect(rendered[0].output).to.equal('Plural');
+  });
+});
+
+lab.experiment('isPost', () => {
+  const getContacts = method => {
+    const contact = { method };
+    contact.licences = ['one'];
+    return [contact];
+  };
+  const licences = { one: {} };
+  const template = '{{ \'Post\' if isPost }}{{ \'Not Post\' if isPost == false }}';
+  const task = {
+    config: {
+      content: { default: template }
+    }
+  };
+
+  lab.test('Renders specific text for a post contact method', async () => {
+    const rendered = renderTemplates(task, {}, getContacts('post'), licences);
+    expect(rendered[0].output).to.equal('Post');
+  });
+
+  lab.test('Renders specific text if not a post contact method', async () => {
+    const rendered = renderTemplates(task, {}, getContacts('sms'), licences);
+    expect(rendered[0].output).to.equal('Not Post');
+  });
+});
+
+exports.lab = lab;


### PR DESCRIPTION
Changes the notifications to append an 's' where appropriate in place of
using text such as 'licence(s)'.

Also will add some letter specific content to the start of the message
if the contact is receiving their notifications via post.