### PR TITLE
Feat: Include expired licences in internal search

### DIFF
--- a/src/modules/internal-search/lib/search-documents.js
+++ b/src/modules/internal-search/lib/search-documents.js
@@ -25,18 +25,23 @@ const mapRow = (row) => {
     licenceNumber: row.system_external_id,
     licenceHolder: getLicenceHolderNameFromDocumentHeader(row),
     documentName: row.document_name,
-    expires: returnsDateToIso(row.metadata.Expires)
+    expires: returnsDateToIso(row.metadata.Expires),
+    isCurrent: row.metadata.IsCurrent
   };
 };
 
 /**
  * Searches documents with given query string
+ *
+ * Unlike most other searches in the application, this search will also request
+ * expired documents to allow the submission of older returns data.
  * @param  {String} query - the user's search query
  * @return {Promise}        resolves with licences
  */
 const searchDocuments = async (query, page = 1) => {
   const filter = {
-    string: query
+    string: query,
+    includeExpired: true // include expired documents
   };
 
   const columns = [

--- a/src/modules/licences/controller.js
+++ b/src/modules/licences/controller.js
@@ -70,7 +70,7 @@ const wrapData = data => ({
   data
 });
 
-const addEarlistEndDate = licence => {
+const addEarliestEndDate = licence => {
   const dates = [
     { key: 'expired', date: licence.licence_data_value.EXPIRY_DATE },
     { key: 'lapsed', date: licence.licence_data_value.LAPSED_DATE },
@@ -88,7 +88,7 @@ const addEarlistEndDate = licence => {
       return l.date.isBefore(r.date) ? -1 : 1;
     })
     .map(date => {
-      date.date = date.date.format('YYYYMMDD');
+      date.date = date.date.format('YYYY-MM-DD');
       return date;
     });
 
@@ -111,7 +111,7 @@ const getLicenceByDocumentId = async (request, h) => {
     const licence = await getLicence(documentId, includeExpired);
 
     if (licence) {
-      return wrapData(addEarlistEndDate(licence));
+      return wrapData(addEarliestEndDate(licence));
     }
     return Boom.notFound();
   } catch (error) {

--- a/src/modules/licences/controller.js
+++ b/src/modules/licences/controller.js
@@ -1,3 +1,4 @@
+const moment = require('moment');
 const Boom = require('boom');
 const { get, isObject } = require('lodash');
 const documentsClient = require('../../lib/connectors/crm/documents');
@@ -11,11 +12,20 @@ const LicenceTransformer = require('../../lib/licence-transformer');
 const { mapGaugingStation, getGaugingStations } = require('./lib/gauging-stations');
 const queries = require('./lib/queries');
 
-const getDocumentHeader = async documentId => {
+const getDocumentHeader = async (documentId, includeExpired = false) => {
   const documentResponse = await documentsClient.findMany({
-    document_id: documentId
+    document_id: documentId,
+    includeExpired
   });
   return get(documentResponse, 'data[0]');
+};
+
+const addDocumentDetails = (licence, document) => {
+  return Object.assign(licence, {
+    document: {
+      name: document.document_name
+    }
+  });
 };
 
 /**
@@ -24,10 +34,10 @@ const getDocumentHeader = async documentId => {
  * @param  {Object}  [documentHeader] - If document header has already been loaded, it is not loaded again
  * @return {Promise}                resolves with permit repo data
  */
-const getLicence = async (document) => {
+const getLicence = async (document, includeExpired) => {
   const documentHeader = isObject(document)
     ? document
-    : await getDocumentHeader(document);
+    : await getDocumentHeader(document, includeExpired);
 
   if (!documentHeader) {
     return;
@@ -39,7 +49,11 @@ const getLicence = async (document) => {
     licence_regime_id: regimeId
   });
 
-  return get(licenceResponse, 'data[0]');
+  const licence = get(licenceResponse, 'data[0]');
+
+  if (licence) {
+    return addDocumentDetails(licence, documentHeader);
+  }
 };
 
 const handleUnexpectedError = (error, documentId) => {
@@ -56,18 +70,48 @@ const wrapData = data => ({
   data
 });
 
+const addEarlistEndDate = licence => {
+  const dates = [
+    { key: 'expired', date: licence.licence_data_value.EXPIRY_DATE },
+    { key: 'lapsed', date: licence.licence_data_value.LAPSED_DATE },
+    { key: 'revoked', date: licence.licence_data_value.REV_DATE }
+  ];
+
+  const endedDates = dates
+    .map(date => {
+      date.date = moment(date.date, 'DD/MM/YYYY');
+      return date;
+    })
+    .filter(date => date.date.isValid())
+    .sort((l, r) => {
+      if (l.date.isSame(r.date)) return 0;
+      return l.date.isBefore(r.date) ? -1 : 1;
+    })
+    .map(date => {
+      date.date = date.date.format('YYYYMMDD');
+      return date;
+    });
+
+  const earliest = endedDates.length ? endedDates[0] : { date: null, key: null };
+  licence.earliestEndDate = earliest.date;
+  licence.earliestEndDateReason = earliest.key;
+
+  return licence;
+};
+
 /**
  * Coordinates finding a full licence from the permit repository
  * using the CRM document ID.
  */
 const getLicenceByDocumentId = async (request, h) => {
   const { documentId } = request.params;
+  const { includeExpired } = request.query;
 
   try {
-    const licence = await getLicence(documentId);
+    const licence = await getLicence(documentId, includeExpired);
 
     if (licence) {
-      return wrapData(licence);
+      return wrapData(addEarlistEndDate(licence));
     }
     return Boom.notFound();
   } catch (error) {
@@ -174,9 +218,10 @@ const mapNotification = (row) => {
 
 const getLicenceCommunicationsByDocumentId = async (request, h) => {
   const { documentId } = request.params;
+  const { includeExpired } = request.query;
 
   try {
-    const documentHeader = await getDocumentHeader(documentId);
+    const documentHeader = await getDocumentHeader(documentId, includeExpired);
     const notifications = await queries.getNotificationsForLicence(documentHeader.system_external_id);
 
     return {

--- a/src/modules/licences/routes.js
+++ b/src/modules/licences/routes.js
@@ -85,6 +85,9 @@ module.exports = {
       validate: {
         params: {
           documentId: Joi.string().guid().required()
+        },
+        query: {
+          includeExpired: Joi.boolean().optional().default(false)
         }
       }
     }

--- a/test/modules/internal-search/lib/search-documents.js
+++ b/test/modules/internal-search/lib/search-documents.js
@@ -15,7 +15,8 @@ const row = {
     Initials: 'J',
     Forename: 'John',
     Salutation: 'Mr',
-    Expires: '20190205'
+    Expires: '20190205',
+    IsCurrent: true
   },
   document_name: 'Fusty meadow'
 };
@@ -28,7 +29,8 @@ experiment('mapRow', () => {
       licenceNumber: row.system_external_id,
       licenceHolder: 'Mr J Doe',
       documentName: row.document_name,
-      expires: '2019-02-05'
+      expires: '2019-02-05',
+      isCurrent: true
     });
   });
 });
@@ -49,7 +51,10 @@ experiment('searchDocuments', () => {
     stub = sinon.stub(documents, 'findMany').resolves({ data: [] });
     searchDocuments('01/123', 5);
     const [filter, sort, pagination, columns] = stub.firstCall.args;
-    expect(filter).to.equal({ string: '01/123' });
+    expect(filter).to.equal({
+      string: '01/123',
+      includeExpired: true
+    });
     expect(sort).to.equal({system_external_id: 1});
     expect(pagination.page).to.equal(5);
     expect(columns).to.equal([

--- a/test/modules/licences/controller.js
+++ b/test/modules/licences/controller.js
@@ -103,7 +103,7 @@ experiment('getLicenceByDocumentId', () => {
     permitClient.licences.findMany.resolves(licenceResponse);
     const response = await controller.getLicenceByDocumentId(testRequest);
 
-    expect(response.data.earliestEndDate).to.equal('20030201');
+    expect(response.data.earliestEndDate).to.equal('2003-02-01');
     expect(response.data.earliestEndDateReason).to.equal('expired');
   });
 


### PR DESCRIPTION
WATER-1976

Updates the internal search to include expired licences as well when
search for a licence internally.

Allow communications to be acquired for expired licences

Adds partial document details to the licence response
Adds earliest expiry date and reason to the licence response