### PR TITLE
Create Role model. Add roles to InvoiceLicence model.

### DIFF
--- a/src/lib/models/invoice-licence.js
+++ b/src/lib/models/invoice-licence.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { assert } = require('@hapi/hoek');
 const { get } = require('lodash');
 
 const Address = require('./address');
@@ -8,6 +7,7 @@ const Company = require('./company');
 const Contact = require('./contact-v2');
 const Licence = require('./licence');
 const Transaction = require('./transaction');
+const Role = require('./role');
 
 const {
   assertIsArrayOfType,
@@ -27,7 +27,7 @@ class InvoiceLicence extends Model {
   * @param {Licence} licence
   */
   set licence (licence) {
-    assert(licence instanceof Licence, 'Licence expected');
+    assertIsInstanceOf(licence, Licence);
     this._licence = licence;
   }
 
@@ -97,6 +97,15 @@ class InvoiceLicence extends Model {
 
   get transactions () {
     return this._transactions;
+  }
+
+  set roles (roles) {
+    assertIsArrayOfType(roles, Role);
+    this._roles = roles;
+  }
+
+  get roles () {
+    return this._roles;
   }
 
   /**

--- a/src/lib/models/role.js
+++ b/src/lib/models/role.js
@@ -51,10 +51,8 @@ class Role extends Model {
   }
 
   set contact (contact) {
-    if (contact) {
-      assertIsInstanceOf(contact, Contact);
-      this._contact = contact;
-    } else { this._contact = null; }
+    assertIsInstanceOf(contact, Contact);
+    this._contact = contact;
   }
 
   get contact () {

--- a/src/lib/models/role.js
+++ b/src/lib/models/role.js
@@ -9,9 +9,12 @@ const Address = require('./address');
 const {
   assertDate,
   assertNullableDate,
-  assertRoleName,
+  assertEnum,
   assertIsInstanceOf
 } = require('./validators');
+
+const ROLE_LICENCE_HOLDER = 'licenceHolder';
+const validRoleNames = [ROLE_LICENCE_HOLDER];
 
 class Role extends Model {
   set startDate (startDate) {
@@ -33,7 +36,7 @@ class Role extends Model {
   }
 
   set roleName (roleName) {
-    assertRoleName(roleName);
+    assertEnum(roleName, validRoleNames);
     this._roleName = roleName;
   }
 

--- a/src/lib/models/role.js
+++ b/src/lib/models/role.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const Model = require('./model');
+
+const Company = require('./company');
+const Contact = require('./contact-v2');
+const Address = require('./address');
+
+const {
+  assertDate,
+  assertNullableDate,
+  assertRoleName,
+  assertIsInstanceOf
+} = require('./validators');
+
+class Role extends Model {
+  set startDate (startDate) {
+    assertDate(startDate);
+    this._startDate = startDate;
+  }
+
+  get startDate () {
+    return this._startDate;
+  }
+
+  set endDate (endDate) {
+    assertNullableDate(endDate);
+    this._endDate = endDate;
+  }
+
+  get endDate () {
+    return this._endDate;
+  }
+
+  set roleName (roleName) {
+    assertRoleName(roleName);
+    this._roleName = roleName;
+  }
+
+  get roleName () {
+    return this._roleName;
+  }
+
+  set company (company) {
+    assertIsInstanceOf(company, Company);
+    this._company = company;
+  }
+
+  get company () {
+    return this._company;
+  }
+
+  set contact (contact) {
+    if (contact) {
+      assertIsInstanceOf(contact, Contact);
+      this._contact = contact;
+    } else { this._contact = null; }
+  }
+
+  get contact () {
+    return this._contact;
+  }
+
+  set address (address) {
+    assertIsInstanceOf(address, Address);
+    this._address = address;
+  }
+
+  get address () {
+    return this._address;
+  }
+}
+
+module.exports = Role;

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -2,6 +2,11 @@ const { isArray } = require('lodash');
 const { assert } = require('@hapi/hoek');
 const Joi = require('joi');
 
+const dateRegex = /^\d{4}-([0][1-9]|[1][0-2])-([0][1-9]|[1-2][0-9]|[3][0-1])$/;
+const validRoleNames = ['licenceHolder'];
+
+const VALID_DATE = Joi.string().regex(dateRegex).required();
+const VALID_ROLE_NAME = Joi.string().valid(validRoleNames).required();
 const VALID_ACCOUNT_NUMBER = Joi.string().regex(/^[ABENSTWY][0-9]{8}A$/).required();
 const VALID_LICENCE_NUMBER = Joi.string().regex(/^[&()*-./0-9A-Z]+$/).required();
 const VALID_GUID = Joi.string().guid().required();
@@ -23,6 +28,9 @@ const assertLicenceNumber = licenceNumber => Joi.assert(licenceNumber, VALID_LIC
 const assertId = id => Joi.assert(id, VALID_GUID);
 const assertNullableString = value => Joi.assert(value, VALID_NULLABLE_STRING);
 const assertIsBoolean = value => Joi.assert(value, Joi.boolean().required());
+const assertDate = date => Joi.assert(date, VALID_DATE);
+const assertNullableDate = date => Joi.assert(date, VALID_DATE.allow(null));
+const assertRoleName = role => Joi.assert(role, VALID_ROLE_NAME);
 
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
@@ -31,3 +39,6 @@ exports.assertAccountNumber = assertAccountNumber;
 exports.assertLicenceNumber = assertLicenceNumber;
 exports.assertId = assertId;
 exports.assertNullableString = assertNullableString;
+exports.assertDate = assertDate;
+exports.assertNullableDate = assertNullableDate;
+exports.assertRoleName = assertRoleName;

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -2,8 +2,10 @@ const { isArray } = require('lodash');
 const { assert } = require('@hapi/hoek');
 const Joi = require('joi');
 
+const ROLE_LICENCE_HOLDER = 'licenceHolder';
+
 const dateRegex = /^\d{4}-([0][1-9]|[1][0-2])-([0][1-9]|[1-2][0-9]|[3][0-1])$/;
-const validRoleNames = ['licenceHolder'];
+const validRoleNames = [ROLE_LICENCE_HOLDER];
 
 const VALID_DATE = Joi.string().regex(dateRegex).required();
 const VALID_ROLE_NAME = Joi.string().valid(validRoleNames).required();
@@ -32,6 +34,7 @@ const assertDate = date => Joi.assert(date, VALID_DATE);
 const assertNullableDate = date => Joi.assert(date, VALID_DATE.allow(null));
 const assertRoleName = role => Joi.assert(role, VALID_ROLE_NAME);
 
+exports.ROLE_LICENCE_HOLDER = ROLE_LICENCE_HOLDER;
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
 exports.assertIsArrayOfType = assertIsArrayOfType;

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -2,13 +2,9 @@ const { isArray } = require('lodash');
 const { assert } = require('@hapi/hoek');
 const Joi = require('joi');
 
-const ROLE_LICENCE_HOLDER = 'licenceHolder';
-
 const dateRegex = /^\d{4}-([0][1-9]|[1][0-2])-([0][1-9]|[1-2][0-9]|[3][0-1])$/;
-const validRoleNames = [ROLE_LICENCE_HOLDER];
 
 const VALID_DATE = Joi.string().regex(dateRegex).required();
-const VALID_ROLE_NAME = Joi.string().valid(validRoleNames).required();
 const VALID_ACCOUNT_NUMBER = Joi.string().regex(/^[ABENSTWY][0-9]{8}A$/).required();
 const VALID_LICENCE_NUMBER = Joi.string().regex(/^[&()*-./0-9A-Z]+$/).required();
 const VALID_GUID = Joi.string().guid().required();
@@ -32,9 +28,8 @@ const assertNullableString = value => Joi.assert(value, VALID_NULLABLE_STRING);
 const assertIsBoolean = value => Joi.assert(value, Joi.boolean().required());
 const assertDate = date => Joi.assert(date, VALID_DATE);
 const assertNullableDate = date => Joi.assert(date, VALID_DATE.allow(null));
-const assertRoleName = role => Joi.assert(role, VALID_ROLE_NAME);
+const assertEnum = (str, values) => Joi.assert(str, Joi.string().valid(values).required());
 
-exports.ROLE_LICENCE_HOLDER = ROLE_LICENCE_HOLDER;
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
 exports.assertIsArrayOfType = assertIsArrayOfType;
@@ -44,4 +39,4 @@ exports.assertId = assertId;
 exports.assertNullableString = assertNullableString;
 exports.assertDate = assertDate;
 exports.assertNullableDate = assertNullableDate;
-exports.assertRoleName = assertRoleName;
+exports.assertEnum = assertEnum;

--- a/test/lib/models/invoice-licence.js
+++ b/test/lib/models/invoice-licence.js
@@ -10,6 +10,7 @@ const Company = require('../../../src/lib/models/company');
 const Licence = require('../../../src/lib/models/licence');
 const Contact = require('../../../src/lib/models/contact-v2');
 const Transaction = require('../../../src/lib/models/transaction');
+const Role = require('../../../src/lib/models/role');
 
 const createData = () => {
   const licence = new Licence();
@@ -132,19 +133,16 @@ experiment('lib/models/invoice-licence', () => {
 
   experiment('.set transactions', () => {
     test('throws for an array containing items other than Transaction objects', async () => {
-      const invoiceLicence = new InvoiceLicence();
       const func = () => (invoiceLicence.transactions = ['one', 'two']);
       expect(func).to.throw();
     });
 
     test('throws for non array', async () => {
-      const invoiceLicence = new InvoiceLicence();
       const func = () => (invoiceLicence.transactions = 'one');
       expect(func).to.throw();
     });
 
     test('sets the value when passed an array of Transaction objects', async () => {
-      const invoiceLicence = new InvoiceLicence();
       const tx1 = new Transaction();
       const tx2 = new Transaction();
       invoiceLicence.transactions = [tx1, tx2];
@@ -154,9 +152,29 @@ experiment('lib/models/invoice-licence', () => {
     });
   });
 
+  experiment('.roles', () => {
+    test('throws for an array containing items other than Role objects', async () => {
+      const func = () => (invoiceLicence.roles = [new Role(), 'two']);
+      expect(func).to.throw();
+    });
+
+    test('throws for non array', async () => {
+      const func = () => (invoiceLicence.roles = 'one');
+      expect(func).to.throw();
+    });
+
+    test('sets the value when passed an array of Role objects', async () => {
+      const tx1 = new Role();
+      const tx2 = new Role();
+      invoiceLicence.roles = [tx1, tx2];
+      expect(invoiceLicence.roles).to.have.length(2);
+      expect(invoiceLicence.roles[0]).to.equal(tx1);
+      expect(invoiceLicence.roles[1]).to.equal(tx2);
+    });
+  });
+
   experiment('.toJSON', () => {
     test('returns the expected object', async () => {
-      const invoiceLicence = new InvoiceLicence();
       const transaction = new Transaction();
       transaction.id = uuid();
       transaction.value = 123;

--- a/test/lib/models/role.js
+++ b/test/lib/models/role.js
@@ -120,16 +120,6 @@ experiment('lib/models/licence', () => {
       expect(role.contact).to.equal(data.contact);
     });
 
-    test('can be set to null', async () => {
-      role.contact = null;
-      expect(role.contact).to.be.null();
-    });
-
-    test('is set to null if contact is undefined', async () => {
-      role.contact = undefined;
-      expect(role.contact).to.be.null();
-    });
-
     test('throws an error if set to an invalid type', async () => {
       const func = () => {
         role.contact = data.company;

--- a/test/lib/models/role.js
+++ b/test/lib/models/role.js
@@ -125,6 +125,11 @@ experiment('lib/models/licence', () => {
       expect(role.contact).to.be.null();
     });
 
+    test('is set to null if contact is undefined', async () => {
+      role.contact = undefined;
+      expect(role.contact).to.be.null();
+    });
+
     test('throws an error if set to an invalid type', async () => {
       const func = () => {
         role.contact = data.company;

--- a/test/lib/models/role.js
+++ b/test/lib/models/role.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const Role = require('../../../src/lib/models/role');
+const Contact = require('../../../src/lib/models/contact-v2');
+const Company = require('../../../src/lib/models/company');
+const Address = require('../../../src/lib/models/address');
+
+const data = {
+  id: '4765cb29-5c87-4b14-88c2-37ef2a0eac41',
+  startDate: '2008-01-01',
+  endDate: '2012-12-21',
+  roleName: 'licenceHolder',
+  company: new Company(),
+  contact: new Contact(),
+  address: new Address()
+};
+
+experiment('lib/models/licence', () => {
+  let role;
+
+  beforeEach(async () => {
+    role = new Role();
+  });
+
+  experiment('.id', () => {
+    test('can be set to a guid string', async () => {
+      role.id = data.id;
+      expect(role.id).to.equal(data.id);
+    });
+
+    test('throws an error if set to a non-guid string', async () => {
+      const func = () => {
+        role.id = 'hey';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.startDate', () => {
+    test('can be set to a valid date', async () => {
+      role.startDate = data.startDate;
+      expect(role.startDate).to.equal(data.startDate);
+    });
+
+    test('throws an error if date is not valid', async () => {
+      const func = () => {
+        role.startDate = '2018-14-40';
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        role.startDate = null;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.endDate', () => {
+    test('can be set to a valid date', async () => {
+      role.endDate = data.endDate;
+      expect(role.endDate).to.equal(data.endDate);
+    });
+
+    test('can be set to null', async () => {
+      role.endDate = null;
+      expect(role.endDate).to.be.null();
+    });
+
+    test('throws an error if date is not valid', async () => {
+      const func = () => {
+        role.endDate = '2018-14-40';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.roleName', () => {
+    test('can be set to a valid option', async () => {
+      role.roleName = data.roleName;
+      expect(role.roleName).to.equal(data.roleName);
+    });
+
+    test('throws an error if role is not valid', async () => {
+      const func = () => {
+        role.roleName = 'waterUndertaker';
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        role.roleName = null;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.company', () => {
+    test('can be set to a Company instance', async () => {
+      role.company = data.company;
+      expect(role.company).to.equal(data.company);
+    });
+
+    test('throws an error if set to an invalid type', async () => {
+      const func = () => {
+        role.company = 'company';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.contact', () => {
+    test('can be set to a Contact instance', async () => {
+      role.contact = data.contact;
+      expect(role.contact).to.equal(data.contact);
+    });
+
+    test('can be set to null', async () => {
+      role.contact = null;
+      expect(role.contact).to.be.null();
+    });
+
+    test('throws an error if set to an invalid type', async () => {
+      const func = () => {
+        role.contact = data.company;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.address', () => {
+    test('can be set to a Address instance', async () => {
+      role.address = data.address;
+      expect(role.address).to.equal(data.address);
+    });
+
+    test('throws an error if set to an invalid type', async () => {
+      const func = () => {
+        role.address = null;
+      };
+      expect(func).to.throw();
+    });
+  });
+});


### PR DESCRIPTION
WATER-2450

Allows multiple licence holders to be stored against one invoice. Currently, only licenceHolder role is valid.