### PR TITLE
Fix: Handle null purposes aliases

### DIFF
--- a/src/modules/import/lib/transform-returns-helpers.js
+++ b/src/modules/import/lib/transform-returns-helpers.js
@@ -39,6 +39,18 @@ const formatReturnNaldMetadata = (format) => {
 };
 
 /**
+ * Returns the trimmed purpose alias if it is not
+ * already empty or equal to 'null'
+ */
+const getPurposeAlias = purpose => {
+  const alias = (purpose.PURP_ALIAS || '').trim();
+
+  if (!['', 'null'].includes(alias.toLowerCase())) {
+    return alias;
+  }
+};
+
+/**
  * Gets metadata object to store in returns table
  * @param {Object} format
  * @return {Object} return metadata
@@ -60,7 +72,7 @@ const formatReturnMetadata = (format) => {
         code: purpose.APUR_APUS_CODE,
         description: purpose.tertiary_purpose
       },
-      alias: purpose.PURP_ALIAS
+      alias: getPurposeAlias(purpose)
     })),
     points: format.points.map(point => formatAbstractionPoint(convertNullStrings(point))),
     nald: formatReturnNaldMetadata(format)

--- a/test/modules/import/lib/transform-returns-helpers.js
+++ b/test/modules/import/lib/transform-returns-helpers.js
@@ -416,27 +416,25 @@ experiment('Test getFormatCycles', () => {
 experiment('formatReturnMetadata', () => {
   let metadata;
 
+  const getPurpose = alias => ({
+    APUR_APPR_CODE: 'W',
+    APUR_APSE_CODE: 'WAT',
+    APUR_APUS_CODE: '180',
+    PURP_ALIAS: alias,
+    primary_purpose: 'primary',
+    secondary_purpose: 'secondary',
+    tertiary_purpose: 'tertiary'
+  });
+
   beforeEach(async () => {
     metadata = formatReturnMetadata({
       purposes: [
-        {
-          APUR_APPR_CODE: 'W',
-          APUR_APSE_CODE: 'WAT',
-          APUR_APUS_CODE: '180',
-          PURP_ALIAS: 'Water alias',
-          primary_purpose: 'primary',
-          secondary_purpose: 'secondary',
-          tertiary_purpose: 'tertiary'
-        },
-        {
-          APUR_APPR_CODE: 'A',
-          APUR_APSE_CODE: 'AGR',
-          APUR_APUS_CODE: '400',
-          PURP_ALIAS: 'Agri alias',
-          primary_purpose: 'primary',
-          secondary_purpose: 'secondary',
-          tertiary_purpose: 'tertiary'
-        }
+        getPurpose('Water alias'),
+        getPurpose('Agri alias'),
+        getPurpose('null'),
+        getPurpose('Null'),
+        getPurpose('NULL'),
+        getPurpose(' null ')
       ],
       points: []
     });
@@ -445,6 +443,13 @@ experiment('formatReturnMetadata', () => {
   test('the purposes contain the alias', async () => {
     expect(metadata.purposes[0].alias).to.equal('Water alias');
     expect(metadata.purposes[1].alias).to.equal('Agri alias');
+  });
+
+  test('null aliases are ignored', async () => {
+    expect(metadata.purposes[2].alias).to.be.undefined();
+    expect(metadata.purposes[3].alias).to.be.undefined();
+    expect(metadata.purposes[4].alias).to.be.undefined();
+    expect(metadata.purposes[5].alias).to.be.undefined();
   });
 });
 


### PR DESCRIPTION
WATER-1392

Fixes an issue where format purposes could have a string value of 'null'
which was then being shown in the UI.

This change does not import the alias into the metadata if the value is
falsey, or once trimmed and lower cased, is equal to 'null'.