### PR TITLE
Uses a unique id for points and conditions data

### DIFF
--- a/src/lib/licence-transformer/csv-transformer.js
+++ b/src/lib/licence-transformer/csv-transformer.js
@@ -8,18 +8,7 @@ const BaseTransformer = require('./base-transformer');
 const LicenceTitleLoader = require('./licence-title-loader');
 const licenceTitleLoader = new LicenceTitleLoader();
 const logger = require('../logger');
-
-/**
- * Formats an abstraction point into a string
- * Example:  name, ngr1, ngr2
- * @param {Object} point - abstraction point from licence data
- * @return {String} abstraction point info formatted as String
- */
-function _formatAbstractionPoint (point) {
-  const { name, ngr1, ngr2, ngr3, ngr4 } = point;
-  const parts = [name, ngr1, ngr2, ngr3, ngr4].filter(x => x);
-  return parts.join(', ');
-}
+const naldHelpers = require('./nald-helpers');
 
 class CSVTransformer extends BaseTransformer {
   /**
@@ -194,7 +183,7 @@ class CSVTransformer extends BaseTransformer {
     const conditionsArr = [];
 
     purposes.forEach((purpose) => {
-      const points = purpose.points.map(_formatAbstractionPoint);
+      const points = purpose.points.map(naldHelpers.formatAbstractionPoint);
 
       purpose.conditions.forEach((condition) => {
         const { code, subCode, parameter1, parameter2, text } = condition;

--- a/src/lib/licence-transformer/nald-helpers.js
+++ b/src/lib/licence-transformer/nald-helpers.js
@@ -39,8 +39,26 @@ function abstractionPointToString (point) {
   return parts.join(', ');
 }
 
+/**
+ * Creates a unique id by including the NALD type, region code and
+ * id into a single string. This is because historically each region had
+ * a different database and therefore the ids are not unique.
+ */
+const createUniqueId = (type, regionCode, id) => `nald://${type}/${regionCode}/${id}`;
+
+/**
+ * Takes the unique id in the format created by the `createUniqueId`
+ * function and extracts the type, id and region code
+ */
+const parseUniqueId = uniqueId => {
+  const [type, regionCode, ...rest] = uniqueId.replace(/^nald:\/\//, '').split('/');
+  return { type, regionCode, id: rest.join('/') };
+};
+
 module.exports = {
   formatAbstractionPoint,
   abstractionPointToString,
-  formatNGRPointStr
+  formatNGRPointStr,
+  createUniqueId,
+  parseUniqueId
 };

--- a/src/modules/licences/lib/extractConditions.js
+++ b/src/modules/licences/lib/extractConditions.js
@@ -1,10 +1,15 @@
 const { get } = require('lodash');
+const { createUniqueId } = require('../../../lib/licence-transformer/nald-helpers');
+const type = 'conditions';
 
 const mapConditions = (purposeText, conditions = []) => {
   return conditions.map(condition => {
+    const { FGAC_REGION_CODE: regionCode, ID: id } = condition;
+
     return {
       purposeText,
-      id: condition.ID,
+      regionCode,
+      id: createUniqueId(type, regionCode, id),
       code: condition.condition_type.CODE,
       subCode: condition.condition_type.SUBCODE,
       text: condition.TEXT,

--- a/src/modules/licences/lib/extractPoints.js
+++ b/src/modules/licences/lib/extractPoints.js
@@ -1,9 +1,12 @@
 const { get, uniqBy } = require('lodash');
+const { createUniqueId } = require('../../../lib/licence-transformer/nald-helpers');
+const type = 'points';
 
 const mapPoints = (points = []) => {
   return points.map(point => {
+    const { ID: id, FGAC_REGION_CODE: regionCode } = point.point_detail;
     return {
-      id: point.point_detail.ID,
+      id: createUniqueId(type, regionCode, id),
       name: point.point_detail.LOCAL_NAME
     };
   });

--- a/test/lib/licence-transformer/nald-helpers.js
+++ b/test/lib/licence-transformer/nald-helpers.js
@@ -1,0 +1,41 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const naldHelpers = require('../../../src/lib/licence-transformer/nald-helpers');
+
+experiment('createUniqueId', () => {
+  test('creates the expected string', async () => {
+    const id = 1;
+    const regionCode = 8;
+    const type = 'points';
+
+    const result = naldHelpers.createUniqueId(type, regionCode, id);
+    expect(result).to.equal('nald://points/8/1');
+  });
+});
+
+experiment('parseUniqueId', () => {
+  test('the id is extracted', async () => {
+    const input = 'nald://conditions/8/123';
+    const id = naldHelpers.parseUniqueId(input).id;
+    expect(id).to.equal('123');
+  });
+
+  test('can handle ids that contain slashes', async () => {
+    const input = 'nald://licences/8/123/S*/45/6789';
+    const id = naldHelpers.parseUniqueId(input).id;
+    expect(id).to.equal('123/S*/45/6789');
+  });
+
+  test('the regionCode is extracted', async () => {
+    const input = 'nald://points/2/123';
+    const id = naldHelpers.parseUniqueId(input).regionCode;
+    expect(id).to.equal('2');
+  });
+
+  test('the type is extracted', async () => {
+    const input = 'nald://conditions/8/123';
+    const id = naldHelpers.parseUniqueId(input).type;
+    expect(id).to.equal('conditions');
+  });
+});

--- a/test/modules/licences/lib/extractConditions.js
+++ b/test/modules/licences/lib/extractConditions.js
@@ -20,14 +20,16 @@ experiment('extractConditions', () => {
             PARAM1: '1 limited',
             PARAM2: '1,000 m3 per day',
             TEXT: 'Some condition text',
-            condition_type: { CODE: 'AA', SUBCODE: 'BB' }
+            condition_type: { CODE: 'AA', SUBCODE: 'BB' },
+            FGAC_REGION_CODE: 2
           },
           {
             ID: 2,
             PARAM1: '2 limited',
             PARAM2: '2,000 m3 per day',
             TEXT: 'Some condition text',
-            condition_type: { CODE: 'CC', SUBCODE: 'DD' }
+            condition_type: { CODE: 'CC', SUBCODE: 'DD' },
+            FGAC_REGION_CODE: 2
           }
         ]
       }]
@@ -49,14 +51,16 @@ experiment('extractConditions', () => {
               PARAM1: 'one/1 - p1',
               PARAM2: 'one/1 - p2',
               TEXT: 'one',
-              condition_type: { CODE: 'AA', SUBCODE: 'BB' }
+              condition_type: { CODE: 'AA', SUBCODE: 'BB' },
+              FGAC_REGION_CODE: 3
             },
             {
               ID: 2,
               PARAM1: 'one/2 - p1',
               PARAM2: 'one/2 - p2',
               TEXT: 'two',
-              condition_type: { CODE: 'CC', SUBCODE: 'DD' }
+              condition_type: { CODE: 'CC', SUBCODE: 'DD' },
+              FGAC_REGION_CODE: 3
             }
           ]
         },
@@ -68,7 +72,8 @@ experiment('extractConditions', () => {
               PARAM1: 'two/3 - p1',
               PARAM2: 'two/3 - p2',
               TEXT: 'three',
-              condition_type: { CODE: 'EE', SUBCODE: 'FF' }
+              condition_type: { CODE: 'EE', SUBCODE: 'FF' },
+              FGAC_REGION_CODE: 3
             }
           ]
         }
@@ -78,7 +83,8 @@ experiment('extractConditions', () => {
     const conditions = extractConditions(licence);
     expect(conditions).to.equal([
       {
-        id: 1,
+        id: 'nald://conditions/3/1',
+        regionCode: 3,
         code: 'AA',
         subCode: 'BB',
         text: 'one',
@@ -87,7 +93,8 @@ experiment('extractConditions', () => {
         purposeText: 'purpose one'
       },
       {
-        id: 2,
+        id: 'nald://conditions/3/2',
+        regionCode: 3,
         code: 'CC',
         subCode: 'DD',
         text: 'two',
@@ -96,7 +103,8 @@ experiment('extractConditions', () => {
         purposeText: 'purpose one'
       },
       {
-        id: 3,
+        id: 'nald://conditions/3/3',
+        regionCode: 3,
         code: 'EE',
         subCode: 'FF',
         text: 'three',

--- a/test/modules/licences/lib/extractPoints.js
+++ b/test/modules/licences/lib/extractPoints.js
@@ -14,16 +14,16 @@ experiment('extractPoints', () => {
     const licence = {
       purposes: [{
         purposePoints: [
-          { point_detail: { ID: 1, LOCAL_NAME: 'one' } },
-          { point_detail: { ID: 2, LOCAL_NAME: 'two' } }
+          { point_detail: { ID: 1, LOCAL_NAME: 'one', FGAC_REGION_CODE: 2 } },
+          { point_detail: { ID: 2, LOCAL_NAME: 'two', FGAC_REGION_CODE: 2 } }
         ]
       }]
     };
 
     const points = extractPoints(licence);
     expect(points).to.equal([
-      { id: 1, name: 'one' },
-      { id: 2, name: 'two' }
+      { id: 'nald://points/2/1', name: 'one' },
+      { id: 'nald://points/2/2', name: 'two' }
     ]);
   });
 
@@ -32,13 +32,13 @@ experiment('extractPoints', () => {
       purposes: [
         {
           purposePoints: [
-            { point_detail: { ID: 1, LOCAL_NAME: 'one' } },
-            { point_detail: { ID: 2, LOCAL_NAME: 'two' } }
+            { point_detail: { ID: 1, LOCAL_NAME: 'one', FGAC_REGION_CODE: 3 } },
+            { point_detail: { ID: 2, LOCAL_NAME: 'two', FGAC_REGION_CODE: 3 } }
           ]
         },
         {
           purposePoints: [
-            { point_detail: { ID: 3, LOCAL_NAME: 'three' } }
+            { point_detail: { ID: 3, LOCAL_NAME: 'three', FGAC_REGION_CODE: 3 } }
           ]
         }
       ]
@@ -46,9 +46,9 @@ experiment('extractPoints', () => {
 
     const points = extractPoints(licence);
     expect(points).to.equal([
-      { id: 1, name: 'one' },
-      { id: 2, name: 'two' },
-      { id: 3, name: 'three' }
+      { id: 'nald://points/3/1', name: 'one' },
+      { id: 'nald://points/3/2', name: 'two' },
+      { id: 'nald://points/3/3', name: 'three' }
     ]);
   });
 
@@ -57,18 +57,18 @@ experiment('extractPoints', () => {
       purposes: [
         {
           purposePoints: [
-            { point_detail: { ID: 1, LOCAL_NAME: 'one' } },
-            { point_detail: { ID: 2, LOCAL_NAME: 'two' } }
+            { point_detail: { ID: 1, LOCAL_NAME: 'one', FGAC_REGION_CODE: 4 } },
+            { point_detail: { ID: 2, LOCAL_NAME: 'two', FGAC_REGION_CODE: 4 } }
           ]
         },
         {
           purposePoints: [
-            { point_detail: { ID: 3, LOCAL_NAME: 'three' } }
+            { point_detail: { ID: 3, LOCAL_NAME: 'three', FGAC_REGION_CODE: 4 } }
           ]
         },
         {
           purposePoints: [
-            { point_detail: { ID: 3, LOCAL_NAME: 'three' } }
+            { point_detail: { ID: 3, LOCAL_NAME: 'three', FGAC_REGION_CODE: 4 } }
           ]
         }
       ]
@@ -76,9 +76,9 @@ experiment('extractPoints', () => {
 
     const points = extractPoints(licence);
     expect(points).to.equal([
-      { id: 1, name: 'one' },
-      { id: 2, name: 'two' },
-      { id: 3, name: 'three' }
+      { id: 'nald://points/4/1', name: 'one' },
+      { id: 'nald://points/4/2', name: 'two' },
+      { id: 'nald://points/4/3', name: 'three' }
     ]);
   });
 });


### PR DESCRIPTION
Create a truly unique id for points and conditions when found via the
`/documents/{documentId}/licences/points` URL.

This is to overcome the legacy problem of non unique ids because each
region had its own datastore.

Also adds a reverse function to parse the unique id if required to break
down into type, region code and id.