### PR TITLE
Fix: Correct scheduling of next job

### DIFF
--- a/migrations/20200116133950-notifications-index.js
+++ b/migrations/20200116133950-notifications-index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200116133950-notifications-index-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200116133950-notifications-index-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200116133950-notifications-index-down.sql
+++ b/migrations/sqls/20200116133950-notifications-index-down.sql
@@ -1,0 +1,2 @@
+DROP INDEX water.idx_scheduled_notification_statuses;
+DROP INDEX water.idx_gauging_stations_station_reference;

--- a/migrations/sqls/20200116133950-notifications-index-up.sql
+++ b/migrations/sqls/20200116133950-notifications-index-up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_scheduled_notification_statuses ON water.scheduled_notification(status, notify_status);
+CREATE INDEX idx_gauging_stations_station_reference ON water.gauging_stations(station_reference);

--- a/src/controllers/tasks/refreshS3data.js
+++ b/src/controllers/tasks/refreshS3data.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const messageQueue = require('../../lib/message-queue');
 const { importNald } = require('../../modules/import')(messageQueue);
 
@@ -10,6 +12,4 @@ const run = async (data) => {
   }
 };
 
-module.exports = {
-  run
-};
+exports.run = run;

--- a/src/modules/import/extract.js
+++ b/src/modules/import/extract.js
@@ -124,14 +124,16 @@ async function getSqlForFile (file, schemaName) {
 
   const indexableFields = intersection(indexableFieldsList, cols);
 
-  for (const field of indexableFields) {
-    const indexName = `${table}_${field}_index`;
-    tableCreate += `\ndrop INDEX  if exists "${indexName}";`;
-  }
   tableCreate += `\n \\copy ${schemaName}."${table}" FROM '${finalPath}/${file}' HEADER DELIMITER ',' CSV;`;
-  for (const field of indexableFields) {
-    const indexName = `${table}_${field}_index`;
-    tableCreate += `\nCREATE INDEX "${indexName}" ON ${schemaName}."${table}" ("${field}");`;
+
+  if (table === 'NALD_RET_LINES') {
+    // NALD_RET_LINES is large so more care is required when creating indexes which can take a long time to create
+    tableCreate += `\nCREATE INDEX idx_nald_ret_lines_id_and_region ON ${schemaName}."NALD_RET_LINES" ("ARFL_ARTY_ID", "FGAC_REGION_CODE");`;
+  } else {
+    for (const field of indexableFields) {
+      const indexName = `${table}_${field}_index`;
+      tableCreate += `\nCREATE INDEX "${indexName}" ON ${schemaName}."${table}" ("${field}");`;
+    }
   }
 
   return tableCreate;

--- a/src/modules/import/index.js
+++ b/src/modules/import/index.js
@@ -30,7 +30,8 @@ module.exports = (messageQueue) => {
   return {
     importNald: () => {
       messageQueue.publish('import.start', {}, {
-        expireIn: '1 hours'
+        expireIn: '1 hours',
+        singletonKey: 'defra-nald-import'
       });
     },
     registerSubscribers: async () => {

--- a/src/routes/water.js
+++ b/src/routes/water.js
@@ -44,6 +44,7 @@ module.exports = [
 const cron = require('node-cron');
 
 taskRunner.reset();
-cron.schedule('*/5 * * * * * *', function () {
+
+cron.schedule('*/1 * * * *', function () {
   taskRunner.run();
 });


### PR DESCRIPTION
WATER-2472

 - Fixes an issue in the scheduler where the job was always being
scheduled to run again in one minute.
 - Due to the nature of the jobs maintained by the scheduler, reduces
the polling time down to once every 1 min
 - Adds some required indexes for the query speed