### PR TITLE
Feat: Update paper form issuing

### DIFF
--- a/src/modules/returns-notifications/lib/request-parser.js
+++ b/src/modules/returns-notifications/lib/request-parser.js
@@ -6,10 +6,10 @@
 const getConfig = (config) => {
   const defaults = {
     prefix: 'RFORM-',
-    rolePriority: ['licence_holder']
+    rolePriority: ['returns_to', 'licence_holder']
   };
 
-  return Object.assign({}, defaults, config);
+  return Object.assign(defaults, config);
 };
 
 /**
@@ -36,7 +36,5 @@ const parseRequest = (request) => {
   };
 };
 
-module.exports = {
-  getConfig,
-  parseRequest
-};
+exports.getConfig = getConfig;
+exports.parseRequest = parseRequest;

--- a/test/lib/connectors/permit.js
+++ b/test/lib/connectors/permit.js
@@ -10,7 +10,7 @@ const sandbox = sinon.createSandbox();
 
 const permit = require('../../../src/lib/connectors/permit');
 
-experiment('permit connector', () => {
+experiment('getLicenceRegionCodes', () => {
   const licenceNumbers = ['05/678', '06/890'];
 
   beforeEach(async () => {
@@ -52,6 +52,74 @@ experiment('permit connector', () => {
 
   test('resolves with an empty object if no licence numbers supplied', async () => {
     const result = await permit.getLicenceRegionCodes([]);
+    expect(result).to.equal({});
+  });
+});
+
+experiment('getLicenceEndDates', () => {
+  const licenceNumbers = ['l-1', 'l-2'];
+
+  beforeEach(async () => {
+    sandbox.stub(permit.licences, 'findAll').resolves([
+      {
+        licence_ref: 'l-1',
+        licence_data_value: {
+          REV_DATE: 'null',
+          EXPIRY_DATE: '01/01/2001',
+          LAPSED_DATE: 'null'
+        }
+      },
+      {
+        licence_ref: 'l-2',
+        licence_data_value: {
+          REV_DATE: '01/01/2001',
+          EXPIRY_DATE: 'null',
+          LAPSED_DATE: '02/02/2002'
+        }
+      }
+    ]);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('calls the permit API with correct arguments', async () => {
+    await permit.getLicenceEndDates(licenceNumbers);
+
+    const [filter, sort, columns] = permit.licences.findAll.firstCall.args;
+
+    expect(filter).to.equal({
+      licence_regime_id: 1,
+      licence_type_id: 8,
+      licence_ref: {
+        $in: licenceNumbers
+      }
+    });
+
+    expect(sort).to.equal(null);
+
+    expect(columns).to.equal(['licence_ref', 'licence_data_value']);
+  });
+
+  test('resolves with a map of licence numbers / end dates', async () => {
+    const result = await permit.getLicenceEndDates(licenceNumbers);
+    expect(result).to.equal({
+      'l-1': {
+        dateRevoked: null,
+        dateExpired: '2001-01-01',
+        dateLapsed: null
+      },
+      'l-2': {
+        dateRevoked: '2001-01-01',
+        dateExpired: null,
+        dateLapsed: '2002-02-02'
+      }
+    });
+  });
+
+  test('resolves with an empty object if no licence numbers supplied', async () => {
+    const result = await permit.getLicenceEndDates([]);
     expect(result).to.equal({});
   });
 });

--- a/test/modules/returns-notifications/controller.js
+++ b/test/modules/returns-notifications/controller.js
@@ -1,0 +1,85 @@
+const { expect } = require('code');
+const {
+  beforeEach,
+  afterEach,
+  experiment,
+  test
+} = exports.lab = require('lab').script();
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { returns } = require('../../../src/lib/connectors/returns');
+const permitsConnector = require('../../../src/lib/connectors/permit');
+const controller = require('../../../src/modules/returns-notifications/controller');
+
+experiment('postPreviewReturnNotification', () => {
+  let response;
+  beforeEach(async () => {
+    sandbox.stub(returns, 'findAll').resolves([
+      { licence_ref: 'lic1', return_id: 'ret1' },
+      { licence_ref: 'lic2', return_id: 'ret2' },
+      { licence_ref: 'lic3', return_id: 'ret3' },
+      { licence_ref: 'lic4', return_id: 'ret4' }
+    ]);
+
+    sandbox.stub(permitsConnector, 'getLicenceEndDates').resolves({
+      lic1: { dateRevoked: null, dateExpired: null, dateLapsed: null },
+      lic2: { dateRevoked: '2002-02-02', dateExpired: null, dateLapsed: null },
+      lic3: { dateRevoked: null, dateExpired: '2003-03-03', dateLapsed: null },
+      lic4: { dateRevoked: null, dateExpired: null, dateLapsed: '2004-04-04' }
+    });
+
+    const request = {
+      params: {},
+      payload: {}
+    };
+
+    response = await controller.postPreviewReturnNotification(request);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('returns the licence_ref and return_id', async () => {
+    expect(response.data.find(x => x.licence_ref === 'lic1').return_id).to.equal('ret1');
+    expect(response.data.find(x => x.licence_ref === 'lic2').return_id).to.equal('ret2');
+    expect(response.data.find(x => x.licence_ref === 'lic3').return_id).to.equal('ret3');
+    expect(response.data.find(x => x.licence_ref === 'lic4').return_id).to.equal('ret4');
+  });
+
+  test('adds the end dates', async () => {
+    expect(response.data.find(x => x.licence_ref === 'lic1')).to.equal({
+      licence_ref: 'lic1',
+      return_id: 'ret1',
+      dateRevoked: null,
+      dateExpired: null,
+      dateLapsed: null
+    });
+
+    expect(response.data.find(x => x.licence_ref === 'lic2')).to.equal({
+      licence_ref: 'lic2',
+      return_id: 'ret2',
+      dateRevoked: '2002-02-02',
+      dateExpired: null,
+      dateLapsed: null
+    });
+
+    expect(response.data.find(x => x.licence_ref === 'lic3')).to.equal({
+      licence_ref: 'lic3',
+      return_id: 'ret3',
+      dateRevoked: null,
+      dateExpired: '2003-03-03',
+      dateLapsed: null
+    });
+
+    expect(response.data.find(x => x.licence_ref === 'lic4')).to.equal({
+      licence_ref: 'lic4',
+      return_id: 'ret4',
+      dateRevoked: null,
+      dateExpired: null,
+      dateLapsed: '2004-04-04'
+    });
+  });
+});

--- a/test/modules/returns-notifications/lib/request-parser.js
+++ b/test/modules/returns-notifications/lib/request-parser.js
@@ -1,31 +1,30 @@
-const Lab = require('lab');
-const lab = Lab.script();
-const Code = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+const { expect } = require('code');
 
 const { parseRequest, getConfig } = require('../../../../src/modules/returns-notifications/lib/request-parser.js');
 
-lab.experiment('Test getConfig', () => {
-  lab.test('It should get a default config object', async () => {
+experiment('getConfig', () => {
+  test('returns a default config object', async () => {
     const result = getConfig();
-    Code.expect(result).to.equal({
-      rolePriority: ['licence_holder'],
+    expect(result).to.equal({
+      rolePriority: ['returns_to', 'licence_holder'],
       prefix: 'RFORM-'
     });
   });
 
-  lab.test('It should be possible to override default options', async () => {
+  test('allows the defaults to be overridden', async () => {
     const result = getConfig({
-      rolePriority: ['returns_to', 'licence_holder'],
+      rolePriority: ['licence_holder'],
       prefix: 'CUSTOM-'
     });
-    Code.expect(result).to.equal({
-      rolePriority: ['returns_to', 'licence_holder'],
+    expect(result).to.equal({
+      rolePriority: ['licence_holder'],
       prefix: 'CUSTOM-'
     });
   });
 });
 
-lab.experiment('Test parseRequest', () => {
+experiment('Test parseRequest', () => {
   const request = {
     params: {
       notificationId: 'pdf.return'
@@ -43,9 +42,10 @@ lab.experiment('Test parseRequest', () => {
     }
   };
 
-  lab.test('parseRequest should parse the request into variables used by the controller', async () => {
+  test('parseRequest should parse the request into variables used by the controller', async () => {
     const result = parseRequest(request);
-    Code.expect(result).to.equal({ messageRef: 'pdf.return',
+    expect(result).to.equal({
+      messageRef: 'pdf.return',
       filter: { return_id: 'abc' },
       issuer: 'mail@example.com',
       name: 'Friendly name',
@@ -55,5 +55,3 @@ lab.experiment('Test parseRequest', () => {
     });
   });
 });
-
-exports.lab = lab;


### PR DESCRIPTION
WATER-1950

Changes the paper form preview endpoint to include any dates that a
licence has ended. (Expired | Revoked | Lapsed)

Updates the default role priority for returns recipients so that a
returns contact is the first point of contact, then the licence holder.