### PR TITLE
Fix: Update next check dates for notify status checks

### DIFF
--- a/src/modules/batch-notifications/lib/jobs/check-status.js
+++ b/src/modules/batch-notifications/lib/jobs/check-status.js
@@ -44,7 +44,8 @@ const handleCheckStatus = async job => {
       notify_status: status
     };
 
-    return scheduledNotifications.repository.update({ id: messageId }, data);
+    const result = await scheduledNotifications.repository.update({ id: messageId }, data);
+    return result;
   } catch (err) {
     logger.error(`Error checking notify status`, err, { messageId });
   }

--- a/src/modules/batch-notifications/lib/status-check-helpers.js
+++ b/src/modules/batch-notifications/lib/status-check-helpers.js
@@ -6,16 +6,17 @@ const moment = require('moment');
  * @param  {String} message.message_type email|letter
  * @param  {String} message.send_after the timestamp when the message was sent
  * @param  {Number} message.status_checks the number of times the message has been checked
+ * @param  {Object} The moment representation of now (used in testing)
  * @return {String}             the timestamp of the next check
  */
-const getNextCheckTime = (message) => {
+const getNextCheckTime = (message, now = moment()) => {
   const {
     message_type: messageType,
     send_after: sent,
     status_checks: checkCount
   } = message;
 
-  const momentSent = moment(sent);
+  const momentSent = moment(sent || now);
 
   // For letters, check their status every 12 hours
   if (messageType === 'letter') {

--- a/test/modules/batch-notifications/lib/status-check-helpers.js
+++ b/test/modules/batch-notifications/lib/status-check-helpers.js
@@ -1,12 +1,15 @@
 const { expect } = require('code');
+const moment = require('moment');
 const {
   beforeEach,
   experiment,
   test
 } = exports.lab = require('lab').script();
 
-const { getNextCheckTime, getNextCheckCount } =
-require('../../../../src/modules/batch-notifications/lib/status-check-helpers');
+const {
+  getNextCheckTime,
+  getNextCheckCount
+} = require('../../../../src/modules/batch-notifications/lib/status-check-helpers');
 
 experiment('batch notifications status check helpers', () => {
   let message;
@@ -63,6 +66,19 @@ experiment('batch notifications status check helpers', () => {
         const msg = { ...message, status_checks: 2 };
         const result = getNextCheckTime(msg);
         expect(result).to.startWith('2019-04-12T11:04:00');
+      });
+    });
+
+    experiment('when send_after is null', () => {
+      test('send_after is considered to be now', async () => {
+        const now = moment();
+        const message = {
+          message_type: 'email',
+          send_after: null,
+          status_checks: null
+        };
+        const result = getNextCheckTime(message, now);
+        expect(result).to.equal(now.add(1, 'minute').format());
       });
     });
   });


### PR DESCRIPTION
WATER-2158

Updates the `getNextCheckTime` function in status-check-helpers so that
if the `send_after` value is null, the current time is used to determine
the next check status.