### PR TITLE
Fix: Updates format cycle end date calculation

### DIFF
--- a/src/modules/import/lib/nald-returns-queries.js
+++ b/src/modules/import/lib/nald-returns-queries.js
@@ -8,10 +8,21 @@ const { dbQuery } = require('./db');
  */
 const getFormats = (licenceNumber) => {
   const query = `
-  SELECT f.*, v.*, l."AREP_AREA_CODE"
+  SELECT
+    f.*,
+    v.*,
+    l."AREP_AREA_CODE",
+    l."EXPIRY_DATE" as "LICENCE_EXPIRY_DATE",
+    l."REV_DATE" as "LICENCE_REVOKED_DATE",
+    l."LAPSED_DATE" as "LICENCE_LAPSED_DATE"
   FROM "import"."NALD_ABS_LICENCES" l
-  LEFT JOIN "import"."NALD_RET_FORMATS" f ON l."ID"=f."ARVN_AABL_ID" AND l."FGAC_REGION_CODE"=f."FGAC_REGION_CODE"
-  JOIN "import"."NALD_RET_VERSIONS" v ON f."ARVN_VERS_NO"=v."VERS_NO" AND f."ARVN_AABL_ID"=v."AABL_ID" AND f."FGAC_REGION_CODE"=v."FGAC_REGION_CODE"
+    LEFT JOIN "import"."NALD_RET_FORMATS" f
+      ON l."ID"=f."ARVN_AABL_ID"
+      AND l."FGAC_REGION_CODE"=f."FGAC_REGION_CODE"
+    JOIN "import"."NALD_RET_VERSIONS" v
+      ON f."ARVN_VERS_NO"=v."VERS_NO"
+      AND f."ARVN_AABL_ID"=v."AABL_ID"
+      AND f."FGAC_REGION_CODE"=v."FGAC_REGION_CODE"
   WHERE l."LIC_NO"=$1
   ORDER BY to_date(v."EFF_ST_DATE", 'DD/MM/YYYY')`;
   const params = [licenceNumber];

--- a/src/modules/import/transform-returns.js
+++ b/src/modules/import/transform-returns.js
@@ -90,5 +90,6 @@ const buildReturnsPacket = async (licenceNumber) => {
 };
 
 module.exports = {
-  buildReturnsPacket
+  buildReturnsPacket,
+  getLicenceFormats
 };

--- a/test/modules/import/lib/transform-returns-helpers.js
+++ b/test/modules/import/lib/transform-returns-helpers.js
@@ -293,43 +293,135 @@ experiment('Test getFormatStartDate', () => {
 });
 
 experiment('Test getFormatEndDate', () => {
-  test('It should return null when both dates are null', async () => {
+  test('returns null when all dates are null', async () => {
     const format = {
       EFF_END_DATE: 'null',
-      TIMELTD_END_DATE: 'null'
+      TIMELTD_END_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null'
     };
     expect(getFormatEndDate(format)).to.equal(null);
   });
 
-  test('It should return effective end date if time limited date is null', async () => {
+  test('returns effective end date if time limited date is null', async () => {
     const format = {
       EFF_END_DATE: '22/02/2014',
-      TIMELTD_END_DATE: 'null'
+      TIMELTD_END_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null'
     };
     expect(getFormatEndDate(format)).to.equal('2014-02-22');
   });
 
-  test('It should return effective end date if time limited date is after effective end date', async () => {
+  test('returns effective end date if time limited date is after effective end date', async () => {
     const format = {
       EFF_END_DATE: '22/02/2014',
-      TIMELTD_END_DATE: '23/02/2014'
+      TIMELTD_END_DATE: '23/02/2014',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null'
     };
     expect(getFormatEndDate(format)).to.equal('2014-02-22');
   });
 
-  test('It should return time limited end date if effective end date is null', async () => {
+  test('returns time limited end date if effective end date is null', async () => {
     const format = {
       EFF_END_DATE: 'null',
-      TIMELTD_END_DATE: '23/02/2014'
+      TIMELTD_END_DATE: '23/02/2014',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null'
     };
     expect(getFormatEndDate(format)).to.equal('2014-02-23');
   });
-  test('It should return time limited end date if before effective end date', async () => {
+  test('returns time limited end date if before effective end date', async () => {
     const format = {
       EFF_END_DATE: '25/04/2015',
-      TIMELTD_END_DATE: '23/02/2014'
+      TIMELTD_END_DATE: '23/02/2014',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null'
     };
     expect(getFormatEndDate(format)).to.equal('2014-02-23');
+  });
+
+  test('returns the licence expiry date is not null', async () => {
+    const format = {
+      EFF_END_DATE: 'null',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: '01/01/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-01-01');
+  });
+
+  test('returns the licence revocation date is not null', async () => {
+    const format = {
+      EFF_END_DATE: 'null',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: '02/02/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-02-02');
+  });
+
+  test('returns the licence lapsed date if not null', async () => {
+    const format = {
+      EFF_END_DATE: 'null',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_EXPIRY_DATE: '01/01/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-01-01');
+  });
+
+  test('returns the earliest date of licence has multiple dates', async () => {
+    const format = {
+      EFF_END_DATE: 'null',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_REVOKED_DATE: '01/01/2018',
+      LICENCE_LAPSED_DATE: '02/02/2018',
+      LICENCE_EXPIRY_DATE: '03/03/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-01-01');
+  });
+
+  test('returns time limited end date if before the licence dates', async () => {
+    const format = {
+      EFF_END_DATE: 'null',
+      TIMELTD_END_DATE: '01/01/2018',
+      LICENCE_REVOKED_DATE: '02/02/2018',
+      LICENCE_LAPSED_DATE: '03/03/2018',
+      LICENCE_EXPIRY_DATE: '04/04/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-01-01');
+  });
+
+  test('returns effective end date if before the licence dates', async () => {
+    const format = {
+      EFF_END_DATE: '01/01/2018',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_REVOKED_DATE: '02/02/2018',
+      LICENCE_LAPSED_DATE: '03/03/2018',
+      LICENCE_EXPIRY_DATE: '04/04/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-01-01');
+  });
+
+  test('returns the licence lapsed date if before effective end date', async () => {
+    const format = {
+      EFF_END_DATE: '02/02/2018',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_LAPSED_DATE: '01/01/2018',
+      LICENCE_EXPIRY_DATE: '04/04/2018'
+    };
+    expect(getFormatEndDate(format)).to.equal('2018-01-01');
   });
 });
 
@@ -340,19 +432,18 @@ experiment('Test getFormatCycles', () => {
       EFF_ST_DATE: '23/05/2016',
       TIMELTD_ST_DATE: 'null',
       EFF_END_DATE: '30/03/2018',
-      TIMELTD_END_DATE: 'null'
+      TIMELTD_END_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null'
     };
     const cycles = getFormatCycles(format, '2014-04-01');
 
-    expect(cycles).to.equal([ { startDate: '2016-05-23',
-      endDate: '2016-10-31',
-      isCurrent: true },
-    { startDate: '2016-11-01',
-      endDate: '2017-10-31',
-      isCurrent: true },
-    { startDate: '2017-11-01',
-      endDate: '2018-03-30',
-      isCurrent: true } ]);
+    expect(cycles).to.equal([
+      { startDate: '2016-05-23', endDate: '2016-10-31', isCurrent: true },
+      { startDate: '2016-11-01', endDate: '2017-10-31', isCurrent: true },
+      { startDate: '2017-11-01', endDate: '2018-03-30', isCurrent: true }
+    ]);
   });
 
   test('It should calculate winter cycle', async () => {
@@ -361,16 +452,17 @@ experiment('Test getFormatCycles', () => {
       EFF_ST_DATE: '23/05/2016',
       TIMELTD_ST_DATE: 'null',
       EFF_END_DATE: '30/03/2018',
-      TIMELTD_END_DATE: 'null'
+      TIMELTD_END_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null'
     };
     const cycles = getFormatCycles(format, '2014-04-01');
 
-    expect(cycles).to.equal([ { startDate: '2016-05-23',
-      endDate: '2017-03-31',
-      isCurrent: true },
-    { startDate: '2017-04-01',
-      endDate: '2018-03-30',
-      isCurrent: true } ]);
+    expect(cycles).to.equal([
+      { startDate: '2016-05-23', endDate: '2017-03-31', isCurrent: true },
+      { startDate: '2017-04-01', endDate: '2018-03-30', isCurrent: true }
+    ]);
   });
 
   test('It should split cycles on current licence version start date', async () => {
@@ -379,19 +471,18 @@ experiment('Test getFormatCycles', () => {
       EFF_ST_DATE: '23/05/2016',
       TIMELTD_ST_DATE: 'null',
       EFF_END_DATE: '30/03/2018',
-      TIMELTD_END_DATE: 'null'
+      TIMELTD_END_DATE: 'null',
+      LICENCE_EXPIRY_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null'
     };
     const cycles = getFormatCycles(format, '2017-06-01');
 
-    expect(cycles).to.equal([ { startDate: '2016-05-23',
-      endDate: '2017-03-31',
-      isCurrent: false },
-    { startDate: '2017-04-01',
-      endDate: '2017-05-31',
-      isCurrent: false },
-    { startDate: '2017-06-01',
-      endDate: '2018-03-30',
-      isCurrent: true } ]);
+    expect(cycles).to.equal([
+      { startDate: '2016-05-23', endDate: '2017-03-31', isCurrent: false },
+      { startDate: '2017-04-01', endDate: '2017-05-31', isCurrent: false },
+      { startDate: '2017-06-01', endDate: '2018-03-30', isCurrent: true }
+    ]);
   });
 
   test('It should observe time limited start/end dates for summer cycle', async () => {
@@ -400,19 +491,39 @@ experiment('Test getFormatCycles', () => {
       EFF_ST_DATE: '23/05/2016',
       TIMELTD_ST_DATE: '25/05/2016',
       EFF_END_DATE: '30/03/2018',
-      TIMELTD_END_DATE: '28/03/2018'
+      TIMELTD_END_DATE: '28/03/2018',
+      LICENCE_EXPIRY_DATE: 'null',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null'
     };
     const cycles = getFormatCycles(format, '2014-04-01');
 
-    expect(cycles).to.equal([ { startDate: '2016-05-25',
-      endDate: '2016-10-31',
-      isCurrent: true },
-    { startDate: '2016-11-01',
-      endDate: '2017-10-31',
-      isCurrent: true },
-    { startDate: '2017-11-01',
-      endDate: '2018-03-28',
-      isCurrent: true } ]);
+    expect(cycles).to.equal([
+      { startDate: '2016-05-25', endDate: '2016-10-31', isCurrent: true },
+      { startDate: '2016-11-01', endDate: '2017-10-31', isCurrent: true },
+      { startDate: '2017-11-01', endDate: '2018-03-28', isCurrent: true }
+    ]);
+  });
+
+  test('a licence ended date is respected and the cycles are reduced in length', async () => {
+    // here the licence has expired before the version end date
+    const format = {
+      FORM_PRODN_MONTH: '80',
+      EFF_ST_DATE: '23/05/2016',
+      TIMELTD_ST_DATE: 'null',
+      EFF_END_DATE: '30/03/2018',
+      TIMELTD_END_DATE: 'null',
+      LICENCE_EXPIRY_DATE: '01/01/2017',
+      LICENCE_REVOKED_DATE: 'null',
+      LICENCE_LAPSED_DATE: 'null'
+    };
+
+    const cycles = getFormatCycles(format, '2014-04-01');
+
+    expect(cycles).to.equal([
+      { startDate: '2016-05-23', endDate: '2016-10-31', isCurrent: true },
+      { startDate: '2016-11-01', endDate: '2017-01-01', isCurrent: true }
+    ]);
   });
 });
 


### PR DESCRIPTION
WATER-1819

Update the `getFormatEndDate` function to use any dates on the licence
that suggested the licence has lapsed, expired or been revoked

Changes the return entry for the now revised return from:
```
{ 
  return_id: 'test-return-id',
  regime: 'water',
  licence_type: 'abstraction',
  licence_ref: 'test-licence-id,
  start_date: '2017-11-01',
  end_date: '2018-10-31',
  due_date: '2018-11-28',
  returns_frequency: 'month',
  status: 'due',
  metadata: 'test-metadata,
  received_date: null,
  return_requirement: 'format-id' 
}
```

to
```
{ 
  return_id: 'test-return-id',
  regime: 'water',
  licence_type: 'abstraction',
  licence_ref: 'test-licence-id,
  start_date: '2017-11-01',
  end_date: '2018-03-31',
  due_date: '2018-04-28',
  returns_frequency: 'month',
  status: 'due',
  source: 'NALD',
 metadata: 'test-metadata,
  received_date: null,
  return_requirement: 'format-id' 
}
```