### PR TITLE
Feat: Capture region data for licences

### DIFF
--- a/migrations/20200108170348-add-undertaker-and-regions-to-licences.js
+++ b/migrations/20200108170348-add-undertaker-and-regions-to-licences.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200108170348-add-undertaker-and-regions-to-licences-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200108170348-add-undertaker-and-regions-to-licences-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-down.sql
+++ b/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-down.sql
@@ -1,0 +1,6 @@
+alter table water.licences
+  drop column is_water_undertaker,
+  drop column regions,
+  drop column date_created,
+  drop column date_updated,
+  drop constraint c_licences_lic_ref_region;

--- a/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-down.sql
+++ b/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-down.sql
@@ -3,4 +3,4 @@ alter table water.licences
   drop column regions,
   drop column date_created,
   drop column date_updated,
-  drop constraint c_licences_lic_ref_region;
+  drop constraint uidx_licences_lic_ref;

--- a/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-up.sql
+++ b/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-up.sql
@@ -1,0 +1,11 @@
+-- no live task will currently populate licences
+-- so this is required for developers who may have
+-- licence data for local testing.
+truncate water.licences cascade;
+
+alter table water.licences
+  add column is_water_undertaker boolean not null,
+  add column regions jsonb not null,
+  add column date_created timestamp not null default now(),
+  add column date_updated timestamp not null default now(),
+  add constraint c_licences_lic_ref_region unique (region_id, licence_ref);

--- a/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-up.sql
+++ b/migrations/sqls/20200108170348-add-undertaker-and-regions-to-licences-up.sql
@@ -8,4 +8,4 @@ alter table water.licences
   add column regions jsonb not null,
   add column date_created timestamp not null default now(),
   add column date_updated timestamp not null default now(),
-  add constraint c_licences_lic_ref_region unique (region_id, licence_ref);
+  add constraint uidx_licences_lic_ref unique (licence_ref);


### PR DESCRIPTION
WATER-2463

Updates the 'water.licences' table
- Adds the regions field to maintain the historic and charge regions required for charging
- Adds a flag to determine if the licence is owned by a water undertaker
- Adds a unique constraint so that a postgres upsert can be run by the import module when persisting a licence.