### PR TITLE
Only watch the file system in local dev

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -1,13 +1,19 @@
 {
   "apps": [
     {
-      "watch": true,
       "name": "water-api",
       "ignore_watch": [
         "node_modules",
-        "src/lib/temp"
+        "src/lib/temp",
+        "temp"
       ],
-      "script": "index.js"
+      "script": "index.js",
+      "env": {
+        "watch": true
+      },
+      "env_production": {
+        "watch": false
+      }
     }
   ]
 }


### PR DESCRIPTION
Uses the ecosystem env region to prevent file watching in production.