### PR TITLE
Feat: Adds returns CSV validator

### DIFF
--- a/src/lib/returns.js
+++ b/src/lib/returns.js
@@ -10,4 +10,18 @@ const getReturnId = (regionCode, licenceNumber, formatId, startDate, endDate) =>
   return `v1:${regionCode}:${licenceNumber}:${formatId}:${startDate}:${endDate}`;
 };
 
+/*
+ * Parses a return ID into constituent variables
+ * @param {String} returnId
+ * @return {Object}
+ */
+const parseReturnId = (returnId) => {
+  const [ version, regionCode, licenceNumber, formatId, startDate, endDate ] = returnId.split(':');
+  return { version, regionCode, licenceNumber, formatId, startDate, endDate };
+};
+
+const returnIDRegex = /^v1:[1-8]:[^:]+:[0-9]+:[0-9]{4}-[0-9]{2}-[0-9]{2}:[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+
+exports.returnIDRegex = returnIDRegex;
 exports.getReturnId = getReturnId;
+exports.parseReturnId = parseReturnId;

--- a/src/modules/import/lib/transform-returns-helpers.js
+++ b/src/modules/import/lib/transform-returns-helpers.js
@@ -3,6 +3,7 @@ const { pick, findIndex, max, mapValues, chunk } = require('lodash');
 const { returns: { date: { getPeriodStart } } } = require('@envage/water-abstraction-helpers');
 const { formatAbstractionPoint } = require('../../../lib/licence-transformer/nald-helpers');
 const naldDates = require('@envage/water-abstraction-helpers').nald.dates;
+const { parseReturnId } = require('../../../lib/returns');
 
 /**
  * Converts 'null' strings to real null in supplied object
@@ -270,16 +271,6 @@ const getFormatCycles = (format, splitDate) => {
   }
 
   return getReturnCycles(startDate, endDate, splitDate, isSummer);
-};
-
-/*
- * Parses a return ID into constituent variables
- * @param {String} returnId
- * @return {Object}
- */
-const parseReturnId = (returnId) => {
-  const [ version, regionCode, licenceNumber, formatId, startDate, endDate ] = returnId.split(':');
-  return { version, regionCode, licenceNumber, formatId, startDate, endDate };
 };
 
 /**

--- a/src/modules/returns/lib/csv-schema-validation.js
+++ b/src/modules/returns/lib/csv-schema-validation.js
@@ -1,0 +1,302 @@
+const parse = require('csv-parse');
+const util = require('util');
+const parseCsv = util.promisify(parse);
+const { isEmpty, flatten, compact, isString, times } = require('lodash');
+
+const { returnIDRegex, parseReturnId } = require('../../../lib/returns');
+const validDateRegex = /(^(Week ending )?\d{1,2} \w{3,9} \d{4}$)|(\w{3,8} \d{4})/;
+const lineErrorRegex = /line (\d*)$/;
+const validAbstractionVolumeRegex = /(^Do not edit$)|(^\d[\d|.|,]*$)|(^\s*$)/;
+
+const parseOptions = {
+  skip_lines_with_empty_values: true,
+  skip_empty_lines: true,
+  trim: true
+};
+
+const errorMessages = {
+  licenceNumber: 'Licence number is missing',
+  returnReference: 'All return references should be integers',
+  nilReturn: 'Nil return should be Y, N or empty',
+  meterUsed: 'Did you use a meter should be Y, N or empty',
+  meterMake: {
+    required: 'Meter make required if a meter was used',
+    notRequired: 'Meter make not allowed if a meter was not used'
+  },
+  meterSerialNumber: {
+    required: 'Meter serial number required if a meter was used',
+    notRequired: 'Meter serial number not allowed if a meter was not used'
+  },
+  abstractionVolumes: 'Abstraction volumes must be numbers',
+  returnId: 'Return id in unexpected format'
+};
+
+/**
+ * Takes a column of CSV data and maps to an object to represent
+ * a single licence return item.
+ */
+const createLicenceReturn = column => ({
+  licenceNumber: { line: 1, value: column[0] },
+  returnReference: { line: 2, value: column[1] },
+  isNilReturn: { line: 3, value: column[2] },
+  meterUsed: { line: 4, value: column[3] },
+  meterMake: { line: 5, value: column[4] },
+  meterSerialNumber: { line: 6, value: column[5] },
+  abstractionVolumes: column.slice(6, column.length - 1).map((value, index) => ({
+    line: 7 + index,
+    value
+  })),
+  returnId: { line: column.length, value: column.reverse()[0] }
+});
+
+/**
+ * If expectation is a string, the value is compared, otherwise
+ * it is assumed that the expectation is a function and the value
+ * is passed to the function
+ * @param  {string|function} expectation How to evaluate the validity of the value
+ * @param  {any} val The value to validate
+ * @return {boolean} True if the value meets the expectation
+ */
+const validateExpectation = (expectation, val) => {
+  return isString(expectation)
+    ? val === expectation
+    : expectation(val);
+};
+
+const getHeadingExpectation = expectation => ({
+  expectation,
+  errorMessage: `${expectation} field not in expected position`
+});
+
+/**
+ * Gets an array of validations to perform where each validator
+ * sits at the same index of the target array.
+ */
+const getHeadingValidation = column => {
+  const validators = [
+    getHeadingExpectation('Licence number'),
+    getHeadingExpectation('Return reference'),
+    getHeadingExpectation('Nil return Y/N'),
+    getHeadingExpectation('Did you use a meter Y/N'),
+    getHeadingExpectation('Meter make'),
+    getHeadingExpectation('Meter serial number')
+  ];
+
+  times(column.length - 7, () => {
+    validators.push({
+      expectation: val => validDateRegex.test(val),
+      errorMessage: 'Unexpected date format for return line'
+    });
+  });
+
+  validators.push(getHeadingExpectation('Unique return reference'));
+
+  return validators;
+};
+
+/**
+ * Takes a 2d array of records and returns the required
+ * column.
+ * @param  {Array} records     The 2d array of CSV records
+ * @param  {Number} columnIndex Which column is required
+ * @return {Array} An array representing a column of CSV data
+ */
+const getColumn = (records, columnIndex) => {
+  return records.reduce((acc, record) => {
+    acc.push(record[columnIndex]);
+    return acc;
+  }, []);
+};
+
+const createError = (message, line) => ({ message, line });
+
+const extractLineNumberFromError = err => {
+  const matches = lineErrorRegex.exec(err);
+  return matches ? parseInt(matches[1]) : -1;
+};
+
+const createErrorFromCsvParseError = err => {
+  return createError(err, extractLineNumberFromError(err));
+};
+
+/**
+ * Validates that all the headings (the first column) are
+ * not modified since the original download of the CSV template.
+ */
+const validateHeadings = records => {
+  const firstColumn = getColumn(records, 0);
+  const validators = getHeadingValidation(firstColumn);
+
+  const errors = firstColumn.reduce((acc, row, index) => {
+    const { errorMessage, expectation } = validators[index];
+
+    if (!validateExpectation(expectation, row)) {
+      acc.push(createError(errorMessage, index + 1));
+    }
+    return acc;
+  }, []);
+
+  return compact(errors);
+};
+
+/**
+ * Maps the CSV records array to an array of licence objects.
+ */
+const recordsToLicences = records => {
+  const licences = [];
+
+  for (let i = 1; i < records[0].length; i++) {
+    licences.push(createLicenceReturn(getColumn(records, i)));
+  }
+  return licences;
+};
+
+/**
+ * Checks if the licence number is present
+ */
+const validateLicenceNumber = licence => {
+  const { value, line } = licence.licenceNumber;
+
+  if (isEmpty(value)) {
+    return createError(errorMessages.licenceNumber, line);
+  }
+};
+
+/**
+ * Checks if the return rerefence is not empty and is a number
+ */
+const validateReturnReference = licence => {
+  const { value, line } = licence.returnReference;
+
+  if (isEmpty(value) || /^\d{1,}$/g.test(value) === false) {
+    return createError(errorMessages.returnReference, line);
+  }
+};
+
+const isValidBooleanOrEmpty = (licence, licenceKey, errorKey = licenceKey) => {
+  const { value, line } = licence[licenceKey];
+  const isValid = ['y', 'n', ''].includes(value.toLowerCase());
+
+  if (!isValid) {
+    return createError(errorMessages[errorKey], line);
+  }
+};
+
+const validateMeterUsed = licence => isValidBooleanOrEmpty(licence, 'meterUsed');
+const validateNilReturn = licence => isValidBooleanOrEmpty(licence, 'isNilReturn', 'nilReturn');
+
+/**
+ * Checks that if the meter details are said to have been suplied
+ * that the meter make is not empty.
+ */
+const validateMeterMake = licence =>
+  validateMeterDetails(licence, 'meterMake');
+
+/**
+ * Checks that if the meter details are said to have been suplied
+ * that the meter serial number is not empty.
+ */
+const validateMeterSerialNumber = licence =>
+  validateMeterDetails(licence, 'meterSerialNumber');
+
+const validateMeterDetails = (licence, meterDetailKey) => {
+  const meterUsed = licence.meterUsed.value.toLowerCase() === 'y';
+  const { value, line } = licence[meterDetailKey];
+  const { required, notRequired } = errorMessages[meterDetailKey];
+
+  if (meterUsed && isEmpty(value)) {
+    return createError(required, line);
+  }
+
+  if (!meterUsed && !isEmpty(value)) {
+    return createError(notRequired, line);
+  }
+};
+
+/**
+ * Checks that the abstraction volumes are valid.
+ *
+ * They can be:
+ *   - empty
+ *   - 'Do not edit'
+ *   - A number including commas.
+ */
+const validateAbstractionVolumes = licence => {
+  return licence.abstractionVolumes.reduce((acc, volume) => {
+    const { value, line } = volume;
+    const isValueValid = validAbstractionVolumeRegex.test(value);
+
+    if (!isValueValid) {
+      acc.push(createError(errorMessages.abstractionVolumes, line));
+    }
+    return acc;
+  }, []);
+};
+
+/**
+ * Checks that the return id:
+ *
+ *  - Matches the return id regex
+ *  - Contains the licence number
+ *  - Contains the return reference
+ */
+const validateReturnId = licence => {
+  const { value, line } = licence.returnId;
+  const matchesReturnIdPattern = returnIDRegex.test(value);
+
+  if (matchesReturnIdPattern) {
+    const licenceNumber = licence.licenceNumber.value;
+    const returnReference = licence.returnReference.value;
+    const parsed = parseReturnId(value);
+
+    if (parsed.licenceNumber === licenceNumber &&
+      parsed.formatId === returnReference) {
+      return;
+    }
+  }
+  return createError(errorMessages.returnId, line);
+};
+
+const validateLicences = licences => {
+  const errors = licences.reduce((acc, licence, index) => {
+    acc.push(validateLicenceNumber(licence));
+    acc.push(validateReturnReference(licence));
+    acc.push(validateNilReturn(licence));
+    acc.push(validateMeterUsed(licence));
+    acc.push(validateMeterMake(licence));
+    acc.push(validateMeterSerialNumber(licence));
+    acc.push(validateAbstractionVolumes(licence));
+    acc.push(validateReturnId(licence));
+    return acc;
+  }, []);
+
+  return flatten(compact(errors));
+};
+
+const validate = async csv => {
+  try {
+    const records = await parseCsv(csv, parseOptions);
+
+    // validate the headings
+    const headerErrors = validateHeadings(records);
+
+    if (headerErrors.length) {
+      return createValidationResult(headerErrors);
+    }
+
+    // headings are good, validate the licence data
+    const licenceErrors = validateLicences(recordsToLicences(records));
+    return createValidationResult(licenceErrors);
+  } catch (err) {
+    const parseErrors = [createErrorFromCsvParseError(err.message)];
+    return createValidationResult(parseErrors);
+  }
+};
+
+const createValidationResult = (errors = []) => ({
+  isValid: errors.length === 0,
+  validationErrors: errors
+});
+
+exports.errorMessages = errorMessages;
+exports.validate = validate;

--- a/src/modules/returns/schema.js
+++ b/src/modules/returns/schema.js
@@ -6,7 +6,7 @@ const readingTypes = ['estimated', 'measured'];
 const statuses = ['due', 'completed', 'received', 'void'];
 const units = ['m³', 'l', 'Ml', 'gal'];
 const userTypes = ['internal', 'external'];
-const returnIDRegex = /^v1:[1-8]:[^:]+:[0-9]+:[0-9]{4}-[0-9]{2}-[0-9]{2}:[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const { returnIDRegex } = require('../../lib/returns');
 
 const userSchema = Joi.object().required().keys({
   email: Joi.string().required(),

--- a/test/lib/returns.js
+++ b/test/lib/returns.js
@@ -1,7 +1,8 @@
 const { expect } = require('code');
 const {
   experiment,
-  test
+  test,
+  beforeEach
 } = exports.lab = require('lab').script();
 
 const returns = require('../../src/lib/returns');
@@ -16,5 +17,37 @@ experiment('getReturnId', () => {
 
     expect(returns.getReturnId(regionCode, licenceNumber, formatId, startDate, endDate))
       .to.equal('v1:1:123abc:1234:2018-01-01:2019-01-01');
+  });
+});
+
+experiment('parseReturnId', () => {
+  let parsed;
+
+  beforeEach(async () => {
+    parsed = returns.parseReturnId('v1:1:123abc:1234:2018-01-01:2019-01-01');
+  });
+
+  test('extracts the version', async () => {
+    expect(parsed.version).to.equal('v1');
+  });
+
+  test('extracts the region code', async () => {
+    expect(parsed.regionCode).to.equal('1');
+  });
+
+  test('extracts the licence number', async () => {
+    expect(parsed.licenceNumber).to.equal('123abc');
+  });
+
+  test('extracts the format id', async () => {
+    expect(parsed.formatId).to.equal('1234');
+  });
+
+  test('extracts the start date', async () => {
+    expect(parsed.startDate).to.equal('2018-01-01');
+  });
+
+  test('extracts the end date', async () => {
+    expect(parsed.endDate).to.equal('2019-01-01');
   });
 });

--- a/test/modules/returns/lib/csv-schema-validation.js
+++ b/test/modules/returns/lib/csv-schema-validation.js
@@ -1,0 +1,656 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const csvSchemaValidation = require('../../../../src/modules/returns/lib/csv-schema-validation');
+const csvStringify = require('csv-stringify/lib/sync');
+
+const validLicenceNumberRecord = ['Licence number', '123', '123abc'];
+const validReturnReferenceRecord = ['Return reference', '123', '456'];
+const validNilReturnRecord = ['Nil return Y/N', 'Y', 'N'];
+const validUseAMeterRecord = ['Did you use a meter Y/N', 'Y', 'N'];
+const validMeterMakeRecord = ['Meter make', 'Make 1', ''];
+const validMeterSerialNumberRecord = ['Meter serial number', '123-123', ''];
+const validUniqueReturnReferenceRecord = ['Unique return reference', '123', '123'];
+const validDailyRecords = [
+  ['9 April 2018', '10', 'Do not edit'],
+  ['10 April 2018', '20', 'Do not edit'],
+  ['11 April 2018', '30', 'Do not edit']
+];
+const validWeeklyRecords = [
+  ['Week ending 9 April 2018', '10', 'Do not edit'],
+  ['Week ending 10 April 2018', '20', 'Do not edit'],
+  ['Week ending 11 April 2018', '30', 'Do not edit']
+];
+const validMonthlyRecords = [
+  ['April 2018', '10', 'Do not edit'],
+  ['April 2018', '20', 'Do not edit'],
+  ['April 2018', '30', 'Do not edit']
+];
+
+const getValidSingleLicenceReturn = () => ([
+  ['Licence number', '123'],
+  ['Return reference', '123456'],
+  ['Nil return Y/N', 'N'],
+  ['Did you use a meter Y/N', 'Y'],
+  ['Meter make', 'Make 1'],
+  ['Meter serial number', '123-123'],
+  ['9 April 2018', '10'],
+  ['10 April 2018', '20'],
+  ['11 April 2018', '30'],
+  ['Unique return reference', 'v1:1:123:123456:2018-04-01:2019-03-31']
+]);
+
+experiment('csv-schema-validation', () => {
+  test('handles inconsistent record lengths', async () => {
+    const records = [
+      ['Licence number', '123', '123abc', '123/abc'],
+      ['Return reference', '123', '1234']
+    ];
+
+    const csv = csvStringify(records);
+    const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+    expect(isValid).to.be.false();
+
+    const errorMessage = 'Number of columns is inconsistent on line 2';
+    const error = validationErrors.find(err => err.message === errorMessage);
+    expect(error).to.equal({
+      message: errorMessage,
+      line: 2
+    });
+  });
+
+  experiment('header validation', () => {
+    test('returns error if Licence number field is incorrect', async () => {
+      const records = [
+        ['Not the licence number', '123', '123/abc']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Licence number field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 1
+      });
+    });
+
+    test('returns error if Return reference field is incorrect', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        ['Not the return reference', '123', '456']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Return reference field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 2
+      });
+    });
+
+    test('returns error if Nil return field is incorrect', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        validReturnReferenceRecord,
+        ['Not the nil return field', 'Y', 'N']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Nil return Y/N field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 3
+      });
+    });
+
+    test('returns error if Did you use a meter field is incorrect', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        validReturnReferenceRecord,
+        validNilReturnRecord,
+        ['Not the Did you use a meter field', 'Y', 'N']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Did you use a meter Y/N field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 4
+      });
+    });
+
+    test('returns error if Meter make field is incorrect', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        validReturnReferenceRecord,
+        validNilReturnRecord,
+        validUseAMeterRecord,
+        ['Not the Meter make record', 'Make 1', '']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Meter make field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 5
+      });
+    });
+
+    test('returns error if Meter serial number field is incorrect', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        validReturnReferenceRecord,
+        validNilReturnRecord,
+        validUseAMeterRecord,
+        validMeterMakeRecord,
+        ['Not the Meter serial number record', 'Ser 1', '']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Meter serial number field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 6
+      });
+    });
+
+    test('returns error if unexpected date field', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        validReturnReferenceRecord,
+        validNilReturnRecord,
+        validUseAMeterRecord,
+        validMeterMakeRecord,
+        validMeterSerialNumberRecord,
+        ...validDailyRecords,
+        ...validWeeklyRecords,
+        ...validMonthlyRecords,
+        ['13/04/2018', '111', 'Do not edit'],
+        validUniqueReturnReferenceRecord
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Unexpected date format for return line';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 16
+      });
+    });
+
+    test('returns error if Unique return reference field is incorrect', async () => {
+      const records = [
+        validLicenceNumberRecord,
+        validReturnReferenceRecord,
+        validNilReturnRecord,
+        validUseAMeterRecord,
+        validMeterMakeRecord,
+        validMeterSerialNumberRecord,
+        ...validDailyRecords,
+        ...validWeeklyRecords,
+        ...validMonthlyRecords,
+        ['Not the Unique return reference record', '123', '123']
+      ];
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Unique return reference field not in expected position';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 16
+      });
+    });
+  });
+
+  experiment('licence return values', () => {
+    test('the licence number must be present', async () => {
+      const records = getValidSingleLicenceReturn();
+
+      // update the licence number to empty
+      records[0][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Licence number is missing';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 1
+      });
+    });
+  });
+
+  experiment('return reference values', () => {
+    test('must be present', async () => {
+      const records = getValidSingleLicenceReturn();
+
+      // update the return reference to empty
+      records[1][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'All return references should be integers';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 2
+      });
+    });
+
+    test('must be integers', async () => {
+      const records = getValidSingleLicenceReturn();
+
+      // update the return reference to a non integer valie
+      records[1][1] = 'not a number';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'All return references should be integers';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 2
+      });
+    });
+  });
+
+  experiment('Nil return', () => {
+    test('can be Y', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[2][1] = 'Y';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be y', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[2][1] = 'y';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be N', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[2][1] = 'N';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be n', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[2][1] = 'n';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be empty', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[2][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('cannot be anything else', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[2][1] = 'Not valid';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Nil return should be Y, N or empty';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 3
+      });
+    });
+  });
+
+  experiment('Meter used', () => {
+    test('can be Y', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'Y';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be y', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'y';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be N', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'N';
+      records[4][1] = '';
+      records[5][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be n', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'n';
+      records[4][1] = '';
+      records[5][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be empty', async () => {
+      const records = getValidSingleLicenceReturn();
+
+      records[3][1] = '';
+      records[4][1] = '';
+      records[5][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('cannot be anything else', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'Not valid';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Did you use a meter should be Y, N or empty';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 4
+      });
+    });
+  });
+
+  experiment('meter make', () => {
+    test('must be present when meter used is true', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[4][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Meter make required if a meter was used';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 5
+      });
+    });
+
+    test('must be empty when meter used is false', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'n';
+      records[4][1] = 'This should be empty';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Meter make not allowed if a meter was not used';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 5
+      });
+    });
+  });
+
+  experiment('meter serial number', () => {
+    test('must be present when meter used is true', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[5][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Meter serial number required if a meter was used';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 6
+      });
+    });
+
+    test('must be empty when meter used is false', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[3][1] = 'n';
+      records[4][1] = '';
+      records[5][1] = 'This should be empty';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Meter serial number not allowed if a meter was not used';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 6
+      });
+    });
+  });
+
+  experiment('abstraction volumes', () => {
+    test('can be empty', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[6][1] = '';
+      records[7][1] = '';
+      records[8][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be "Do not edit"', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[6][1] = 'Do not edit';
+      records[7][1] = 'Do not edit';
+      records[8][1] = 'Do not edit';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('can be numbers including commas', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[6][1] = '1';
+      records[7][1] = '1.0';
+      records[8][1] = '1,234,567.89';
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('cannot be other values', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[6][1] = 'not valid';
+      records[7][1] = '';
+      records[8][1] = '';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Abstraction volumes must be numbers';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 7
+      });
+    });
+  });
+
+  experiment('return id', () => {
+    test('must contain the licence number', async () => {
+      const records = getValidSingleLicenceReturn();
+      // update the return id on the last row to not include
+      // the licence number that is included in the first line.
+      records[9][1] = 'v1:1:--INVALID--:123456:2018-04-01:2019-03-31';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Return id in unexpected format';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 10
+      });
+    });
+
+    test('must contain the return reference', async () => {
+      const records = getValidSingleLicenceReturn();
+      // update the return id on the last row to not include
+      // the return reference that is included in the second line.
+      records[9][1] = 'v1:1:123:--INVALID--:2018-04-01:2019-03-31';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Return id in unexpected format';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 10
+      });
+    });
+
+    test('must match the return id pattern', async () => {
+      const records = getValidSingleLicenceReturn();
+      // update the return id on the last row to not include
+      // unexpected date formats
+      records[9][1] = 'v1:1:123:123456:not-a-date:2019-03-31';
+
+      const csv = csvStringify(records);
+      const { isValid, validationErrors } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.false();
+
+      const errorMessage = 'Return id in unexpected format';
+      const error = validationErrors.find(err => err.message === errorMessage);
+      expect(error).to.equal({
+        message: errorMessage,
+        line: 10
+      });
+    });
+  });
+
+  experiment('handles empty data', () => {
+    test('empty lines are ignored', async () => {
+      const records = getValidSingleLicenceReturn();
+      records.splice(1, 0, ['', '']);
+      records.splice(5, 0, ['', '']);
+      records.splice(5, 0, ['', '']);
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+
+    test('data is trimmed for inspection', async () => {
+      const records = getValidSingleLicenceReturn();
+      records[0] = ['  Licence number', '123   '];
+      records[6] = ['9 April 2018', '   10     '];
+
+      const csv = csvStringify(records);
+      const { isValid } = await csvSchemaValidation.validate(csv);
+
+      expect(isValid).to.be.true();
+    });
+  });
+});


### PR DESCRIPTION
WATER-2070

Adds CSV validator which validates that the CSV is in the expected
shape.

Moves return id parser and regex to `src/lib/returns`