### PR TITLE
Feat: Handle meter readings in return model

### DIFF
--- a/src/modules/returns/lib/model-returns-mapper.js
+++ b/src/modules/returns/lib/model-returns-mapper.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash');
+const { get, pick } = require('lodash');
 const moment = require('moment');
 const { convertToCubicMetres, convertToUserUnit } = require('./unit-conversion');
 const uuidv4 = require('uuid/v4');
@@ -134,17 +134,12 @@ const getRequiredLines = (startDate, endDate, frequency) => {
   }
 };
 
-/**
- * Creates a unified data model for a single return
- * @param {Object} ret - return
- * @param {Object} version - the current / selected version of the return
- * @param {Array} lines - array of line data
- * @param {Object} document - CRM document
- * @return {Object} unified view of return
- */
-const mapReturnToModel = (ret, version, lines, versions) => {
-  const requiredLines = lines.length ? null : getRequiredLines(ret.start_date, ret.end_date, ret.returns_frequency);
+const getMetersFromVersionMetadata = version => {
+  const meters = get(version, 'metadata.meters', []);
+  return meters;
+};
 
+const getReadingFromVersionMetadata = version => {
   const nullVersionMetadata = {
     // Can be measured | estimated
     type: null,
@@ -157,6 +152,22 @@ const mapReturnToModel = (ret, version, lines, versions) => {
     total: null
   };
 
+  return version
+    ? pick(version.metadata, Object.keys(nullVersionMetadata))
+    : nullVersionMetadata;
+};
+
+/**
+ * Creates a unified data model for a single return
+ * @param {Object} ret - return
+ * @param {Object} version - the current / selected version of the return
+ * @param {Array} lines - array of line data
+ * @param {Object} document - CRM document
+ * @return {Object} unified view of return
+ */
+const mapReturnToModel = (ret, version, lines, versions) => {
+  const requiredLines = lines.length ? null : getRequiredLines(ret.start_date, ret.end_date, ret.returns_frequency);
+
   return {
     returnId: ret.return_id,
     licenceNumber: ret.licence_ref,
@@ -168,17 +179,17 @@ const mapReturnToModel = (ret, version, lines, versions) => {
     status: ret.status,
     versionNumber: version ? version.version_number : null,
     isCurrent: version ? version.current : null,
-    reading: version ? version.metadata : nullVersionMetadata,
+    reading: getReadingFromVersionMetadata(version),
+    meters: getMetersFromVersionMetadata(version),
     requiredLines,
     lines: lines ? lines.map(returnLineToModel) : null,
     metadata: ret.metadata,
     versions: versions.map(version => {
-      const {user_id, created_at, version_number, current} = version;
       return {
-        versionNumber: version_number,
-        email: user_id,
-        createdAt: created_at,
-        isCurrent: current
+        versionNumber: version.version_number,
+        email: version.user_id,
+        createdAt: version.created_at,
+        isCurrent: version.current
       };
     })
   };
@@ -196,7 +207,10 @@ const mapReturnToVersion = (ret) => {
     user_id: ret.user.email,
     user_type: ret.user.type,
     version_number: ret.versionNumber,
-    metadata: JSON.stringify(ret.reading),
+    metadata: JSON.stringify({
+      ...ret.reading,
+      meters: ret.meters
+    }),
     nil_return: ret.isNil,
     current: true
   };

--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -59,6 +59,16 @@ module.exports = {
               total: Joi.when('totalFlag', { is: true, then: Joi.number().required() })
             }
           }),
+          meters: Joi.when('isNil', { is: false,
+            then: Joi.array().items({
+              manufacturer: Joi.string().required(),
+              serialNumber: Joi.string().required(),
+              startReading: Joi.number().positive().required(),
+              multiplier: Joi.number().valid(1, 10).required(),
+              units: Joi.string().required(),
+              readings: Joi.object()
+            })
+          }),
           requiredLines: Joi.array().allow(null).optional(),
           lines: Joi.when('isNil', { is: false,
             then:

--- a/test/modules/returns/lib/model-returns-mapper.js
+++ b/test/modules/returns/lib/model-returns-mapper.js
@@ -1,0 +1,101 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const { mapReturnToModel, mapReturnToVersion } = require('../../../../src/modules/returns/lib/model-returns-mapper');
+
+const getTestReturn = () => ({
+  return_id: 'test-return-id',
+  start_date: '2018-01-01',
+  end_date: '2018-05-01',
+  returns_frequency: 'month'
+});
+
+const getTestReadingData = () => ({
+  type: 'measured',
+  total: null,
+  units: 'm³',
+  method: null,
+  totalFlag: false
+});
+
+const getTestMeter = () => ({
+  manufacturer: 'test-man',
+  serialNumber: '1234v3',
+  multiplier: 10,
+  startReading: 1000,
+  readings: {
+    '2018-01-01_2018-02-31': 2000,
+    '2018-02-01_2018-02-28': 2000
+  }
+});
+
+const getTestVersion = (hasMeters = false) => {
+  const version = {
+    metadata: getTestReadingData()
+  };
+
+  if (hasMeters) {
+    version.metadata.meters = [getTestMeter()];
+  }
+
+  return version;
+};
+
+experiment('mapReturnToModel', () => {
+  test('assigns the reading meta data when no meters', async () => {
+    const lines = [];
+    const versions = [];
+    const model = mapReturnToModel(getTestReturn(), getTestVersion(), lines, versions);
+    expect(model.reading).to.equal(getTestReadingData());
+  });
+
+  test('assigns the reading meta data when version has meters', async () => {
+    const lines = [];
+    const versions = [];
+    const model = mapReturnToModel(getTestReturn(), getTestVersion(true), lines, versions);
+    expect(model.reading).to.only.include(getTestReadingData());
+  });
+
+  test('meters is an empty array when version has no meters', async () => {
+    const lines = [];
+    const versions = [];
+    const model = mapReturnToModel(getTestReturn(), getTestVersion(), lines, versions);
+    expect(model.meters).to.equal([]);
+  });
+
+  test('meters is populated when version has meters', async () => {
+    const lines = [];
+    const versions = [];
+    const model = mapReturnToModel(getTestReturn(), getTestVersion(true), lines, versions);
+    expect(model.meters).to.have.length(1);
+    expect(model.meters[0]).to.equal(getTestMeter());
+  });
+});
+
+experiment('mapReturnToVersion', () => {
+  test('sets the metadata using the reading', async () => {
+    const returnModel = {
+      user: {},
+      reading: getTestReadingData()
+    };
+    const mappedVersion = mapReturnToVersion(returnModel);
+
+    expect(JSON.parse(mappedVersion.metadata)).to.equal(getTestReadingData());
+  });
+
+  test('sets the metadata using the reading and meters when passed', async () => {
+    const returnModel = {
+      user: {},
+      reading: getTestReadingData(),
+      meters: [getTestMeter()]
+    };
+    const mappedVersion = mapReturnToVersion(returnModel);
+
+    const expectedMetadata = {
+      ...getTestReadingData(),
+      meters: [getTestMeter()]
+    };
+
+    expect(JSON.parse(mappedVersion.metadata)).to.equal(expectedMetadata);
+  });
+});


### PR DESCRIPTION
Changes the return model to have a meters property that is mapped into
the metadata of the version.