### PR TITLE
Feat: Consolidate env variables

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -4,6 +4,7 @@
     "migrations",
     "test",
     "node_modules",
-    "data"
+    "data",
+    "src/lib/logger/vendor/winston-airbrake.js"
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,31 @@
+SERVICE_NAME=water-api
+
+PORT=
 DATABASE_URL=
 
-servicename=
-cacheKey=
-PORT=
 JWT_TOKEN=
 JWT_SECRET=
-WATER_URI=
+
+# URIs including port and path up to version of down stream APIs
 PERMIT_URI=
-ADMIN_URI=
 CRM_URI=
 RETURNS_URI=
 
-licenceRegimeId=
-licenceTypeId=
-
-s3_bucket=
-s3_key=
-s3_secret=
-environment=
+S3_BUCKET=
+S3_KEY=
+S3_SECRET=
 
 # Notify keys
 TEST_NOTIFY_KEY=
 LIVE_NOTIFY_KEY=
 WHITELIST_NOTIFY_KEY=
 
-slackhook=
+SLACK_HOOK=
 
-errbit_key=
-errbit_server=
+ERRBIT_KEY=
+ERRBIT_SERVER=
 
-test_mode=
+TEST_MODE=
 NODE_ENV=
 
 NALD_ZIP_PASSWORD=

