### PR TITLE
Feat: Future licences are not deemed to be current

### DIFF
--- a/src/modules/import/transform-crm.js
+++ b/src/modules/import/transform-crm.js
@@ -6,6 +6,7 @@
 const { mapValues, find } = require('lodash');
 const { addressFormatter, findCurrent, crmNameFormatter, transformNull } = require('../../lib/licence-transformer/nald-functional');
 const sentenceCase = require('sentence-case');
+const moment = require('moment');
 
 /**
  * Contacts formatter
@@ -88,11 +89,12 @@ function buildCRMMetadata (currentVersion) {
   const expires = currentVersion.expiry_date;
   const modified = currentVersion.version_effective_date;
   const contact = buildCRMContactMetadata(currentVersion);
+
   const data = {
     ...contact,
     Expires: expires,
     Modified: modified,
-    IsCurrent: true
+    IsCurrent: moment().isBetween(modified, expires, 'day')
   };
   return pruneNullString(data);
 }
@@ -113,7 +115,6 @@ function buildCRMPacket (licenceData, licenceRef, licenceId) {
   };
   try {
     const currentVersion = licenceData.data.current_version;
-
     let metadata = buildCRMMetadata(currentVersion);
     metadata.contacts = contactsFormatter(findCurrent(licenceData.data.versions), licenceData.data.roles);
     crmData.metadata = JSON.stringify(metadata);
@@ -124,5 +125,6 @@ function buildCRMPacket (licenceData, licenceRef, licenceId) {
 }
 
 module.exports = {
-  buildCRMPacket
+  buildCRMPacket,
+  buildCRMMetadata
 };

--- a/test/modules/import/lib/transform-crm.js
+++ b/test/modules/import/lib/transform-crm.js
@@ -1,0 +1,51 @@
+const Lab = require('lab');
+const { experiment, test } = exports.lab = Lab.script();
+const { expect } = require('code');
+const moment = require('moment');
+
+const { buildCRMMetadata } = require('../../../../src/modules/import/transform-crm');
+
+experiment('buildCRMMetadata', () => {
+  test('returns a default object if the current version is falsy', async () => {
+    const meta = buildCRMMetadata();
+    expect(meta).to.equal({
+      IsCurrent: false
+    });
+  });
+
+  test('IsCurrent is false if the currentVersion has not started', async () => {
+    const currentVersion = {
+      expiry_date: moment().add(2, 'months').format('YYYYMMDD'),
+      version_effective_date: moment().add(1, 'month').format('YYYYMMDD'),
+      party: {},
+      address: {}
+    };
+
+    const meta = buildCRMMetadata(currentVersion);
+    expect(meta.IsCurrent).to.be.false();
+  });
+
+  test('IsCurrent is false if the currentVersion has ended', async () => {
+    const currentVersion = {
+      expiry_date: moment().subtract(1, 'months').format('YYYYMMDD'),
+      version_effective_date: moment().subtract(2, 'month').format('YYYYMMDD'),
+      party: {},
+      address: {}
+    };
+
+    const meta = buildCRMMetadata(currentVersion);
+    expect(meta.IsCurrent).to.be.false();
+  });
+
+  test('IsCurrent is true if the currentVersion has started but not ended', async () => {
+    const currentVersion = {
+      expiry_date: moment().add(1, 'months').format('YYYYMMDD'),
+      version_effective_date: moment().subtract(1, 'month').format('YYYYMMDD'),
+      party: {},
+      address: {}
+    };
+
+    const meta = buildCRMMetadata(currentVersion);
+    expect(meta.IsCurrent).to.be.true();
+  });
+});


### PR DESCRIPTION
Changes the crm transform to set the `IsCurrent` property in the saved
metadata if the licence effective date is in the future, or if the
licence has expired.