### PR TITLE
Feat: Improved due returns messaging

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -3,5 +3,6 @@
 // This is overridden if arguments are passed to lab via the command line.
 module.exports = {
   // This version global seems to be introduced by sinon.
-  globals: 'version,payload'
+  globals: 'version,payload',
+  verbose: true
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - npm run migrate
 script:
-  - npm run lint && npm run test && ./node_modules/.bin/codecov
+  - npm run lint
+  - npm run test:travis
+  - npm run codecov
 env:
   global:
     - DATABASE_URL=postgres://postgres:@localhost:5432/travis_ci_test

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Web app for Water Abstraction Permit service",
   "main": "index.js",
   "scripts": {
-    "heroku-prebuild": "npm install --only=dev",
-    "heroku-postbuild": "gulp clean && gulp copy-govuk-files && gulp install-govuk-files && gulp copy-static-assets && gulp sass",
-    "test": "./node_modules/lab/bin/lab -t 55 -m 0 --coverage-path ./src/ -r lcov -o lcov.info -r console -o stdout",
-    "test:only": "./node_modules/lab/bin/lab",
-    "test-cov-html": "lab -r html -o coverage.html",
-    "migrate": "node scripts/create-schema && node node_modules/db-migrate/bin/db-migrate up --verbose && node scripts/migrate-task-config",
-    "lint": "./node_modules/.bin/eslint ./src/**/*.js --fix"
+    "test": "DATABASE_URL=postgres://postgres:postgres@localhost:5432/permits-test lab",
+    "test:travis": "lab -t 55 -m 0 --coverage-path ./src/ -r lcov -o lcov.info -r console -o stdout",
+    "codecov": "codecov",
+    "migrate": "node scripts/create-schema && db-migrate up --verbose && node scripts/migrate-task-config",
+    "migrate:local-test": "DATABASE_URL=postgres://postgres:postgres@localhost:5432/permits-test node scripts/create-schema && DATABASE_URL=postgres://postgres:postgres@localhost:5432/permits-test db-migrate up --verbose && DATABASE_URL=postgres://postgres:postgres@localhost:5432/permits-test node scripts/migrate-task-config",
+    "lint": "eslint ./src/**/*.js"
   },
   "engines": {
     "node": ">=8.0"

--- a/src/modules/import/lib/transform-returns-helpers.js
+++ b/src/modules/import/lib/transform-returns-helpers.js
@@ -361,6 +361,11 @@ const getStatus = (receivedDate) => {
   return receivedDate === null ? 'due' : 'completed';
 };
 
+const getDueDate = endDate => {
+  const format = 'YYYY-MM-DD';
+  return moment(endDate, format).add(1, 'month').endOf('month').format(format);
+};
+
 module.exports = {
   convertNullStrings,
   mapPeriod,
@@ -379,5 +384,6 @@ module.exports = {
   addDate,
   getStatus,
   getFormatStartDate,
-  getFormatEndDate
+  getFormatEndDate,
+  getDueDate
 };

--- a/src/modules/import/transform-returns.js
+++ b/src/modules/import/transform-returns.js
@@ -13,7 +13,8 @@ const {
   getFormatCycles,
   mapReceivedDate,
   getReturnId,
-  getStatus
+  getStatus,
+  getDueDate
 } = require('./lib/transform-returns-helpers.js');
 
 /**
@@ -74,6 +75,7 @@ const buildReturnsPacket = async (licenceNumber, currentVersionStart) => {
         licence_ref: licenceNumber,
         start_date: startDate,
         end_date: endDate,
+        due_date: getDueDate(endDate),
         returns_frequency: mapPeriod(format.ARTC_REC_FREQ_CODE),
         status,
         source: 'NALD',

--- a/src/modules/returns/lib/model-returns-mapper.js
+++ b/src/modules/returns/lib/model-returns-mapper.js
@@ -174,6 +174,7 @@ const mapReturnToModel = (ret, version, lines, versions) => {
     receivedDate: ret.received_date,
     startDate: moment(ret.start_date).format('YYYY-MM-DD'),
     endDate: moment(ret.end_date).format('YYYY-MM-DD'),
+    dueDate: ret.due_date,
     frequency: ret.returns_frequency,
     isNil: get(version, 'nil_return'),
     status: ret.status,

--- a/test/modules/import/lib/transform-returns-helpers.js
+++ b/test/modules/import/lib/transform-returns-helpers.js
@@ -13,7 +13,8 @@ const {
   getFormatStartDate,
   getFormatEndDate,
   getFormatCycles,
-  formatReturnMetadata
+  formatReturnMetadata,
+  getDueDate
 } = require('../../../../src/modules/import/lib/transform-returns-helpers');
 
 lab.experiment('Test returns data transformation helpers', () => {
@@ -444,6 +445,15 @@ lab.experiment('formatReturnMetadata', () => {
   lab.test('the purposes contain the alias', async () => {
     expect(metadata.purposes[0].alias).to.equal('Water alias');
     expect(metadata.purposes[1].alias).to.equal('Agri alias');
+  });
+});
+
+lab.experiment('getDueDate', () => {
+  lab.test('it returns a date equal to the last day of the next month', async () => {
+    expect(getDueDate('2018-01-01')).to.equal('2018-02-28');
+    expect(getDueDate('2018-02-11')).to.equal('2018-03-31');
+    expect(getDueDate('2018-03-31')).to.equal('2018-04-30');
+    expect(getDueDate('2018-12-25')).to.equal('2019-01-31');
   });
 });
 

--- a/test/modules/returns/lib/model-returns-mapper.js
+++ b/test/modules/returns/lib/model-returns-mapper.js
@@ -7,6 +7,7 @@ const getTestReturn = () => ({
   return_id: 'test-return-id',
   start_date: '2018-01-01',
   end_date: '2018-05-01',
+  due_date: '2018-06-30',
   returns_frequency: 'month'
 });
 
@@ -69,6 +70,14 @@ experiment('mapReturnToModel', () => {
     const model = mapReturnToModel(getTestReturn(), getTestVersion(true), lines, versions);
     expect(model.meters).to.have.length(1);
     expect(model.meters[0]).to.equal(getTestMeter());
+  });
+
+  test('adds the dueDate from the return', async () => {
+    const lines = [];
+    const versions = [];
+    const testReturn = getTestReturn();
+    let model = mapReturnToModel(testReturn, getTestVersion(), lines, versions);
+    expect(model.dueDate).to.equal(testReturn.due_date);
   });
 });
 


### PR DESCRIPTION
Adds a `due_date` to the imported returns.

Also separates out the test tasks for local dev and Travis execution.