### PR TITLE
Fix: Returns notifications job completion

### DIFF
--- a/src/modules/returns-notifications/index.js
+++ b/src/modules/returns-notifications/index.js
@@ -4,14 +4,14 @@ const { prepareMessageData } = require('./lib/send');
 const { logger } = require('../../logger');
 
 const registerSendSubscriber = (messageQueue) => {
-  return messageQueue.subscribe('returnsNotification.send', async (job, done) => {
+  return messageQueue.subscribe('returnsNotification.send', async (job) => {
     try {
       const options = await prepareMessageData(job.data);
       await enqueue(options);
-      return done();
+      return job.done();
     } catch (err) {
       logger.error('Failed to enqueue return notification', err);
-      return done(err);
+      return job.done(err);
     }
   });
 };


### PR DESCRIPTION
Fixes an issue where the message queue subscription handler does not
contain the `done` callback and instead it should be accessed of the
`job` argument.