### PR TITLE
Fix: Use Sun - Sat weeks for NALD

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,3 +1,6 @@
+const moment = require('moment');
+moment.locale('en-gb');
+
 const { load } = require('./src/modules/import/load');
 const { getNextImportBatch } = require('./src/modules/import/lib/import-log');
 const config = require('./config');

--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ const HapiAuthJwt2 = require('hapi-auth-jwt2');
 const Vision = require('vision');
 const Nunjucks = require('nunjucks');
 
+const moment = require('moment');
+moment.locale('en-gb');
+
 // -------------- Require project code -----------------
 const config = require('./config');
 const messageQueue = require('./src/lib/message-queue');

--- a/src/lib/nald-dates.js
+++ b/src/lib/nald-dates.js
@@ -1,0 +1,21 @@
+const moment = require('moment');
+
+const withNaldLocale = date => moment(date).locale('en');
+const getFirstDayOfWeek = day => withNaldLocale(day).startOf('week');
+const getLastDayOfWeek = day => withNaldLocale(day).endOf('week');
+
+/**
+ * Gets the start and end days of a week relative to the passed day
+ * in NALD terms, where the week is deemed to start on a sunday, and
+ * end on the saturday.
+ */
+const getWeek = day => {
+  return {
+    start: getFirstDayOfWeek(day),
+    end: getLastDayOfWeek(day)
+  };
+};
+
+module.exports = {
+  getWeek
+};

--- a/src/modules/import/lib/transform-returns-helpers.js
+++ b/src/modules/import/lib/transform-returns-helpers.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const { findIndex, max, mapValues, chunk } = require('lodash');
 const { formatAbstractionPoint } = require('../../../lib/licence-transformer/nald-helpers');
+const naldDates = require('../../../lib/nald-dates');
 
 /**
  * Converts 'null' strings to real null in supplied object
@@ -321,7 +322,8 @@ const getStartDate = (startDate, endDate, period) => {
     o = d.startOf('month');
   }
   if (period === 'week') {
-    o = d.startOf('isoWeek');
+    const naldWeek = naldDates.getWeek(d);
+    o = naldWeek.start;
   }
   if (period === 'day') {
     o = d;

--- a/src/modules/pdf-notifications/view-helpers.js
+++ b/src/modules/pdf-notifications/view-helpers.js
@@ -2,6 +2,8 @@ const moment = require('moment');
 const { chunk } = require('lodash');
 const naldRegions = require('./data/nald-regions');
 const naldAreas = require('./data/nald-areas');
+const naldDates = require('../../lib/nald-dates');
+
 /**
  * Outputs the region name given the NALD region code
  * @param {Number} code
@@ -48,8 +50,8 @@ const paginateDailyReturnLines = (startDate, endDate) => {
 };
 
 const paginateWeeklyReturnLines = (startDate, endDate) => {
-  let datePtr = moment(startDate).endOf('week');
-  const end = moment(endDate).endOf('week');
+  let datePtr = naldDates.getWeek(startDate).end;
+  const end = naldDates.getWeek(endDate).end;
   const dates = [];
   do {
     dates.push({ label: datePtr.format('D MMMM YYYY') });

--- a/src/modules/returns/lib/model-returns-mapper.js
+++ b/src/modules/returns/lib/model-returns-mapper.js
@@ -2,6 +2,7 @@ const { get, pick } = require('lodash');
 const moment = require('moment');
 const { convertToCubicMetres, convertToUserUnit } = require('./unit-conversion');
 const uuidv4 = require('uuid/v4');
+const naldDates = require('../../../lib/nald-dates');
 
 /**
  * Converts a line from the returns service to
@@ -92,18 +93,18 @@ const getYears = (startDate, endDate) => {
  * @return {Array} list of required return lines
  */
 const getWeeks = (startDate, endDate) => {
-  const datePtr = moment(startDate);
+  let datePtr = naldDates.getWeek(startDate);
   const lines = [];
-  datePtr.startOf('week');
+
   do {
     lines.push({
-      startDate: datePtr.startOf('week').format('YYYY-MM-DD'),
-      endDate: datePtr.endOf('week').format('YYYY-MM-DD'),
+      startDate: datePtr.start.format('YYYY-MM-DD'),
+      endDate: datePtr.end.format('YYYY-MM-DD'),
       timePeriod: 'week'
     });
-    datePtr.add(1, 'week');
+    datePtr = naldDates.getWeek(datePtr.start.add(1, 'week'));
   }
-  while (datePtr.isSameOrBefore(endDate, 'month'));
+  while (datePtr.end.isSameOrBefore(endDate, 'day'));
 
   return lines;
 };
@@ -262,5 +263,6 @@ module.exports = {
   mapReturnToVersion,
   mapReturnToLines,
   mapReturn,
-  getRequiredLines
+  getRequiredLines,
+  getWeeks
 };

