### PR TITLE
Feat: Remove customer from a bill run

### DIFF
--- a/migrations/20200110135211-update-batch-status-enum.js
+++ b/migrations/20200110135211-update-batch-status-enum.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200110135211-update-batch-status-enum-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200110135211-update-batch-status-enum-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200110135211-update-batch-status-enum-down.sql
+++ b/migrations/sqls/20200110135211-update-batch-status-enum-down.sql
@@ -1,0 +1,16 @@
+alter type water.batch_status
+  rename to batch_status_old;
+
+create type water.batch_status as enum (
+  'processing',
+  'complete',
+  'error'
+);
+
+alter table water.billing_batches
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+alter table water.billing_batch_charge_version_years
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+drop type water.batch_status_old;

--- a/migrations/sqls/20200110135211-update-batch-status-enum-up.sql
+++ b/migrations/sqls/20200110135211-update-batch-status-enum-up.sql
@@ -1,0 +1,17 @@
+alter type water.batch_status
+  rename to batch_status_old;
+
+create type water.batch_status as enum (
+  'processing',
+  'review',
+  'complete',
+  'error'
+);
+
+alter table water.billing_batches
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+alter table water.billing_batch_charge_version_years
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+drop type water.batch_status_old;

--- a/src/lib/connectors/crm-v2/invoice-accounts.js
+++ b/src/lib/connectors/crm-v2/invoice-accounts.js
@@ -18,4 +18,11 @@ const getInvoiceAccountsByIds = ids => {
   });
 };
 
+/**
+ * Gets an invoice account including company data for the given invoice account id
+ * @param String id The invoice account id
+ */
+const getInvoiceAccountById = id => serviceRequest.get(getUri(id));
+
+exports.getInvoiceAccountById = getInvoiceAccountById;
 exports.getInvoiceAccountsByIds = getInvoiceAccountsByIds;

--- a/src/lib/connectors/repository/BillingTransactionRepository.js
+++ b/src/lib/connectors/repository/BillingTransactionRepository.js
@@ -1,6 +1,16 @@
 const Repository = require('@envage/hapi-pg-rest-api/src/repository');
 const db = require('../db');
 
+const deleteByInvoiceAccountQuery = `
+  delete
+  from water.billing_transactions tx
+    using water.billing_invoice_licences il, water.billing_invoices i
+  where il.billing_invoice_licence_id = tx.billing_invoice_licence_id
+    and i.billing_invoice_id = il.billing_invoice_id
+    and i.billing_batch_id = $1
+    and i.invoice_account_id = $2;
+`;
+
 class BillingTransactionRepository extends Repository {
   constructor (config = {}) {
     super(Object.assign({
@@ -8,6 +18,17 @@ class BillingTransactionRepository extends Repository {
       table: 'water.billing_transactions',
       primaryKey: 'billing_transaction_id'
     }, config));
+  }
+
+  /**
+   * Deletes all transactions from water.billing_transactions that are associated
+   * with the batch and invoice account specified in the parameters.
+   *
+   * @param {String} batchId UUID of the batch containing the transactions to delete
+   * @param {String} invoiceAccountId UUID of the account for which to delete all transactions
+   */
+  deleteByInvoiceAccount (batchId, invoiceAccountId) {
+    return this.dbQuery(deleteByInvoiceAccountQuery, [batchId, invoiceAccountId]);
   }
 }
 

--- a/src/modules/billing/routes.js
+++ b/src/modules/billing/routes.js
@@ -61,7 +61,22 @@ const getBatchInvoiceDetail = {
   }
 };
 
+const deleteAccountFromBatch = {
+  method: 'DELETE',
+  path: '/water/1.0/billing/batches/{batchId}/account/{accountId}',
+  handler: controller.deleteAccountFromBatch,
+  config: {
+    validate: {
+      params: {
+        batchId: Joi.string().uuid().required(),
+        accountId: Joi.string().uuid().required()
+      }
+    }
+  }
+};
+
 exports.postCreateBatch = postCreateBatch;
 exports.getBatch = getBatch;
 exports.getBatchInvoices = getBatchInvoices;
 exports.getBatchInvoiceDetail = getBatchInvoiceDetail;
+exports.deleteAccountFromBatch = deleteAccountFromBatch;

--- a/src/modules/billing/services/invoice-accounts-service.js
+++ b/src/modules/billing/services/invoice-accounts-service.js
@@ -37,5 +37,17 @@ const getByInvoiceAccountIds = async ids => {
   );
 };
 
+/**
+ * Gets the invoice accounts with the specified ID from CRM and
+ * returns as an InvoiceAccount model
+ * @param String id - GUID for CRM invoice account ID
+ * @return {Promise<InvoiceAccount>}
+ */
+const getByInvoiceAccountId = async id => {
+  const invoiceAccount = await invoiceAccountsConnector.getInvoiceAccountById(id);
+  return mapCRMInvoiceAccountToModel(invoiceAccount, invoiceAccount.company);
+};
+
 exports.mapCRMInvoiceAccountToModel = mapCRMInvoiceAccountToModel;
 exports.getByInvoiceAccountIds = getByInvoiceAccountIds;
+exports.getByInvoiceAccountId = getByInvoiceAccountId;

