### PR TITLE
Fix: Adds the dueDate to the expected payload

### DIFF
--- a/src/modules/returns/routes.js
+++ b/src/modules/returns/routes.js
@@ -44,6 +44,7 @@ module.exports = {
           receivedDate: Joi.string().regex(isoDateRegex).allow(null).required(),
           startDate: Joi.string().regex(isoDateRegex).required(),
           endDate: Joi.string().regex(isoDateRegex).required(),
+          dueDate: Joi.string().regex(isoDateRegex).required(),
           frequency: Joi.string().valid(allowedPeriods).required(),
           isNil: Joi.boolean().required(),
           status: Joi.string().valid(statuses).required(),
@@ -91,7 +92,5 @@ module.exports = {
         }
       }
     }
-
   }
-
 };


### PR DESCRIPTION
The dueDate has been recently added to the returns model. Therefore the
validation on the endpoint needs to include this otherwise the request
is rejected.