--- a/test/lib/nald-dates.js
+++ b/test/lib/nald-dates.js
@@ -1,0 +1,215 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+const moment = require('moment');
+moment.locale('en-gb');
+
+const naldDates = require('../../src/lib/nald-dates');
+
+experiment('is the main locale', async () => {
+  test('in the context of the outer test suite the last day of the week is a sunday', async () => {
+    const sunday = moment('2018-10-28', 'YYYY-MM-DD').endOf('day');
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    expect(monday.endOf('week').toString()).to.equal(sunday.toString());
+  });
+
+  test('in the context of the outer test suite the first day of the week is a monday', async () => {
+    const sunday = moment('2018-10-28', 'YYYY-MM-DD');
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    expect(sunday.startOf('week').toString()).to.equal(monday.toString());
+  });
+});
+
+experiment('getWeek using moments', () => {
+  test('for a sunday the first day of the week is that sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(sunday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a sunday the last day of the week is the next saturday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(sunday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a monday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(monday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a monday the last day of the week is the next saturday', async () => {
+    const monday = moment('2018-10-22', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(monday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a tuesday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const tuesday = moment('2018-10-23', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a tuesday the last day of the week is the next saturday', async () => {
+    const tuesday = moment('2018-10-23', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a wednesday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const wednesday = moment('2018-10-24', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a wednesday the last day of the week is the next saturday', async () => {
+    const wednesday = moment('2018-10-24', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a thursday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const thursday = moment('2018-10-25', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(thursday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a thursday the last day of the week is the next saturday', async () => {
+    const thursday = moment('2018-10-25', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(thursday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a friday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const friday = moment('2018-10-26', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(friday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a friday the last day of the week is the next saturday', async () => {
+    const friday = moment('2018-10-26', 'YYYY-MM-DD');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(friday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a saturday the first day of the week is the previous sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD');
+    const week = naldDates.getWeek(saturday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a saturday the last day of the week is that saturday', async () => {
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(saturday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+});
+
+experiment('getWeek using strings', () => {
+  test('for a sunday the first day of the week is that sunday', async () => {
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD');
+    const week = naldDates.getWeek('2018-10-21');
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a sunday the last day of the week is the next saturday', async () => {
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek('2018-10-21');
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a monday the first day of the week is the previous sunday', async () => {
+    const monday = '2018-10-22';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(monday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a monday the last day of the week is the next saturday', async () => {
+    const monday = '2018-10-22';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(monday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a tuesday the first day of the week is the previous sunday', async () => {
+    const tuesday = '2018-10-23';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a tuesday the last day of the week is the next saturday', async () => {
+    const tuesday = '2018-10-23';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(tuesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a wednesday the first day of the week is the previous sunday', async () => {
+    const wednesday = '2018-10-24';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a wednesday the last day of the week is the next saturday', async () => {
+    const wednesday = '2018-10-24';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(wednesday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a thursday the first day of the week is the previous sunday', async () => {
+    const thursday = '2018-10-25';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(thursday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a thursday the last day of the week is the next saturday', async () => {
+    const thursday = '2018-10-25';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(thursday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a friday the first day of the week is the previous sunday', async () => {
+    const friday = '2018-10-26';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(friday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a friday the last day of the week is the next saturday', async () => {
+    const friday = '2018-10-26';
+    const saturday = moment('2018-10-27', 'YYYY-MM-DD').endOf('day');
+    const week = naldDates.getWeek(friday);
+    expect(week.end.toString()).to.equal(saturday.toString());
+  });
+
+  test('for a saturday the first day of the week is the previous sunday', async () => {
+    const saturday = '2018-10-27';
+    const sunday = moment('2018-10-21', 'YYYY-MM-DD').startOf('day');
+    const week = naldDates.getWeek(saturday);
+    expect(week.start.toString()).to.equal(sunday.toString());
+  });
+
+  test('for a saturday the last day of the week is that saturday', async () => {
+    const saturday = '2018-10-27';
+    const week = naldDates.getWeek(saturday);
+    expect(week.end.toString()).to.equal(moment(saturday).endOf('day').toString());
+  });
+});

--- a/test/modules/import/lib/transform-returns-helpers.js
+++ b/test/modules/import/lib/transform-returns-helpers.js
@@ -1,6 +1,8 @@
 const Lab = require('lab');
 const { beforeEach, experiment, test } = exports.lab = Lab.script();
 const { expect } = require('code');
+const moment = require('moment');
+moment.locale('en-gb');
 
 const {
   convertNullStrings,
@@ -14,7 +16,8 @@ const {
   getFormatEndDate,
   getFormatCycles,
   formatReturnMetadata,
-  getDueDate
+  getDueDate,
+  getStartDate
 } = require('../../../../src/modules/import/lib/transform-returns-helpers');
 
 experiment('Test returns data transformation helpers', () => {
@@ -467,5 +470,13 @@ experiment('getDueDate', () => {
   test('returns a date 28 days later', async () => {
     expect(getDueDate('2018-01-01')).to.equal('2018-01-29');
     expect(getDueDate('2018-12-10')).to.equal('2019-01-07');
+  });
+});
+
+experiment('getStartDate', () => {
+  test('a weekly date starts on a sunday', async () => {
+    const wednesday = '2018-11-14';
+    const sunday = '2018-11-11';
+    expect(getStartDate('2018-11-11', wednesday, 'week')).to.equal(sunday);
   });
 });

--- a/test/modules/pdf-notifications/view-helpers.js
+++ b/test/modules/pdf-notifications/view-helpers.js
@@ -3,24 +3,24 @@ const { experiment, test } = exports.lab = require('lab').script();
 const viewHelpers = require('../../../src/modules/pdf-notifications/view-helpers');
 
 experiment('paginateReturnLines (weekly)', async () => {
-  test('the first week uses the week ending date', async () => {
+  test('the first week uses the week ending date (saturday)', async () => {
     const personalisation = {
       start_date: '2018-01-03',
       end_date: '2018-02-18',
       returns_frequency: 'week'
     };
     const pages = viewHelpers.paginateReturnLines(personalisation);
-    expect(pages[0].columns[0].items[0].label).to.equal('7 January 2018');
+    expect(pages[0].columns[0].items[0].label).to.equal('6 January 2018');
   });
 
-  test('the last week uses the week ending date', async () => {
+  test('the last week uses the week ending date (saturday)', async () => {
     const personalisation = {
       start_date: '2018-01-03',
       end_date: '2018-02-18',
       returns_frequency: 'week'
     };
     const pages = viewHelpers.paginateReturnLines(personalisation);
-    expect(pages[0].columns[0].items[6].label).to.equal('18 February 2018');
+    expect(pages[0].columns[0].items[6].label).to.equal('17 February 2018');
   });
 
   // 14 rows per column
@@ -31,17 +31,17 @@ experiment('paginateReturnLines (weekly)', async () => {
       returns_frequency: 'week'
     };
     const pages = viewHelpers.paginateReturnLines(personalisation);
-    expect(pages[0].columns[1].items[0].label).to.equal('15 April 2018');
+    expect(pages[0].columns[1].items[0].label).to.equal('14 April 2018');
   });
 
   test('when more than two columns, there are two pages', async () => {
     const personalisation = {
       start_date: '2018-01-03',
-      end_date: '2018-07-22',
+      end_date: '2018-07-21',
       returns_frequency: 'week'
     };
     const pages = viewHelpers.paginateReturnLines(personalisation);
-    expect(pages[1].columns[0].items[0].label).to.equal('22 July 2018');
+    expect(pages[1].columns[0].items[0].label).to.equal('21 July 2018');
   });
 });
 

--- a/test/modules/returns/lib/model-returns-mapper.js
+++ b/test/modules/returns/lib/model-returns-mapper.js
@@ -1,8 +1,10 @@
 const { expect } = require('code');
 const moment = require('moment');
+moment.locale('en-gb');
+
 const { experiment, test } = exports.lab = require('lab').script();
 
-const { mapReturnToModel, mapReturnToVersion, mapReturn } = require('../../../../src/modules/returns/lib/model-returns-mapper');
+const { getWeeks, mapReturnToModel, mapReturnToVersion, mapReturn } = require('../../../../src/modules/returns/lib/model-returns-mapper');
 
 const getTestReturn = () => ({
   return_id: 'test-return-id',
@@ -137,5 +139,24 @@ experiment('mapReturn', () => {
       received_date: receivedDate,
       under_query: true
     });
+  });
+});
+
+experiment('getWeeks', () => {
+  test('returns a week starting on sunday', async () => {
+    const lines = getWeeks('2018-11-04', '2018-11-10');
+    expect(lines[0].startDate).to.equal('2018-11-04');
+    expect(lines[0].endDate).to.equal('2018-11-10');
+  });
+
+  /**
+   * Ensures that the last week does not bleed out of the
+   * bounds of the return cycle.
+   */
+  test('the last full week does not cross the end date', async () => {
+    const lines = getWeeks('2018-10-01', '2018-10-31');
+    const lastLine = lines.reverse()[0];
+    expect(lastLine.startDate).to.equal('2018-10-21');
+    expect(lastLine.endDate).to.equal('2018-10-27');
   });
 });


### PR DESCRIPTION
WATER-1632

Changes week calculations to us weeks that start on Sundays.

Sets the global moment locale to en-gb, but then adds a nald-dates
module for calculating the weeks, where a local locale of `en` is used
which treats weeks as running Sun - Sat.

Updates any existing code that used `startOf` or `endOf` and routes
through nald-dates.