--- a/.labrc.js
+++ b/.labrc.js
@@ -4,5 +4,14 @@
 module.exports = {
   // This version global seems to be introduced by sinon.
   globals: 'version,payload,fetch,Response,Headers,Request',
-  verbose: true
+  verbose: true,
+
+  'coverage-exclude': [
+    'data',
+    'migrations',
+    'node_modules',
+    'scripts',
+    'src/lib/logger/vendor',
+    'test'
+  ]
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,5 @@ env:
     - DATABASE_URL=postgres://postgres:@localhost:5432/travis_ci_test
     - JWT_SECRET=secret
     - JWT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIzNH0.MOREC6-Kszb9bDFw0O1UKywpnkcP-c5cPjASMpjk8Po
-    - errbit_key=xyz
-    - errbit_server=http://localhost
     - PORT=8001
     - NOTIFY_KEY=somerealnotifykey-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000

--- a/README.MD
+++ b/README.MD
@@ -33,3 +33,7 @@ The following attribution statement MUST be cited in your products and applicati
 The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.
+
+## Environment Variables
+
+The required environment variables for local development can be found in the [.env.example file](./.env.example).

--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 module.exports = {
 
   admin: {
-    baseUrl: process.env.admin_base_url
+    baseUrl: process.env.ADMIN_BASE_URL
   },
 
   blipp: {
@@ -17,8 +17,8 @@ module.exports = {
 
   logger: {
     level: 'info',
-    airbrakeKey: process.env.errbit_key,
-    airbrakeHost: process.env.errbit_server,
+    airbrakeKey: process.env.ERRBIT_KEY,
+    airbrakeHost: process.env.ERRBIT_SERVER,
     airbrakeLevel: 'error'
   },
 
@@ -42,16 +42,16 @@ module.exports = {
 
   pgBoss: {
     schema: 'water',
-    application_name: process.env.servicename,
+    application_name: process.env.SERVICE_NAME,
     newJobCheckIntervalSeconds: 5
   },
 
   s3: {
-    accessKeyId: process.env.s3_key,
-    secretAccessKey: process.env.s3_secret,
+    accessKeyId: process.env.S3_KEY,
+    secretAccessKey: process.env.S3_SECRET,
     region: 'eu-west-1',
-    bucket: process.env.s3_bucket,
-    proxy: process.env.proxy
+    bucket: process.env.S3_BUCKET,
+    proxy: process.env.PROXY
   },
 
   server: {
@@ -61,6 +61,10 @@ module.exports = {
     }
   },
 
-  testMode: parseInt(process.env.test_mode) === 1
+  testMode: parseInt(process.env.TEST_MODE) === 1,
 
+  licence: {
+    regimeId: 1,
+    typeId: 8
+  }
 };

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ const start = async function () {
 
     if (!module.parent) {
       await server.start();
-      const name = process.env.servicename;
+      const name = process.env.SERVICE_NAME;
       const uri = server.info.uri;
       server.log('info', `Service ${name} running at: ${uri}`);
     }

--- a/src/lib/connectors/permit.js
+++ b/src/lib/connectors/permit.js
@@ -1,23 +1,26 @@
 const rp = require('request-promise-native').defaults({
   proxy: null,
-  strictSSL: false,
+  strictSSL: false
 });
-const {APIClient} = require('hapi-pg-rest-api');
+
+const { APIClient } = require('hapi-pg-rest-api');
+const config = require('../../../config');
 
 const licences = new APIClient(rp, {
-  endpoint: `${ process.env.PERMIT_URI }licence`,
-  headers : {
-    Authorization : process.env.JWT_TOKEN
+  endpoint: `${process.env.PERMIT_URI}licence`,
+  headers: {
+    Authorization: process.env.JWT_TOKEN
   }
 });
-
 
 const expiringLicences = new APIClient(rp, {
-  endpoint: `${ process.env.PERMIT_URI }expiring_licences?filter={licence_type_id:${process.env.licenceTypeId},licence_regime_id:${process.env.licenceRegimeId}}`,
-  headers : {
-    Authorization : process.env.JWT_TOKEN
+  endpoint: `${process.env.PERMIT_URI}expiring_licences?filter={licence_type_id:${config.licence.typeId},licence_regime_id:${config.licence.regimeId}}`,
+  headers: {
+    Authorization: process.env.JWT_TOKEN
   }
 });
 
-
-module.exports = {licences,expiringLicences};
+module.exports = {
+  licences,
+  expiringLicences
+};

--- a/src/lib/logger/index.js
+++ b/src/lib/logger/index.js
@@ -46,7 +46,7 @@ const init = (config = {}) => {
       projectId: true,
       level: options.airbrakeLevel,
       env: process.env.NODE_ENV,
-      proxy: process.env.proxy
+      proxy: process.env.PROXY
     };
     logger.add(Airbrake, airbrakeOptions);
   }

--- a/src/lib/slack.js
+++ b/src/lib/slack.js
@@ -8,9 +8,9 @@ const rp = require('request-promise-native').defaults({
 });
 
 function post (message) {
-  const msg = message + ' - ' + hostname + ' - ' + process.env.environment;
+  const msg = message + ' - ' + hostname + ' - ' + process.env.NODE_ENV;
   logger.info(`Slack: ${msg}`);
-  const uri = 'https://hooks.slack.com/services/' + process.env.slackhook;
+  const uri = 'https://hooks.slack.com/services/' + process.env.SLACK_HOOK;
   const options = {
     method: 'POST',
     url: uri,

--- a/src/modules/notify/connectors/notify.js
+++ b/src/modules/notify/connectors/notify.js
@@ -95,7 +95,7 @@ async function preview (notifyTemplate, personalisation) {
  * @return {String}
  */
 const getPdfNotifyKey = (env) => {
-  if (env.NODE_ENV === 'prod') {
+  if (env.NODE_ENV === 'production') {
     return env.LIVE_NOTIFY_KEY;
   }
   return env.TEST_NOTIFY_KEY;

--- a/src/modules/returns-notifications/lib/message-helpers.js
+++ b/src/modules/returns-notifications/lib/message-helpers.js
@@ -29,12 +29,11 @@ const formatAddressKeys = (contact) => {
 
 /**
  * Formats personalisation object
- * @param {Object} env - the environment from process.env
  * @param {Object} ret - the return row
  * @param {Object} contact - a contact from getting contact list call
  * @return {Object}
  */
-const formatEnqueuePersonalisation = (env, ret, contact) => {
+const formatEnqueuePersonalisation = (ret, contact) => {
   const {
     start_date: startDate,
     end_date: endDate,
@@ -75,7 +74,7 @@ const formatEnqueuePersonalisation = (env, ret, contact) => {
  * @param {Object} contactData - contact data, including address for sending
  * @return {Object} message data for enqueue()
  */
-const formatEnqueueOptions = (env, data, ret, contactData) => {
+const formatEnqueueOptions = (data, ret, contactData) => {
   const {
     return_id: returnId,
     licence_ref: licenceNumber
@@ -84,7 +83,7 @@ const formatEnqueueOptions = (env, data, ret, contactData) => {
 
   const { entity_id: entityId, ...contact } = contactData.contact;
 
-  const personalisation = formatEnqueuePersonalisation(env, ret, contact);
+  const personalisation = formatEnqueuePersonalisation(ret, contact);
 
   return {
     messageRef,

--- a/src/modules/returns-notifications/lib/send.js
+++ b/src/modules/returns-notifications/lib/send.js
@@ -40,7 +40,7 @@ const prepareMessageData = async (data) => {
     throw Boom.notFound(`Return ${returnId} not found`);
   }
 
-  return formatEnqueueOptions(process.env, { eventId, messageRef }, ret, contactData);
+  return formatEnqueueOptions({ eventId, messageRef }, ret, contactData);
 };
 
 module.exports = {

--- a/test/modules/notify/connectors/notify.js
+++ b/test/modules/notify/connectors/notify.js
@@ -43,19 +43,19 @@ lab.experiment('Test getPdfNotifyKey', () => {
     NODE_ENV: 'preprod'
   };
 
-  const prod = {
+  const production = {
     ...env,
-    NODE_ENV: 'prod'
+    NODE_ENV: 'production'
   };
 
-  lab.test('Should return test key for all environments other than prod', async () => {
+  lab.test('Should return test key for all environments other than production', async () => {
     Code.expect(getPdfNotifyKey(test)).to.equal('test-key');
     Code.expect(getPdfNotifyKey(local)).to.equal('test-key');
     Code.expect(getPdfNotifyKey(preprod)).to.equal('test-key');
   });
 
-  lab.test('Should return live key for prod only', async () => {
-    Code.expect(getPdfNotifyKey(prod)).to.equal('live-key');
+  lab.test('Should return live key for production only', async () => {
+    Code.expect(getPdfNotifyKey(production)).to.equal('live-key');
   });
 });
 

--- a/test/modules/returns-notifications/lib/message-helpers.js
+++ b/test/modules/returns-notifications/lib/message-helpers.js
@@ -52,7 +52,6 @@ lab.experiment('formatEnqueueOptions', () => {
   let result;
 
   lab.beforeEach(async () => {
-    const env = {};
     const data = { eventId: 1, messageRef: 'ref' };
     const ret = {
       due_date: '2018-01-01',
@@ -69,7 +68,7 @@ lab.experiment('formatEnqueueOptions', () => {
       }
     };
     const contactData = { contact: { entity_id: 'e_id' } };
-    result = formatEnqueueOptions(env, data, ret, contactData);
+    result = formatEnqueueOptions(data, ret, contactData);
   });
 
   lab.test('adds regionCode to the personalisation', async () => {


### PR DESCRIPTION
- Always use `NODE_ENV` and remove `environment` and `NODEENV`
- Use `production` rather than `prod` for the live environment variable.
- Moves `licenseTypeId` and `licenceRegimeId` to config
- Uppercase env variable keys
- Removes unused vars from .env.example file.
- Removes errbit from travis (not used).