--- a/test/lib/connectors/crm-v2/invoice-accounts.js
+++ b/test/lib/connectors/crm-v2/invoice-accounts.js
@@ -64,4 +64,22 @@ experiment('lib/connectors/crm-v2/invoice-accounts', () => {
       ]);
     });
   });
+
+  experiment('.getInvoiceAccountById', () => {
+    let response;
+
+    beforeEach(async () => {
+      serviceRequest.get.resolves({ invoiceAccountId: 'test-id-1' });
+      response = await invoiceAccountConnector.getInvoiceAccountById('test-id-1');
+    });
+
+    test('makes a request to the expected URL', async () => {
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal('http://test.defra/invoice-accounts/test-id-1');
+    });
+
+    test('returns the result from the crm', async () => {
+      expect(response).to.equal({ invoiceAccountId: 'test-id-1' });
+    });
+  });
 });

--- a/test/lib/connectors/repository/BillingTransactionRepository.js
+++ b/test/lib/connectors/repository/BillingTransactionRepository.js
@@ -1,0 +1,34 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const BillingTransactionRepository = require('../../../../src/lib/connectors/repository/BillingTransactionRepository');
+
+experiment('lib/connectors/repository/BillingTransactionRepository', () => {
+  beforeEach(async () => {
+    sandbox.stub(BillingTransactionRepository.prototype, 'dbQuery').resolves();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.deleteByInvoiceAccount', () => {
+    beforeEach(async () => {
+      const repo = new BillingTransactionRepository();
+      await repo.deleteByInvoiceAccount('test-batch-id', 'test-invoice-account-id');
+    });
+
+    test('passes the expected parameters to the query', async () => {
+      const [, params] = BillingTransactionRepository.prototype.dbQuery.lastCall.args;
+      expect(params[0]).to.equal('test-batch-id');
+      expect(params[1]).to.equal('test-invoice-account-id');
+    });
+  });
+});

--- a/test/modules/billing/routes.js
+++ b/test/modules/billing/routes.js
@@ -197,4 +197,39 @@ experiment('modules/billing/routes', () => {
       expect(response.statusCode).to.equal(400);
     });
   });
+
+  experiment('deleteAccountFromBatch', () => {
+    let request;
+    let server;
+    let validBatchId;
+    let validAccountId;
+
+    beforeEach(async () => {
+      server = getServer(routes.deleteAccountFromBatch);
+      validBatchId = uuid();
+      validAccountId = uuid();
+
+      request = {
+        method: 'DELETE',
+        url: `/water/1.0/billing/batches/${validBatchId}/account/${validAccountId}`
+      };
+    });
+
+    test('returns the 200 for a valid payload', async () => {
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('returns a 400 if the batch id is not a uuid', async () => {
+      request.url = request.url.replace(validBatchId, '123');
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the account id is not a uuid', async () => {
+      request.url = request.url.replace(validAccountId, '123');
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/test/modules/billing/services/invoice-accounts-service.js
+++ b/test/modules/billing/services/invoice-accounts-service.js
@@ -50,6 +50,7 @@ experiment('modules/billing/services/invoice-accounts-service', () => {
       }
     ];
     sandbox.stub(invoiceAccountsConnector, 'getInvoiceAccountsByIds').resolves(connectorResponse);
+    sandbox.stub(invoiceAccountsConnector, 'getInvoiceAccountById').resolves(connectorResponse[0]);
   });
 
   afterEach(async () => {
@@ -84,6 +85,28 @@ experiment('modules/billing/services/invoice-accounts-service', () => {
       expect(response[1].company.id).to.equal(connectorResponse[1].company.companyId);
       expect(response[1].company.name).to.equal(connectorResponse[1].company.name);
       expect(response[1].company.type).to.equal(connectorResponse[1].company.type);
+    });
+  });
+
+  experiment('.getByInvoiceAccountId', () => {
+    test('passes the invoice account id to the connector', async () => {
+      const id = uuid();
+      await invoiceAccountsService.getByInvoiceAccountId(id);
+
+      const [passedId] = invoiceAccountsConnector.getInvoiceAccountById.lastCall.args;
+      expect(passedId).to.equal(id);
+    });
+
+    test('returns the data as an InvoiceAccount object', async () => {
+      const response = await invoiceAccountsService.getByInvoiceAccountId(uuid());
+
+      expect(response).to.be.an.instanceOf(InvoiceAccount);
+      expect(response.id).to.equal(connectorResponse[0].invoiceAccountId);
+      expect(response.accountNumber).to.equal(connectorResponse[0].invoiceAccountNumber);
+      expect(response.company).to.be.an.instanceOf(Company);
+      expect(response.company.id).to.equal(connectorResponse[0].company.companyId);
+      expect(response.company.name).to.equal(connectorResponse[0].company.name);
+      expect(response.company.type).to.equal(connectorResponse[0].company.type);
     });
   });
 });


### PR DESCRIPTION
WATER-2411

- Adds new DELETE route for /batches/{batchId}/account/{accountId}

Checks if the batch exists and if it has invoices for the account, then
deletes the transactions from `water.billing_transactions`.

Requires more work in the future to delete the transactions from the
charge module.