### PR TITLE
Fix: Only create contacts for non null version

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -6,7 +6,9 @@
       "ignore_watch": [
         "node_modules",
         "src/lib/temp",
-        "temp"
+        "temp",
+        ".git",
+        ".git/index.lock"
       ],
       "script": "index.js",
       "env": {
@@ -24,7 +26,9 @@
       "ignore_watch": [
         "node_modules",
         "src/lib/temp",
-        "temp"
+        "temp",
+        ".git",
+        ".git/index.lock"
       ],
       "script" : "import.js",
       "env": {
@@ -35,7 +39,5 @@
         "instances" : "1"
       }
     }
-
-
   ]
 }

--- a/src/lib/licence-transformer/csv-transformer.js
+++ b/src/lib/licence-transformer/csv-transformer.js
@@ -2,36 +2,21 @@
  * Transforms NALD data into VML native format
  * @module lib/licence-transformer/nald-transformer
  */
-const deepMap = require('deep-map');
 const { find, uniqBy } = require('lodash');
 const BaseTransformer = require('./base-transformer');
 const LicenceTitleLoader = require('./licence-title-loader');
 const licenceTitleLoader = new LicenceTitleLoader();
 const { logger } = require('../../logger');
 const naldHelpers = require('./nald-helpers');
+const naldFunctional = require('./nald-functional');
 
 class CSVTransformer extends BaseTransformer {
-  /**
-   * Transform string 'null' values to real null
-   * @param {Object} data
-   * @return {Object}
-   */
-  transformNull (data) {
-    return deepMap(data, (val) => {
-      // Convert string null to real null
-      if (typeof (val) === 'string' && (val === 'null' || val === '')) {
-        return null;
-      }
-      return val;
-    });
-  }
-
   /**
    * Load data into the transformer
    * @param {Object} data - data loaded from NALD
    */
   async load (data) {
-    data = this.transformNull(data);
+    data = naldFunctional.transformNull(data);
 
     this.data = {
       licenceNumber: data.id,

--- a/src/lib/licence-transformer/nald-functional.js
+++ b/src/lib/licence-transformer/nald-functional.js
@@ -1,4 +1,3 @@
-const { find } = require('lodash');
 const deepMap = require('deep-map');
 
 /**
@@ -6,31 +5,16 @@ const deepMap = require('deep-map');
  * @param {Object} contactAddress - party/role address
  * @return {Object} reformatted address
  */
-const addressFormatter = (contactAddress) => {
-  const {
-    ADDR_LINE1,
-    ADDR_LINE2,
-    ADDR_LINE3
-  } = contactAddress;
-  const {
-    ADDR_LINE4,
-    TOWN,
-    COUNTY,
-    POSTCODE,
-    COUNTRY
-  } = contactAddress;
-
-  return {
-    addressLine1: ADDR_LINE1,
-    addressLine2: ADDR_LINE2,
-    addressLine3: ADDR_LINE3,
-    addressLine4: ADDR_LINE4,
-    town: TOWN,
-    county: COUNTY,
-    postcode: POSTCODE,
-    country: COUNTRY
-  };
-};
+const addressFormatter = (contactAddress) => ({
+  addressLine1: contactAddress.ADDR_LINE1,
+  addressLine2: contactAddress.ADDR_LINE2,
+  addressLine3: contactAddress.ADDR_LINE3,
+  addressLine4: contactAddress.ADDR_LINE4,
+  town: contactAddress.TOWN,
+  county: contactAddress.COUNTY,
+  postcode: contactAddress.POSTCODE,
+  country: contactAddress.COUNTRY
+});
 
 /**
  * Formats a party name - whether person or organisation
@@ -69,13 +53,14 @@ const crmNameFormatter = (party) => {
   };
 };
 
+const isCurrentVersion = version => version.STATUS === 'CURR';
+
 /**
+ * From an array of version, finds a versiont that has a status of CURR
  * @param {Array} versions
- * @return {Array}
+ * @return {Object | undefined} The current version or undeined if not current version
  */
-const findCurrent = (versions) => {
-  return find(versions, version => version.STATUS === 'CURR');
-};
+const findCurrent = (versions = []) => versions.find(isCurrentVersion);
 
 /**
  * Transform string 'null' values to real null
@@ -92,10 +77,8 @@ const transformNull = (data) => {
   });
 };
 
-module.exports = {
-  addressFormatter,
-  nameFormatter,
-  crmNameFormatter,
-  findCurrent,
-  transformNull
-};
+exports.addressFormatter = addressFormatter;
+exports.nameFormatter = nameFormatter;
+exports.crmNameFormatter = crmNameFormatter;
+exports.findCurrent = findCurrent;
+exports.transformNull = transformNull;

--- a/src/lib/models/factory/contact-list.js
+++ b/src/lib/models/factory/contact-list.js
@@ -4,6 +4,7 @@ const { find, get } = require('lodash');
 // Import models
 const Contact = require('../contact');
 const ContactList = require('../contact-list');
+const naldFunctional = require('../../licence-transformer/nald-functional');
 
 const { createContact } = require('./contact');
 
@@ -52,7 +53,7 @@ const createContacts = (data) => {
   const contacts = new ContactList();
 
   // Get current version
-  const currentVersion = find(data.data.versions, version => version.STATUS === 'CURR');
+  const currentVersion = naldFunctional.findCurrent(data.data.versions);
   if (!currentVersion) {
     return contacts;
   }

--- a/src/modules/internal-search/lib/search-documents.js
+++ b/src/modules/internal-search/lib/search-documents.js
@@ -4,6 +4,17 @@ const { getPagination } = require('./pagination');
 const { returnsDateToIso } = require('../../../lib/dates');
 const { getFullName } = require('../../../lib/licence-transformer/nald-helpers');
 
+const validateRowMetadata = row => {
+  if (!row.metadata) {
+    const err = new Error('No metadata for document');
+    err.params = {
+      documentId: row.document_id,
+      licenceRef: row.system_external_id
+    };
+    throw err;
+  }
+};
+
 /**
  * Gets full name for a licence
  * @param  {[type]} documentHeader [description]
@@ -20,6 +31,8 @@ const getLicenceHolderNameFromDocumentHeader = (documentHeader) => {
 };
 
 const mapRow = (row) => {
+  validateRowMetadata(row);
+
   return {
     documentId: row.document_id,
     licenceNumber: row.system_external_id,
@@ -65,7 +78,5 @@ const searchDocuments = async (query, page = 1) => {
   };
 };
 
-module.exports = {
-  mapRow,
-  searchDocuments
-};
+exports.mapRow = mapRow;
+exports.searchDocuments = searchDocuments;

--- a/test/lib/licence-transformer/nald-functional.js
+++ b/test/lib/licence-transformer/nald-functional.js
@@ -1,0 +1,62 @@
+const {
+  experiment,
+  test
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+
+const naldFunctional = require('../../../src/lib/licence-transformer/nald-functional');
+
+experiment('lib/licence-transformer/nald-functional', () => {
+  experiment('.addressFormatter', () => {
+    test('maps the expected data', async () => {
+      const address = naldFunctional.addressFormatter({
+        ADDR_LINE1: 'address_line1',
+        ADDR_LINE2: 'address_line2',
+        ADDR_LINE3: 'address_line3',
+        ADDR_LINE4: 'address_line4',
+        TOWN: 'town',
+        COUNTY: 'county',
+        POSTCODE: 'postcode',
+        COUNTRY: 'country'
+      });
+
+      expect(address).to.equal({
+        addressLine1: 'address_line1',
+        addressLine2: 'address_line2',
+        addressLine3: 'address_line3',
+        addressLine4: 'address_line4',
+        town: 'town',
+        county: 'county',
+        postcode: 'postcode',
+        country: 'country'
+      });
+    });
+  });
+
+  experiment('.findCurrent', () => {
+    test('returns undefined if no versions ', async () => {
+      const current = naldFunctional.findCurrent();
+      expect(current).to.be.undefined();
+    });
+
+    test('returns undefined if no current version ', async () => {
+      const current = naldFunctional.findCurrent([
+        { STATUS: 'DRAFT' },
+        { STATUS: 'DRAFT' }
+      ]);
+      expect(current).to.be.undefined();
+    });
+
+    test('returns the expected current version', async () => {
+      const current = naldFunctional.findCurrent([
+        { STATUS: 'DRAFT' },
+        { STATUS: 'CURR', test: true }
+      ]);
+
+      expect(current).to.equal(
+        { STATUS: 'CURR', test: true }
+      );
+    });
+  });
+});

--- a/test/modules/import/lib/transform-crm.js
+++ b/test/modules/import/lib/transform-crm.js
@@ -1,29 +1,103 @@
-const Lab = require('@hapi/lab');
-const { experiment, test } = exports.lab = Lab.script();
+const {
+  beforeEach,
+  experiment,
+  test
+} = exports.lab = require('@hapi/lab').script();
 const { expect } = require('@hapi/code');
 const moment = require('moment');
 
-const { buildCRMMetadata } = require('../../../../src/modules/import/transform-crm');
+const transformCrm = require('../../../../src/modules/import/transform-crm');
 
-experiment('buildCRMMetadata', () => {
-  test('returns a default object if the current version is falsy', async () => {
-    const meta = buildCRMMetadata();
-    expect(meta).to.equal({
-      IsCurrent: false
+experiment('modules/import/lib/transform-crm', () => {
+  experiment('.buildCRMMetadata', () => {
+    test('returns a default object if the current version is falsy', async () => {
+      const meta = transformCrm.buildCRMMetadata();
+      expect(meta).to.equal({
+        IsCurrent: false
+      });
+    });
+
+    test('IsCurrent is true if the currentVersion is supplied', async () => {
+      const currentVersion = {
+        expiry_date: moment().add(2, 'months').format('YYYYMMDD'),
+        version_effective_date: moment().subtract(1, 'month').format('YYYYMMDD'),
+        party: {},
+        address: {}
+      };
+
+      const meta = transformCrm.buildCRMMetadata(currentVersion);
+      expect(meta.IsCurrent).to.be.true();
+      expect(meta.Expires).to.equal(currentVersion.expiry_date);
+      expect(meta.Modified).to.equal(currentVersion.version_effective_date);
     });
   });
 
-  test('IsCurrent is true if the currentVersion is supplied', async () => {
-    const currentVersion = {
-      expiry_date: moment().add(2, 'months').format('YYYYMMDD'),
-      version_effective_date: moment().subtract(1, 'month').format('YYYYMMDD'),
-      party: {},
-      address: {}
-    };
+  experiment('.contactsFormatter', () => {
+    experiment('when the current version is null', () => {
+      test('an empty array is returned', async () => {
+        const contacts = transformCrm.contactsFormatter(null, []);
+        expect(contacts).to.equal([]);
+      });
+    });
 
-    const meta = buildCRMMetadata(currentVersion);
-    expect(meta.IsCurrent).to.be.true();
-    expect(meta.Expires).to.equal(currentVersion.expiry_date);
-    expect(meta.Modified).to.equal(currentVersion.version_effective_date);
+    experiment('when the current version is present', () => {
+      let currentVersion;
+      let roles;
+
+      beforeEach(async () => {
+        currentVersion = {
+          ACON_APAR_ID: 1,
+          ACON_AADD_ID: 2,
+          parties: [
+            {
+              ID: 1,
+              APAR_TYPE: 'PER',
+              FORENAME: 'forename',
+              NAME: 'name',
+              contacts: [
+                {
+                  AADD_ID: 2,
+                  party_address: {
+                    ADDR_LINE1: 'test-1'
+                  }
+                }
+              ]
+            }
+          ]
+        };
+
+        roles = [
+          {
+            role_type: {
+              DESCR: 'For Sentance Casing'
+            },
+            role_address: {
+              ADDR_LINE1: 'test-1'
+            }
+          }
+        ];
+      });
+
+      test('the licence holder is added to the contacts', async () => {
+        const contacts = transformCrm.contactsFormatter(currentVersion, roles);
+        const licenceHolder = contacts[0];
+        expect(licenceHolder.role).to.equal('Licence holder');
+        expect(licenceHolder.type).to.equal('Person');
+        expect(licenceHolder.forename).to.equal('forename');
+        expect(licenceHolder.name).to.equal('name');
+        expect(licenceHolder.addressLine1).to.equal('test-1');
+      });
+
+      test('the roles are added after the licence holder', async () => {
+        const contacts = transformCrm.contactsFormatter(currentVersion, roles);
+        const role = contacts[1];
+
+        expect(role.role).to.equal('For sentance casing');
+        expect(role.type).to.equal('Person');
+        expect(role.forename).to.equal('forename');
+        expect(role.name).to.equal('name');
+        expect(role.addressLine1).to.equal('test-1');
+      });
+    });
   });
 });

--- a/test/modules/internal-search/lib/search-documents.js
+++ b/test/modules/internal-search/lib/search-documents.js
@@ -1,79 +1,101 @@
 const sinon = require('sinon');
-const Lab = require('@hapi/lab');
-const { experiment, test, afterEach } = exports.lab = Lab.script();
-const { expect } = require('@hapi/code');
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect, fail } = require('@hapi/code');
 
 const documents = require('../../../../src/lib/connectors/crm/documents');
 const { mapRow, searchDocuments } = require('../../../../src/modules/internal-search/lib/search-documents');
 
-// Row of data returned from CRM API
-const row = {
-  document_id: 'abc',
-  system_external_id: '01/123/456',
-  metadata: {
-    Name: 'Doe',
-    Initials: 'J',
-    Forename: 'John',
-    Salutation: 'Mr',
-    Expires: '20190205',
-    IsCurrent: true
-  },
-  document_name: 'Fusty meadow'
-};
+experiment('modules/internal-search/lib/search-documents', () => {
+  let row;
 
-experiment('mapRow', () => {
-  test('It should map a row of data from the CRM documents API', async () => {
-    const mapped = mapRow(row);
-    expect(mapped).to.equal({
-      documentId: row.document_id,
-      licenceNumber: row.system_external_id,
-      licenceHolder: 'Mr J Doe',
-      documentName: row.document_name,
-      expires: '2019-02-05',
-      isCurrent: true
+  beforeEach(async () => {
+    row = {
+      document_id: 'abc',
+      system_external_id: '01/123/456',
+      metadata: {
+        Name: 'Doe',
+        Initials: 'J',
+        Forename: 'John',
+        Salutation: 'Mr',
+        Expires: '20190205',
+        IsCurrent: true
+      },
+      document_name: 'Fusty meadow'
+    };
+  });
+
+  experiment('mapRow', () => {
+    test('It should map a row of data from the CRM documents API', async () => {
+      const mapped = mapRow(row);
+      expect(mapped).to.equal({
+        documentId: row.document_id,
+        licenceNumber: row.system_external_id,
+        licenceHolder: 'Mr J Doe',
+        documentName: row.document_name,
+        expires: '2019-02-05',
+        isCurrent: true
+      });
+    });
+
+    test('throws an error if the metadata is undefined', async () => {
+      delete row.metadata;
+
+      try {
+        mapRow(row);
+        fail('Should not get here');
+      } catch (e) {
+        expect(e.message).to.equal('No metadata for document');
+        expect(e.params.documentId).to.equal(row.document_id);
+        expect(e.params.licenceRef).to.equal(row.system_external_id);
+      }
     });
   });
-});
 
-experiment('searchDocuments', () => {
-  let stub;
+  experiment('searchDocuments', () => {
+    let stub;
 
-  afterEach(async () => {
-    stub.restore();
-  });
-
-  test('It should throw an error if an error returned by the API', async () => {
-    stub = sinon.stub(documents, 'findMany').resolves({ error: 'Some error' });
-    expect(searchDocuments('01/123')).to.reject();
-  });
-
-  test('It should call the API with the correct arguments', async () => {
-    stub = sinon.stub(documents, 'findMany').resolves({ data: [] });
-    searchDocuments('01/123', 5);
-    const [filter, sort, pagination, columns] = stub.firstCall.args;
-    expect(filter).to.equal({
-      string: '01/123',
-      includeExpired: true
+    afterEach(async () => {
+      stub.restore();
     });
-    expect(sort).to.equal({ system_external_id: 1 });
-    expect(pagination.page).to.equal(5);
-    expect(columns).to.equal([
-      'document_id',
-      'system_external_id',
-      'metadata',
-      'document_name'
-    ]);
-  });
 
-  test('It should return pagination object and mapped data from API call', async () => {
-    const pagination = { page: 5, perPage: 50 };
-    stub = sinon.stub(documents, 'findMany').resolves({
-      data: [row], pagination
+    test('It should throw an error if an error returned by the API', async () => {
+      stub = sinon.stub(documents, 'findMany').resolves({ error: 'Some error' });
+      expect(searchDocuments('01/123')).to.reject();
     });
-    const result = await searchDocuments('01/123', 5);
 
-    expect(Object.keys(result).sort()).to.equal(['data', 'pagination']);
-    expect(result.data[0]).to.be.an.object();
-    expect(result.pagination).to.equal(pagination);
+    test('It should call the API with the correct arguments', async () => {
+      stub = sinon.stub(documents, 'findMany').resolves({ data: [] });
+      searchDocuments('01/123', 5);
+      const [filter, sort, pagination, columns] = stub.firstCall.args;
+      expect(filter).to.equal({
+        string: '01/123',
+        includeExpired: true
+      });
+      expect(sort).to.equal({ system_external_id: 1 });
+      expect(pagination.page).to.equal(5);
+      expect(columns).to.equal([
+        'document_id',
+        'system_external_id',
+        'metadata',
+        'document_name'
+      ]);
+    });
+
+    test('It should return pagination object and mapped data from API call', async () => {
+      const pagination = { page: 5, perPage: 50 };
+      stub = sinon.stub(documents, 'findMany').resolves({
+        data: [row], pagination
+      });
+      const result = await searchDocuments('01/123', 5);
+
+      expect(Object.keys(result).sort()).to.equal(['data', 'pagination']);
+      expect(result.data[0]).to.be.an.object();
+      expect(result.pagination).to.equal(pagination);
+    });
   });
 });


### PR DESCRIPTION
WATER-2212

Prevents an attempts to access the parties of the current version if the
licence has no current version.