### PR TITLE
Fix: Prevent email status check time getting to large

### DIFF
--- a/src/modules/batch-notifications/lib/status-check-helpers.js
+++ b/src/modules/batch-notifications/lib/status-check-helpers.js
@@ -25,7 +25,7 @@ const getNextCheckTime = (message, now = moment()) => {
   }
   // For emails, use an exponential check time starting with 1 minute
   if (messageType === 'email') {
-    const minutes = Math.pow(2, checkCount);
+    const minutes = Math.pow(checkCount + 1, 2);
     momentSent.add(minutes, 'minute');
   }
   return momentSent.format();

--- a/test/modules/batch-notifications/lib/status-check-helpers.js
+++ b/test/modules/batch-notifications/lib/status-check-helpers.js
@@ -56,16 +56,16 @@ experiment('batch notifications status check helpers', () => {
         expect(result).to.startWith('2019-04-12T11:01:00');
       });
 
-      test('second additional status check is 2 minutes after sending', () => {
+      test('second additional status check is 4 minutes after sending', () => {
         const msg = { ...message, status_checks: 1 };
         const result = getNextCheckTime(msg);
-        expect(result).to.startWith('2019-04-12T11:02:00');
+        expect(result).to.startWith('2019-04-12T11:04:00');
       });
 
-      test('third additional status check is 4 hours after sending', () => {
+      test('third additional status check is 9 minutes after sending', () => {
         const msg = { ...message, status_checks: 2 };
         const result = getNextCheckTime(msg);
-        expect(result).to.startWith('2019-04-12T11:04:00');
+        expect(result).to.startWith('2019-04-12T11:09:00');
       });
     });
 


### PR DESCRIPTION
Fixes an issue when the email status check could too quickly create a
number of minutes to be added to now, that exceeded the max JS date.