### PR TITLE
Feat/water 2500 handle supplementary hashes

### DIFF
--- a/src/lib/connectors/bookshelf/index.js
+++ b/src/lib/connectors/bookshelf/index.js
@@ -5,3 +5,4 @@ exports.BillingTransaction = require('./BillingTransaction');
 exports.ChargeElement = require('./ChargeElement');
 exports.Region = require('./Region');
 exports.Licence = require('./Licence');
+exports.bookshelf = require('./bookshelf').bookshelf;

--- a/src/lib/connectors/crm-v2/index.js
+++ b/src/lib/connectors/crm-v2/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   contacts: require('./contacts'),
-  documents: require('./documents')
+  documents: require('./documents'),
+  invoiceAccounts: require('./invoice-accounts')
 };

--- a/src/lib/connectors/repos/billing-batches.js
+++ b/src/lib/connectors/repos/billing-batches.js
@@ -28,5 +28,11 @@ const findPage = async (page, pageSize) => {
   return paginatedEnvelope(result);
 };
 
+const update = (id, data) => BillingBatch
+  .forge({ billing_batch_id: id })
+  .set(data)
+  .save();
+
 exports.findOne = findOne;
 exports.findPage = findPage;
+exports.update = update;

--- a/src/lib/connectors/repos/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/billing-invoice-licences.js
@@ -1,0 +1,24 @@
+const { bookshelf } = require('../bookshelf');
+
+const camelCaseKeys = require('../../camel-case-keys');
+
+const queries = require('./queries/billing-invoice-licences');
+
+/**
+ * Upserts a water.billing_invoice_licences record
+ * @param {Object} data - camel case
+ */
+const upsert = async data => {
+  const result = await bookshelf.knex.raw(queries.upsert, data);
+  return camelCaseKeys(result.rows[0]);
+};
+
+/**
+ * Deletes invoice licences in the batch which have no transactions
+ * @param {String} batchId
+ */
+const deleteEmptyByBatchId = batchId =>
+  bookshelf.knex.raw(queries.deleteEmptyByBatchId, { batchId });
+
+exports.upsert = upsert;
+exports.deleteEmptyByBatchId = deleteEmptyByBatchId;

--- a/src/lib/connectors/repos/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/billing-invoice-licences.js
@@ -1,17 +1,12 @@
 const { bookshelf } = require('../bookshelf');
-
-const camelCaseKeys = require('../../camel-case-keys');
-
+const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoice-licences');
 
 /**
  * Upserts a water.billing_invoice_licences record
  * @param {Object} data - camel case
  */
-const upsert = async data => {
-  const result = await bookshelf.knex.raw(queries.upsert, data);
-  return camelCaseKeys(result.rows[0]);
-};
+const upsert = async data => raw.singleRow(queries.upsert, data);
 
 /**
  * Deletes invoice licences in the batch which have no transactions

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -1,0 +1,24 @@
+const { bookshelf } = require('../bookshelf');
+
+const camelCaseKeys = require('../../camel-case-keys');
+
+const queries = require('./queries/billing-invoices');
+
+/**
+ * Upserts a water.billing_invoices record
+ * @param {Object} data - camel case
+ */
+const upsert = async data => {
+  const result = await bookshelf.knex.raw(queries.upsert, data);
+  return camelCaseKeys(result.rows[0]);
+};
+
+/**
+ * Deletes invoices in the batch which have no invoice licences
+ * @param {String} batchId
+ */
+const deleteEmptyByBatchId = batchId =>
+  bookshelf.knex.raw(queries.deleteEmptyByBatchId, { batchId });
+
+exports.upsert = upsert;
+exports.deleteEmptyByBatchId = deleteEmptyByBatchId;

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -1,17 +1,12 @@
 const { bookshelf } = require('../bookshelf');
-
-const camelCaseKeys = require('../../camel-case-keys');
-
+const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoices');
 
 /**
  * Upserts a water.billing_invoices record
  * @param {Object} data - camel case
  */
-const upsert = async data => {
-  const result = await bookshelf.knex.raw(queries.upsert, data);
-  return camelCaseKeys(result.rows[0]);
-};
+const upsert = async data => raw.singleRow(queries.upsert, data);
 
 /**
  * Deletes invoices in the batch which have no invoice licences

--- a/src/lib/connectors/repos/billing-transactions.js
+++ b/src/lib/connectors/repos/billing-transactions.js
@@ -72,10 +72,23 @@ const findHistoryByBatchId = async batchId => {
  */
 const deleteRecords = id => bookshelf
   .knex('water.billing_transactions')
-  .whereIn('billing_transaction_id', makeArray(id));
+  .whereIn('billing_transaction_id', makeArray(id))
+  .delete();
+
+/**
+ * Insert a new transaction record
+ * @param {Object} data - camel case
+ */
+const create = async data => {
+  const model = await BillingTransaction
+    .forge(data)
+    .save();
+  return model.toJSON();
+};
 
 exports.findOne = findOne;
 exports.find = find;
 exports.findHistoryByBatchId = findHistoryByBatchId;
 exports.findByBatchId = findByBatchId;
 exports.delete = deleteRecords;
+exports.create = create;

--- a/src/lib/connectors/repos/billing-transactions.js
+++ b/src/lib/connectors/repos/billing-transactions.js
@@ -2,6 +2,7 @@ const { BillingTransaction, bookshelf } = require('../bookshelf');
 const queries = require('./queries/billing-transactions');
 const camelCaseKeys = require('../../camel-case-keys');
 const makeArray = require('../../../lib/make-array');
+const raw = require('./lib/raw');
 
 const withRelated = [
   'chargeElement',
@@ -49,10 +50,7 @@ const find = async ids => {
  * @param {String} batchId - the supplementary batch ID being processed
  * @return {Promise<Array>}
  */
-const findByBatchId = async batchId => {
-  const result = await bookshelf.knex.raw(queries.findByBatchId, { batchId });
-  return camelCaseKeys(result.rows);
-};
+const findByBatchId = batchId => raw.multiRow(queries.findByBatchId, { batchId });
 
 /**
  * For supplementary billing, finds historical transactions
@@ -61,10 +59,7 @@ const findByBatchId = async batchId => {
  * @param {String} batchId - the supplementary batch ID being processed
  * @return {Promise<Array>} water.billing_transactions rows
  */
-const findHistoryByBatchId = async batchId => {
-  const result = await bookshelf.knex.raw(queries.findHistoryByBatchId, { batchId });
-  return camelCaseKeys(result.rows);
-};
+const findHistoryByBatchId = batchId => raw.multiRow(queries.findHistoryByBatchId, { batchId });
 
 /**
  * Delete one or many records

--- a/src/lib/connectors/repos/billing-transactions.js
+++ b/src/lib/connectors/repos/billing-transactions.js
@@ -1,4 +1,6 @@
-const { BillingTransaction } = require('../bookshelf');
+const { BillingTransaction, bookshelf } = require('../bookshelf');
+const queries = require('./queries/billing-transactions');
+const camelCaseKeys = require('../../camel-case-keys');
 
 /**
  * Gets transaction and related models by GUID
@@ -23,4 +25,29 @@ const findOne = async id => {
   return model.toJSON();
 };
 
+/**
+ * For supplementary billing, finds transactions in the supplied batch ID
+ * for hash comparison
+ * @param {String} batchId - the supplementary batch ID being processed
+ * @return {Promise<Array>}
+ */
+const findByBatchId = async batchId => {
+  const result = await bookshelf.knex.raw(queries.findByBatchId, { batchId });
+  return camelCaseKeys(result.rows);
+};
+
+/**
+ * For supplementary billing, finds historical transactions
+ * in completed batches for licences which are also contained
+ * in the supplied batch ID, for hash comparison
+ * @param {String} batchId - the supplementary batch ID being processed
+ * @return {Promise<Array>} water.billing_transactions rows
+ */
+const findHistoryByBatchId = async batchId => {
+  const result = await bookshelf.knex.raw(queries.findHistoryByBatchId, { batchId });
+  return camelCaseKeys(result.rows);
+};
+
 exports.findOne = findOne;
+exports.findHistoryByBatchId = findHistoryByBatchId;
+exports.findByBatchId = findByBatchId;

--- a/src/lib/connectors/repos/billing-transactions.js
+++ b/src/lib/connectors/repos/billing-transactions.js
@@ -1,6 +1,5 @@
 const { BillingTransaction, bookshelf } = require('../bookshelf');
 const queries = require('./queries/billing-transactions');
-const camelCaseKeys = require('../../camel-case-keys');
 const makeArray = require('../../../lib/make-array');
 const raw = require('./lib/raw');
 

--- a/src/lib/connectors/repos/index.js
+++ b/src/lib/connectors/repos/index.js
@@ -1,2 +1,4 @@
 exports.billingBatches = require('./billing-batches');
+exports.billingInvoices = require('./billing-invoices');
+exports.billingInvoiceLicences = require('./billing-invoice-licences');
 exports.billingTransactions = require('./billing-transactions');

--- a/src/lib/connectors/repos/lib/raw.js
+++ b/src/lib/connectors/repos/lib/raw.js
@@ -1,0 +1,16 @@
+const { bookshelf } = require('../../bookshelf');
+
+const camelCaseKeys = require('../../../camel-case-keys');
+
+const multiRow = async (query, params) => {
+  const { rows } = await bookshelf.knex.raw(query, params);
+  return camelCaseKeys(rows);
+};
+
+const singleRow = async (query, params) => {
+  const result = await multiRow(query, params);
+  return result.length ? result[0] : null;
+};
+
+exports.multiRow = multiRow;
+exports.singleRow = singleRow;

--- a/src/lib/connectors/repos/queries/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/queries/billing-invoice-licences.js
@@ -1,0 +1,28 @@
+exports.upsert = `
+insert into water.billing_invoice_licences (
+  billing_invoice_id, company_id, contact_id, address_id, licence_ref, licence_holder_name, 
+  licence_holder_address, date_created, date_updated, licence_id
+)
+values (
+  :billingInvoiceId, :companyId, :contactId, :addressId, :licenceRef, :licenceHolderName,
+  :licenceHolderAddress, NOW(), NOW(), :licenceId
+)
+on conflict (billing_invoice_id, company_id, address_id, licence_id) do update 
+  set date_updated = NOW()
+returning *
+`;
+
+exports.deleteEmptyByBatchId = `
+delete from water.billing_invoice_licences l
+  where l.billing_invoice_licence_id in (
+    select l.billing_invoice_licence_id 
+      from water.billing_batches b 
+      join water.billing_invoices i on b.billing_batch_id=i.billing_batch_id
+      join water.billing_invoice_licences l on i.billing_invoice_id=l.billing_invoice_id
+      left join water.billing_transactions t on l.billing_invoice_licence_id=t.billing_invoice_licence_id
+      where b.billing_batch_id=:batchId
+      group by l.billing_invoice_licence_id
+      having count(t.billing_transaction_id)=0
+  )
+`
+;

--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -1,0 +1,22 @@
+exports.upsert = `
+insert into water.billing_invoices 
+  (invoice_account_id, address, invoice_account_number, date_created, date_updated, billing_batch_id)
+values
+  (:invoiceAccountId, :address, :invoiceAccountNumber, NOW(), NOW(), :billingBatchId)
+on conflict (invoice_account_id, billing_batch_id) do update 
+  set date_updated = NOW()
+returning *
+`;
+
+exports.deleteEmptyByBatchId = `
+delete from water.billing_invoices i
+  where i.billing_invoice_id in (
+    select i.billing_invoice_id from water.billing_batches b 
+      join water.billing_invoices i on b.billing_batch_id=i.billing_batch_id
+      left join water.billing_invoice_licences l on i.billing_invoice_id=l.billing_invoice_id
+      where b.billing_batch_id=:batchId
+      group by i.billing_invoice_id
+      having count(l.billing_invoice_licence_id)=0
+  )
+`
+;

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -17,6 +17,7 @@ where
   and b.billing_batch_id<>:batchId
   and t.start_date>=il_2.min_date
   and t.end_date<=il_2.max_date
+order by t.date_created ASC
 `;
 
 exports.findByBatchId = `

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -15,6 +15,7 @@ join (
 where 
   b.status='complete' 
   and b.billing_batch_id<>:batchId
+  and b.batch_type<>'two_part_tariff' 
   and t.start_date>=il_2.min_date
   and t.end_date<=il_2.max_date
 order by t.date_created ASC

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -1,0 +1,29 @@
+exports.findHistoryByBatchId = `
+select t.* from water.billing_transactions t
+join water.billing_invoice_licences il on t.billing_invoice_licence_id=il.billing_invoice_licence_id
+join water.billing_invoices i on il.billing_invoice_id=i.billing_invoice_id
+join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
+join (
+  select il.licence_id,  
+    make_date(b.from_financial_year_ending-1, 4, 1) AS min_date,
+    make_date(b.to_financial_year_ending, 3, 31) AS max_date
+  from water.billing_batches b
+  join water.billing_invoices i on b.billing_batch_id=i.billing_batch_id
+  join water.billing_invoice_licences il on i.billing_invoice_id=il.billing_invoice_id
+  where b.billing_batch_id=:batchId
+) il_2 on il.licence_id=il_2.licence_id
+where 
+  b.status='complete' 
+  and b.billing_batch_id<>:batchId
+  and t.start_date>=il_2.min_date
+  and t.end_date<=il_2.max_date
+`;
+
+exports.findByBatchId = `
+select t.* from water.billing_transactions t
+join water.billing_invoice_licences il on t.billing_invoice_licence_id=il.billing_invoice_licence_id 
+join water.billing_invoices i on il.billing_invoice_id=i.billing_invoice_id 
+join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
+where b.billing_batch_id=:batchId
+`
+;

--- a/src/lib/connectors/repos/readme.md
+++ b/src/lib/connectors/repos/readme.md
@@ -21,4 +21,5 @@ Note: these methods return an empty result set if nothing found (default Bookshe
 Other operations:
 - create(data)
 - update(id, data)
+- upsert(data)
 - delete(id)

--- a/src/lib/make-array.js
+++ b/src/lib/make-array.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { isArray } = require('lodash');
+
+const makeArray = value => isArray(value) ? value : [value];
+
+module.exports = makeArray;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -8,7 +8,6 @@ const { isArray } = require('lodash');
 const { assertIsInstanceOf, assertEnum, assertIsArrayOfType } = require('./validators');
 
 const VALID_SEASON = Joi.string().valid('summer', 'winter', 'all year').required();
-const VALID_STATUS = Joi.string().valid('processing', 'review', 'complete', 'error').required();
 
 const Model = require('./model');
 
@@ -16,6 +15,13 @@ const types = {
   annual: 'annual',
   supplementary: 'supplementary',
   twoPartTariff: 'two_part_tariff'
+};
+
+const statuses = {
+  processing: 'processing',
+  review: 'review',
+  complete: 'complete',
+  error: 'error'
 };
 
 class Batch extends Model {
@@ -39,6 +45,14 @@ class Batch extends Model {
    */
   get type () {
     return this._type;
+  }
+
+  /**
+   * Checks whether this is a supplementary batch
+   * @return {Boolean}
+   */
+  isSupplementary () {
+    return this._type === types.supplementary;
   }
 
   /**
@@ -97,7 +111,7 @@ class Batch extends Model {
    * @param {String} status
    */
   set status (status) {
-    Joi.assert(status, VALID_STATUS);
+    assertEnum(status, Object.keys(statuses));
     this._status = status;
   }
 
@@ -185,3 +199,4 @@ class Batch extends Model {
 
 module.exports = Batch;
 module.exports.types = types;
+module.exports.statuses = statuses;

--- a/src/lib/models/transaction.js
+++ b/src/lib/models/transaction.js
@@ -37,6 +37,24 @@ class Transaction extends Model {
     return transaction;
   }
 
+  /**
+   * Creates a fresh model (with no ID) from the current model, set up as
+   * a credit
+   * @return {Transaction}
+   */
+  toCredit () {
+    const transaction = new Transaction();
+    transaction.pickFrom(this, [
+      'value', 'authorisedDays', 'billableDays', 'agreements', 'chargePeriod',
+      'isCompensationCharge', 'description', 'chargeElement', 'volume'
+    ]);
+    transaction.fromHash({
+      isCredit: true,
+      status: statuses.candidate
+    });
+    return transaction;
+  }
+
   get value () {
     return this._value;
   }

--- a/src/modules/billing/jobs/prepare-transactions.js
+++ b/src/modules/billing/jobs/prepare-transactions.js
@@ -2,7 +2,7 @@ const { logger } = require('../../../logger');
 const repos = require('../../../lib/connectors/repository');
 
 const batchService = require('../services/batch-service');
-const transactionsService = require('../services/transactions-service');
+const supplementaryBillingService = require('../services/supplementary-billing-service');
 
 const JOB_NAME = 'billing.prepare-transactions';
 
@@ -19,7 +19,7 @@ const handlePrepareTransactions = async job => {
 
     if (batch.isSupplementary()) {
       logger.info(`Processing supplementary transactions ${JOB_NAME}`);
-      await transactionsService.processSupplementary(batch.id);
+      await supplementaryBillingService.processBatch(batch.id);
     }
 
     // @TODO replace with newRepos.billingBatches.findByBatchId when downstream handlers can cope

--- a/src/modules/billing/jobs/prepare-transactions.js
+++ b/src/modules/billing/jobs/prepare-transactions.js
@@ -1,6 +1,9 @@
 const { logger } = require('../../../logger');
 const repos = require('../../../lib/connectors/repository');
 
+const batchService = require('../services/batch-service');
+const transactionsService = require('../services/transactions-service');
+
 const JOB_NAME = 'billing.prepare-transactions';
 
 const createMessage = (eventId, batch) => ({
@@ -11,31 +14,29 @@ const createMessage = (eventId, batch) => ({
 const handlePrepareTransactions = async job => {
   logger.info(`Handling ${JOB_NAME}`);
 
-  const { batch } = job.data;
+  try {
+    const batch = await batchService.getBatchById(job.data.batch.billing_batch_id);
 
-  const transactions = await repos.billingTransactions.getByBatchId(batch.billing_batch_id);
+    if (batch.isSupplementary()) {
+      logger.info(`Processing supplementary transactions ${JOB_NAME}`);
+      await transactionsService.processSupplementary(batch.id);
+    }
 
-  /**
-   * Placeholder:
-   *
-   * get the batch from the job data
-   *
-   * loadCandidateTransactions
-   *
-   * if (isSupplementaryBatch?) {
-   *  loadExistingTransactions
-   *  diff transactions deleting any candidate transactions that are not required
-   * }
-   *
-   * persist new transactions to water.billing.transactions
-   *
-   * return all the transactions that have been created
-   * return the batch
-   */
-  return {
-    batch,
-    transactions
-  };
+    // @TODO replace with newRepos.billingBatches.findByBatchId when downstream handlers can cope
+    // with camel case
+    const transactions = await repos.billingTransactions.getByBatchId(batch.id);
+
+    return {
+      batch: job.data.batch,
+      transactions
+    };
+  } catch (err) {
+    logger.error(`Error handling ${JOB_NAME}`, err, {
+      batch: job.data.batch
+    });
+    await batchService.setErrorStatus(job.data.batch.billing_batch_id);
+    throw err;
+  }
 };
 
 exports.jobName = JOB_NAME;

--- a/src/modules/billing/mappers/invoice-account.js
+++ b/src/modules/billing/mappers/invoice-account.js
@@ -9,13 +9,13 @@ const Company = require('../../../lib/models/company');
  * @param {Object} company - CRM company data
  * @return {InvoiceAccount}
  */
-const crmToModel = (invoiceAccount, company) => {
+const crmToModel = (invoiceAccount) => {
   const invoiceAccountModel = new InvoiceAccount(invoiceAccount.invoiceAccountId);
   invoiceAccountModel.accountNumber = invoiceAccount.invoiceAccountNumber;
 
-  if (company) {
-    const companyModel = new Company(company.companyId);
-    companyModel.pickFrom(company, ['type', 'name']);
+  if (invoiceAccount.company) {
+    const companyModel = new Company(invoiceAccount.company.companyId);
+    companyModel.pickFrom(invoiceAccount.company, ['type', 'name']);
     invoiceAccountModel.company = companyModel;
   }
 

--- a/src/modules/billing/mappers/invoice-licence.js
+++ b/src/modules/billing/mappers/invoice-licence.js
@@ -14,6 +14,7 @@ const address = require('./address');
 const company = require('./company');
 const contact = require('./contact');
 const transaction = require('./transaction');
+const licence = require('./licence');
 
 /**
  * Maps a row of data from water.billing_invoice_licences
@@ -27,9 +28,12 @@ const dbToModel = row => {
   // @todo suggest we serialise company, address and contact to jsonb fields in table
   invoiceLicence.company = new Company(row.companyId);
   invoiceLicence.address = new Address(row.addressId);
+  invoiceLicence.address.fromHash(row.licenceHolderAddress);
+
   if (row.contactId) {
     invoiceLicence.contact = new Contact(row.contactId);
   }
+  invoiceLicence.licence = licence.dbToModel(row.licence);
   return invoiceLicence;
 };
 
@@ -46,14 +50,14 @@ const modelToDb = (invoice, invoiceLicence) => {
   const licenceHolder = invoiceLicence.contact ? invoiceLicence.contact.toJSON() : invoiceLicence.company.toJSON();
 
   return {
-    billing_invoice_id: invoice.id,
-    company_id: invoiceLicence.company.id,
-    contact_id: get(invoiceLicence, 'contact.id', null),
-    address_id: invoiceLicence.address.id,
-    licence_ref: invoiceLicence.licence.licenceNumber,
-    licence_holder_name: licenceHolder,
-    licence_holder_address: invoiceLicence.address.toObject(),
-    licence_id: invoiceLicence.licence.id
+    billingInvoiceId: invoice.id,
+    companyId: invoiceLicence.company.id,
+    contactId: get(invoiceLicence, 'contact.id', null),
+    addressId: invoiceLicence.address.id,
+    licenceRef: invoiceLicence.licence.licenceNumber,
+    licenceHolderName: licenceHolder,
+    licenceHolderAddress: invoiceLicence.address.toObject(),
+    licenceId: invoiceLicence.licence.id
   };
 };
 

--- a/src/modules/billing/mappers/invoice.js
+++ b/src/modules/billing/mappers/invoice.js
@@ -28,10 +28,10 @@ const dbToModel = row => {
  * @return {Object}
  */
 const modelToDb = (batch, invoice) => ({
-  invoice_account_id: invoice.invoiceAccount.id,
-  invoice_account_number: invoice.invoiceAccount.accountNumber,
+  invoiceAccountId: invoice.invoiceAccount.id,
+  invoiceAccountNumber: invoice.invoiceAccount.accountNumber,
   address: omit(invoice.address.toObject(), 'id'),
-  billing_batch_id: batch.id
+  billingBatchId: batch.id
 });
 
 const getInvoiceAccountNumber = row => row.invoiceAccount.invoiceAccount.invoiceAccountNumber;

--- a/src/modules/billing/mappers/invoice.js
+++ b/src/modules/billing/mappers/invoice.js
@@ -87,6 +87,19 @@ const chargeToModels = (data, batch) => {
   });
 };
 
+const crmToModel = row => {
+  const invoice = new Invoice();
+
+  // Create invoice account model
+  invoice.invoiceAccount = invoiceAccount.crmToModel(row);
+
+  // Create invoice address model
+  invoice.address = address.crmToModel(row.address);
+
+  return invoice;
+};
+
 exports.dbToModel = dbToModel;
 exports.modelToDb = modelToDb;
 exports.chargeToModels = chargeToModels;
+exports.crmToModel = crmToModel;

--- a/src/modules/billing/mappers/transaction.js
+++ b/src/modules/billing/mappers/transaction.js
@@ -2,7 +2,7 @@
 
 const moment = require('moment');
 const { titleCase } = require('title-case');
-const { get, pick, identity, omit } = require('lodash');
+const { get, pick, identity } = require('lodash');
 
 const Batch = require('../../../lib/models/batch');
 const DateRange = require('../../../lib/models/date-range');

--- a/src/modules/billing/mappers/transaction.js
+++ b/src/modules/billing/mappers/transaction.js
@@ -103,7 +103,7 @@ const dbToModel = row => {
   const transaction = new Transaction();
   transaction.fromHash({
     id: row.billingTransactionId,
-    ...pick(row, ['status', 'isCredit', 'authorisedDays', 'billableDays', 'description']),
+    ...pick(row, ['status', 'isCredit', 'authorisedDays', 'billableDays', 'description', 'transactionKey']),
     chargePeriod: new DateRange(row.startDate, row.endDate),
     isCompensationCharge: row.chargeType === 'compensation',
     chargeElement: chargeElementMapper.dbToModel(row.chargeElement),
@@ -156,7 +156,7 @@ const modelToDb = (invoiceLicence, transaction) => ({
   status: transaction.status,
   volume: transaction.volume,
   ...mapAgreementsToDB(transaction.agreements),
-  transaction_key: transaction.transactionKey
+  transactionKey: transaction.transactionKey
 });
 
 const DATE_FORMAT = 'YYYY-MM-DD';

--- a/src/modules/billing/service/charge-version-year.js
+++ b/src/modules/billing/service/charge-version-year.js
@@ -47,7 +47,7 @@ const createBatchFromChargeVersionYear = async chargeVersionYear => {
  */
 const persistChargeVersionYearBatch = batch => {
   assert(batch instanceof Batch, 'Batch expected');
-  await batchService.saveInvoicesToDB(batch);
+  return batchService.saveInvoicesToDB(batch);
 };
 
 exports.createBatchFromChargeVersionYear = createBatchFromChargeVersionYear;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -3,6 +3,7 @@ const mappers = require('../mappers');
 const repos = require('../../../lib/connectors/repository');
 
 const chargeModuleBatchConnector = require('../../../lib/connectors/charge-module/batches');
+const Batch = require('../../../lib/models/batch');
 
 /**
  * Loads a Batch instance by ID
@@ -37,6 +38,15 @@ const deleteBatch = async batchId => {
   await repos.billingBatches.deleteByBatchId(batchId);
 };
 
+/**
+ * Sets the specified batch to 'error' status
+ * @param {String} batchId
+ * @return {Promise}
+ */
+const setErrorStatus = batchId =>
+  newRepos.billingBatches.update(batchId, Batch.statuses.error);
+
 exports.getBatchById = getBatchById;
 exports.getBatches = getBatches;
 exports.deleteBatch = deleteBatch;
+exports.setErrorStatus = setErrorStatus;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -50,18 +50,19 @@ const deleteBatch = async batchId => {
 const setErrorStatus = batchId =>
   newRepos.billingBatches.update(batchId, { status: Batch.statuses.error });
 
-const saveInvoiceLicenceTransactions = async invoiceLicence => {
+const saveInvoiceLicenceTransactions = async (batch, invoice, invoiceLicence) => {
   for (const transaction of invoiceLicence.transactions) {
+    transaction.createTransactionKey(invoice.invoiceAccount, invoiceLicence.licence, batch);
     const { billingTransactionId } = await transactionsService.saveTransactionToDB(invoiceLicence, transaction);
     transaction.id = billingTransactionId;
   }
 };
 
-const saveInvoiceLicences = async invoice => {
+const saveInvoiceLicences = async (batch, invoice) => {
   for (const invoiceLicence of invoice.invoiceLicences) {
     const { billingInvoiceLicenceId } = await invoiceLicenceService.saveInvoiceLicenceToDB(invoice, invoiceLicence);
     invoiceLicence.id = billingInvoiceLicenceId;
-    await saveInvoiceLicenceTransactions(invoiceLicence);
+    await saveInvoiceLicenceTransactions(batch, invoice, invoiceLicence);
   }
 };
 
@@ -69,7 +70,7 @@ const saveInvoicesToDB = async batch => {
   for (const invoice of batch.invoices) {
     const { billingInvoiceId } = await invoiceService.saveInvoiceToDB(batch, invoice);
     invoice.id = billingInvoiceId;
-    await saveInvoiceLicences(invoice);
+    await saveInvoiceLicences(batch, invoice);
   }
 };
 

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -48,7 +48,7 @@ const deleteBatch = async batchId => {
  * @return {Promise}
  */
 const setErrorStatus = batchId =>
-  newRepos.billingBatches.update(batchId, Batch.statuses.error);
+  newRepos.billingBatches.update(batchId, { status: Batch.statuses.error });
 
 const saveInvoiceLicenceTransactions = async invoiceLicence => {
   for (const transaction of invoiceLicence.transactions) {

--- a/src/modules/billing/services/invoice-accounts-service.js
+++ b/src/modules/billing/services/invoice-accounts-service.js
@@ -17,7 +17,7 @@ const getByInvoiceAccountIds = async (ids = []) => {
   const invoiceAccounts = await invoiceAccountsConnector.getInvoiceAccountsByIds(ids);
 
   return invoiceAccounts.map(invoiceAccount =>
-    mappers.invoiceAccount.crmToModel(invoiceAccount, invoiceAccount.company)
+    mappers.invoiceAccount.crmToModel(invoiceAccount)
   );
 };
 
@@ -29,7 +29,7 @@ const getByInvoiceAccountIds = async (ids = []) => {
  */
 const getByInvoiceAccountId = async id => {
   const invoiceAccount = await invoiceAccountsConnector.getInvoiceAccountById(id);
-  return mappers.invoiceAccount.crmToModel(invoiceAccount, invoiceAccount.company);
+  return mappers.invoiceAccount.crmToModel(invoiceAccount);
 };
 
 exports.getByInvoiceAccountIds = getByInvoiceAccountIds;

--- a/src/modules/billing/services/invoice-licences-service.js
+++ b/src/modules/billing/services/invoice-licences-service.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const repos = require('../../../lib/connectors/repository');
 const newRepos = require('../../../lib/connectors/repos');
 
 const mappers = require('../mappers');
-
-const licenceService = require('./licence-service');
 
 /**
  * Saves an Invoice model to water.billing_invoices
@@ -18,18 +15,4 @@ const saveInvoiceLicenceToDB = (invoice, invoiceLicence) => {
   return newRepos.billingInvoiceLicences.upsert(data);
 };
 
-/**
- * Retrieves an invoice licence row from water.billing_invoices relating to the
- * given transaction ID, and returns an Invoice model
- * @param {String} transactionId - GUID
- * @return {Promise<Invoice>}
- */
-const getByTransactionId = async transactionId => {
-  const data = await repos.billingInvoiceLicences.findOneByTransactionId(transactionId);
-  const invoiceLicence = mappers.invoiceLicence.dbToModel(data);
-  invoiceLicence.licence = await licenceService.getByLicenceNumber(data.licence_ref);
-  return invoiceLicence;
-};
-
 exports.saveInvoiceLicenceToDB = saveInvoiceLicenceToDB;
-exports.getByTransactionId = getByTransactionId;

--- a/src/modules/billing/services/invoice-licences-service.js
+++ b/src/modules/billing/services/invoice-licences-service.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const repos = require('../../../lib/connectors/repository');
+const newRepos = require('../../../lib/connectors/repos');
+
 const mappers = require('../mappers');
 
 const licenceService = require('./licence-service');
@@ -11,10 +13,9 @@ const licenceService = require('./licence-service');
  * @param {InvoiceLicence} invoiceLicence
  * @return {Promise<Object>} row data inserted
  */
-const saveInvoiceLicenceToDB = async (invoice, invoiceLicence) => {
+const saveInvoiceLicenceToDB = (invoice, invoiceLicence) => {
   const data = mappers.invoiceLicence.modelToDB(invoice, invoiceLicence);
-  const { rows: [row] } = await repos.billingInvoiceLicences.create(data);
-  return row;
+  return newRepos.billingInvoiceLicences.upsert(data);
 };
 
 /**

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -161,18 +161,6 @@ const saveInvoiceToDB = async (batch, invoice) => {
   return newRepos.billingInvoices.upsert(data);
 };
 
-/**
- * Retrieves an invoice row from water.billing_invoices relating to the
- * given transaction ID, and returns an Invoice model
- * @param {String} transactionId - GUID
- * @return {Promise<Invoice>}
- */
-const getByTransactionId = async transactionId => {
-  const data = await repos.billingInvoices.findOneByTransactionId(transactionId);
-  return mappers.invoice.dbToModel(data);
-};
-
 exports.getInvoicesForBatch = getInvoicesForBatch;
 exports.getInvoiceForBatch = getInvoiceForBatch;
 exports.saveInvoiceToDB = saveInvoiceToDB;
-exports.getByTransactionId = getByTransactionId;

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -3,6 +3,8 @@
 const { first } = require('lodash');
 
 const repos = require('../../../lib/connectors/repository');
+const newRepos = require('../../../lib/connectors/repos');
+
 const mappers = require('../mappers');
 
 // Services
@@ -152,12 +154,11 @@ const getInvoiceForBatch = async (batchId, invoiceId) => {
  * Saves an Invoice model to water.billing_invoices
  * @param {Batch} batch
  * @param {Invoice} invoice
- * @return {Promise<Object>} row data inserted
+ * @return {Promise<Object>} row data inserted (camel case)
  */
 const saveInvoiceToDB = async (batch, invoice) => {
   const data = mappers.invoice.modelToDb(batch, invoice);
-  const { rows: [row] } = await repos.billingInvoices.create(data);
-  return row;
+  return newRepos.billingInvoices.upsert(data);
 };
 
 /**

--- a/src/modules/billing/services/supplementary-billing-service.js
+++ b/src/modules/billing/services/supplementary-billing-service.js
@@ -6,7 +6,6 @@ const newRepos = require('../../../lib/connectors/repos');
 const crmV2Connector = require('../../../lib/connectors/crm-v2');
 const mappers = require('../mappers');
 const batchService = require('./batch-service');
-const { logger } = require('../../../logger');
 
 /**
  * Builds an index where the most recent transaction with a given key

--- a/src/modules/billing/services/supplementary-billing-service.js
+++ b/src/modules/billing/services/supplementary-billing-service.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const { uniq, groupBy, find } = require('lodash');
+
+const newRepos = require('../../../lib/connectors/repos');
+const crmV2Connector = require('../../../lib/connectors/crm-v2');
+const mappers = require('../mappers');
+const batchService = require('./batch-service');
+const { logger } = require('../../../logger');
+
+/**
+ * Builds an index where the most recent transaction with a given key
+ * can be found, since the transactions are already sorted by dateCreated
+ * @param {Array} transactions
+ * @return {Object}
+ */
+const indexByTransactionKey = transactions => transactions.reduce((acc, transaction) => {
+  return {
+    ...acc,
+    [transaction.transactionKey]: transaction
+  };
+}, {});
+
+/**
+ * Given the batch/historical transaction indexes:
+ *
+ * ╔══════════════════════════════════╤════════════════════════╤═══════════════╗
+ * ║ List A (historical transactions) │ List B (current batch) │ Action        ║
+ * ╠══════════════════════════════════╪════════════════════════╪═══════════════╣
+ * ║ -                                │ Charge                 │ -             ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Charge                           │ Charge                 │ Delete from B ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Credit                           │ Charge                 │ -             ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Charge                           │ -                      │ Credit in B   ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Credit                           │ -                      │ -             ║
+ * ╚══════════════════════════════════╧════════════════════════╧═══════════════╝
+ *
+ * @param {Object} indexes
+ * @return {Object} - { delete : [...transactionIds], credit : [...transactionIds] }
+ */
+const getSupplementaryActions = indexes => {
+  const allKeys = [...Object.keys(indexes.batch), ...Object.keys(indexes.historical)];
+  const skeleton = {
+    delete: [],
+    credit: []
+  };
+
+  return uniq(allKeys).reduce((acc, key) => {
+    const existsInNewBatch = key in indexes.batch;
+    const isExistingCharge = (key in indexes.historical) && (indexes.historical[key].isCredit === false);
+
+    if (isExistingCharge && existsInNewBatch) {
+      acc.delete.push(indexes.batch[key].billingTransactionId);
+    }
+    if (isExistingCharge && !existsInNewBatch) {
+      acc.credit.push(indexes.historical[key].billingTransactionId);
+    }
+    return acc;
+  }, skeleton);
+};
+
+const getInvoiceAccountId = billingTransaction =>
+  billingTransaction.billingInvoiceLicence.billingInvoice.invoiceAccountId;
+
+const getUniqueInvoiceAccountIds = transactions => {
+  const ids = transactions.map(getInvoiceAccountId);
+  return uniq(ids);
+};
+
+const decorateBatchWithInvoices = async (batch, transactions) => {
+  const invoiceAccountIds = getUniqueInvoiceAccountIds(transactions);
+
+  // Load invoice account data from CRM
+  const invoiceAccounts = await crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds(invoiceAccountIds);
+
+  // Add invoices to batch
+  batch.invoices = invoiceAccounts.map(mappers.invoice.crmToModel);
+
+  return batch;
+};
+
+const getLicenceGroup = row =>
+  [
+    row.billingInvoiceLicence.companyId,
+    row.billingInvoiceLicence.contactId,
+    row.billingInvoiceLicence.addressId,
+    row.billingInvoiceLicence.licence.licenceRef,
+    row.billingInvoiceLicence.billingInvoice.invoiceAccountId
+  ].join(':');
+
+const decorateBatchWithLicences = (batch, transactions) => {
+  const groups = groupBy(transactions, getLicenceGroup);
+
+  Object.values(groups).forEach(transactions => {
+    // Create InvoiceLicence and map transactions
+    const invoiceLicence = mappers.invoiceLicence.dbToModel(transactions[0].billingInvoiceLicence);
+    invoiceLicence.transactions = transactions.map(
+      row => mappers.transaction.dbToModel(row).toCredit()
+    );
+
+    // Append to correct invoice in batch
+    const invoice = find(batch.invoices,
+      invoice => invoice.invoiceAccount.id === getInvoiceAccountId(transactions[0])
+    );
+    invoice.invoiceLicences.push(invoiceLicence);
+  });
+};
+
+/**
+ * @param {Strign} batchId
+ * @param {Array<String>} transactionIds
+ * @return {Promise}
+ */
+const addCreditsToBatch = async (batchId, transactionIds) => {
+  if (transactionIds.length === 0) {
+    return;
+  }
+
+  // Get current batch and list of credit transactions with relations
+  const [batch, transactions] = await Promise.all([
+    batchService.getBatchById(batchId),
+    newRepos.billingTransactions.find(transactionIds)
+  ]);
+
+  await decorateBatchWithInvoices(batch, transactions);
+  decorateBatchWithLicences(batch, transactions);
+
+  // Persist batch
+  await batchService.saveInvoicesToDB(batch);
+};
+
+/**
+ * Cleans up any
+ * - billing_invoice_licences with no related billing_transactions
+ * - billing_invoices with no related billing_invoice_licences
+ * @param {String} batchId
+ * @return {Promise}
+ */
+const cleanup = async batchId => {
+  await newRepos.billingInvoiceLicences.deleteEmptyByBatchId(batchId);
+  await newRepos.billingInvoices.deleteEmptyByBatchId(batchId);
+};
+
+/**
+ * Processes the supplementary billing batch specified by
+ * deleting some transactions in the batch and crediting others
+ * previously billed
+ * @param {String} batchId
+ * @reutrn {Promise}
+ */
+const processBatch = async batchId => {
+  // Loads:
+  // - transactions in current batch
+  // - historical transactions relating to licences in current batch
+  const [batchTransactions, historicalTransactions] = await Promise.all([
+    newRepos.billingTransactions.findByBatchId(batchId),
+    newRepos.billingTransactions.findHistoryByBatchId(batchId)
+  ]);
+
+  // Create indexes on the unique transaction keys
+  const indexes = {
+    batch: indexByTransactionKey(batchTransactions),
+    historical: indexByTransactionKey(historicalTransactions)
+  };
+
+  // Create a list of delete/credit actions required
+  const actions = getSupplementaryActions(indexes);
+
+  await Promise.all([
+    newRepos.billingTransactions.delete(actions.delete),
+    addCreditsToBatch(batchId, actions.credit)
+  ]);
+
+  await cleanup(batchId);
+};
+
+exports.processBatch = processBatch;

--- a/src/modules/billing/services/supplementary-billing-service.js
+++ b/src/modules/billing/services/supplementary-billing-service.js
@@ -128,7 +128,7 @@ const addCreditsToBatch = async (batchId, transactionIds) => {
   decorateBatchWithLicences(batch, transactions);
 
   // Persist batch
-  await batchService.saveInvoicesToDB(batch);
+  return batchService.saveInvoicesToDB(batch);
 };
 
 /**

--- a/src/modules/billing/services/transactions-service.js
+++ b/src/modules/billing/services/transactions-service.js
@@ -1,11 +1,15 @@
 'use strict';
 
+const { uniq, groupBy, find } = require('lodash');
+
 const chargeModuleTransactionsConnector = require('../../../lib/connectors/charge-module/transactions');
 const ChargeModuleTransaction = require('../../../lib/models/charge-module-transaction');
+const crmV2Connector = require('../../../lib/connectors/crm-v2');
 const { logger } = require('../../../logger');
 const repos = require('../../../lib/connectors/repository');
 const newRepos = require('../../../lib/connectors/repos');
 const mappers = require('../mappers');
+const batchService = require('./batch-service');
 
 const mapTransaction = chargeModuleTransaction => {
   const transaction = new ChargeModuleTransaction(chargeModuleTransaction.id);
@@ -92,7 +96,151 @@ const getById = async transactionId => {
   return batch;
 };
 
+/**
+ * Builds an index where the most recent transaction with a given key
+ * can be found, since the transactions are already sorted by dateCreated
+ * @param {Array} transactions
+ * @return {Object}
+ */
+const indexByTransactionKey = transactions => transactions.reduce((acc, transaction) => {
+  return {
+    ...acc,
+    [transaction.transactionKey]: transaction
+  };
+}, {});
+
+/**
+ * Given the batch/historical transaction indexes:
+ *
+ * ╔══════════════════════════════════╤════════════════════════╤═══════════════╗
+ * ║ List A (historical transactions) │ List B (current batch) │ Action        ║
+ * ╠══════════════════════════════════╪════════════════════════╪═══════════════╣
+ * ║ -                                │ Charge                 │ -             ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Charge                           │ Charge                 │ Delete from B ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Credit                           │ Charge                 │ -             ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Charge                           │ -                      │ Credit in B   ║
+ * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
+ * ║ Credit                           │ -                      │ -             ║
+ * ╚══════════════════════════════════╧════════════════════════╧═══════════════╝
+ *
+ * @param {Object} indexes
+ * @return {Object} - { delete : [...transactionIds], credit : [...transactionIds] }
+ */
+const getSupplementaryActions = indexes => {
+  const allKeys = [...Object.keys(indexes.batch), ...Object.keys(indexes.historical)];
+  const skeleton = {
+    delete: [],
+    credit: []
+  };
+
+  return uniq(allKeys).reduce((acc, key) => {
+    const existsInNewBatch = key in indexes.batch;
+    const isExistingCharge = (key in indexes.historical) && (indexes.historical[key].isCredit === false);
+
+    if (isExistingCharge && existsInNewBatch) {
+      acc.delete.push(indexes.batch[key].billingTransactionId);
+    }
+    if (isExistingCharge && !existsInNewBatch) {
+      acc.credit.push(indexes.historical[key].billingTransactionId);
+    }
+    return acc;
+  }, skeleton);
+};
+
+const getInvoiceAccountId = billingTransaction =>
+  billingTransaction.billingInvoiceLicence.billingInvoice.invoiceAccountId;
+
+const getUniqueInvoiceAccountIds = transactions => {
+  const ids = transactions.map(getInvoiceAccountId);
+  return uniq(ids);
+};
+
+const decorateBatchWithInvoices = async (batch, transactions) => {
+  const invoiceAccountIds = getUniqueInvoiceAccountIds(transactions);
+
+  // Load invoice account data from CRM
+  const invoiceAccounts = await crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds(invoiceAccountIds);
+
+  // Add invoices to batch
+  batch.invoices = invoiceAccounts.map(mappers.invoice.crmToModel);
+
+  return batch;
+};
+
+const getLicenceGroup = row =>
+  [
+    row.billingInvoiceLicence.companyId,
+    row.billingInvoiceLicence.contactId,
+    row.billingInvoiceLicence.addressId,
+    row.billingInvoiceLicence.licence.licenceRef,
+    row.billingInvoiceLicence.billingInvoice.invoiceAccountId
+  ].join(':');
+
+const decorateBatchWithLicences = (batch, transactions) => {
+  const groups = groupBy(transactions, getLicenceGroup);
+
+  Object.values(groups).forEach(transactions => {
+    // Create InvoiceLicence and map transactions
+    const invoiceLicence = mappers.invoiceLicence.dbToModel(transactions[0].billingInvoiceLicence);
+    invoiceLicence.transactions = transactions.map(mappers.transaction.dbToCreditModel);
+
+    // Append to correct invoice in batch
+    const invoice = find(batch.invoices,
+      invoice => invoice.invoiceAccount.id === getInvoiceAccountId(transactions[0])
+    );
+    invoice.invoiceLicences.push(invoiceLicence);
+  });
+};
+
+const addCreditsToBatch = async (batchId, transactionIds) => {
+  if (transactionIds.length === 0) {
+    return;
+  }
+
+  // Get current batch and list of credit transactions with relations
+  const [batch, transactions] = await Promise.all([
+    batchService.getBatchById(batchId),
+    newRepos.billingTransactions.find(transactionIds)
+  ]);
+
+  await decorateBatchWithInvoices(batch, transactions);
+  decorateBatchWithLicences(batch, transactions);
+
+  console.log(JSON.stringify(batch, null, 2));
+};
+
+const processSupplementary = async batchId => {
+  // Loads:
+  // - transactions in current batch
+  // - historical transactions relating to licences in current batch
+  const [batchTransactions, historicalTransactions] = await Promise.all([
+    newRepos.billingTransactions.findByBatchId(batchId),
+    newRepos.billingTransactions.findHistoryByBatchId(batchId)
+  ]);
+
+  // Create indexes on the unique transaction keys
+  const indexes = {
+    batch: indexByTransactionKey(batchTransactions),
+    historical: indexByTransactionKey(historicalTransactions)
+  };
+
+  // Create a list of delete/credit actions required
+  const actions = getSupplementaryActions(indexes);
+
+  await Promise.all([
+    newRepos.billingTransactions.delete(actions.delete),
+    addCreditsToBatch(batchId, actions.credit)
+  ]);
+
+  // @TODO clean batch - remove any licences/invoices with zero children
+};
+
 exports.getTransactionsForBatch = getTransactionsForBatch;
 exports.getTransactionsForBatchInvoice = getTransactionsForBatchInvoice;
 exports.saveTransactionToDB = saveTransactionToDB;
 exports.getById = getById;
+exports._getSupplementaryActions = getSupplementaryActions;
+exports.processSupplementary = processSupplementary;

--- a/src/modules/billing/services/transactions-service.js
+++ b/src/modules/billing/services/transactions-service.js
@@ -1,15 +1,10 @@
 'use strict';
 
-const { uniq, groupBy, find } = require('lodash');
-
 const chargeModuleTransactionsConnector = require('../../../lib/connectors/charge-module/transactions');
 const ChargeModuleTransaction = require('../../../lib/models/charge-module-transaction');
-const crmV2Connector = require('../../../lib/connectors/crm-v2');
 const { logger } = require('../../../logger');
-const repos = require('../../../lib/connectors/repository');
 const newRepos = require('../../../lib/connectors/repos');
 const mappers = require('../mappers');
-const batchService = require('./batch-service');
 
 const mapTransaction = chargeModuleTransaction => {
   const transaction = new ChargeModuleTransaction(chargeModuleTransaction.id);
@@ -67,7 +62,7 @@ const getTransactionsForBatchInvoice = async (batchId, invoiceReference) => {
  */
 const saveTransactionToDB = (invoiceLicence, transaction) => {
   const data = mappers.transaction.modelToDb(invoiceLicence, transaction);
-  return repos.billingTransactions.create(data);
+  return newRepos.billingTransactions.create(data);
 };
 
 /**
@@ -96,151 +91,7 @@ const getById = async transactionId => {
   return batch;
 };
 
-/**
- * Builds an index where the most recent transaction with a given key
- * can be found, since the transactions are already sorted by dateCreated
- * @param {Array} transactions
- * @return {Object}
- */
-const indexByTransactionKey = transactions => transactions.reduce((acc, transaction) => {
-  return {
-    ...acc,
-    [transaction.transactionKey]: transaction
-  };
-}, {});
-
-/**
- * Given the batch/historical transaction indexes:
- *
- * ╔══════════════════════════════════╤════════════════════════╤═══════════════╗
- * ║ List A (historical transactions) │ List B (current batch) │ Action        ║
- * ╠══════════════════════════════════╪════════════════════════╪═══════════════╣
- * ║ -                                │ Charge                 │ -             ║
- * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
- * ║ Charge                           │ Charge                 │ Delete from B ║
- * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
- * ║ Credit                           │ Charge                 │ -             ║
- * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
- * ║ Charge                           │ -                      │ Credit in B   ║
- * ╟──────────────────────────────────┼────────────────────────┼───────────────╢
- * ║ Credit                           │ -                      │ -             ║
- * ╚══════════════════════════════════╧════════════════════════╧═══════════════╝
- *
- * @param {Object} indexes
- * @return {Object} - { delete : [...transactionIds], credit : [...transactionIds] }
- */
-const getSupplementaryActions = indexes => {
-  const allKeys = [...Object.keys(indexes.batch), ...Object.keys(indexes.historical)];
-  const skeleton = {
-    delete: [],
-    credit: []
-  };
-
-  return uniq(allKeys).reduce((acc, key) => {
-    const existsInNewBatch = key in indexes.batch;
-    const isExistingCharge = (key in indexes.historical) && (indexes.historical[key].isCredit === false);
-
-    if (isExistingCharge && existsInNewBatch) {
-      acc.delete.push(indexes.batch[key].billingTransactionId);
-    }
-    if (isExistingCharge && !existsInNewBatch) {
-      acc.credit.push(indexes.historical[key].billingTransactionId);
-    }
-    return acc;
-  }, skeleton);
-};
-
-const getInvoiceAccountId = billingTransaction =>
-  billingTransaction.billingInvoiceLicence.billingInvoice.invoiceAccountId;
-
-const getUniqueInvoiceAccountIds = transactions => {
-  const ids = transactions.map(getInvoiceAccountId);
-  return uniq(ids);
-};
-
-const decorateBatchWithInvoices = async (batch, transactions) => {
-  const invoiceAccountIds = getUniqueInvoiceAccountIds(transactions);
-
-  // Load invoice account data from CRM
-  const invoiceAccounts = await crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds(invoiceAccountIds);
-
-  // Add invoices to batch
-  batch.invoices = invoiceAccounts.map(mappers.invoice.crmToModel);
-
-  return batch;
-};
-
-const getLicenceGroup = row =>
-  [
-    row.billingInvoiceLicence.companyId,
-    row.billingInvoiceLicence.contactId,
-    row.billingInvoiceLicence.addressId,
-    row.billingInvoiceLicence.licence.licenceRef,
-    row.billingInvoiceLicence.billingInvoice.invoiceAccountId
-  ].join(':');
-
-const decorateBatchWithLicences = (batch, transactions) => {
-  const groups = groupBy(transactions, getLicenceGroup);
-
-  Object.values(groups).forEach(transactions => {
-    // Create InvoiceLicence and map transactions
-    const invoiceLicence = mappers.invoiceLicence.dbToModel(transactions[0].billingInvoiceLicence);
-    invoiceLicence.transactions = transactions.map(mappers.transaction.dbToCreditModel);
-
-    // Append to correct invoice in batch
-    const invoice = find(batch.invoices,
-      invoice => invoice.invoiceAccount.id === getInvoiceAccountId(transactions[0])
-    );
-    invoice.invoiceLicences.push(invoiceLicence);
-  });
-};
-
-const addCreditsToBatch = async (batchId, transactionIds) => {
-  if (transactionIds.length === 0) {
-    return;
-  }
-
-  // Get current batch and list of credit transactions with relations
-  const [batch, transactions] = await Promise.all([
-    batchService.getBatchById(batchId),
-    newRepos.billingTransactions.find(transactionIds)
-  ]);
-
-  await decorateBatchWithInvoices(batch, transactions);
-  decorateBatchWithLicences(batch, transactions);
-
-  console.log(JSON.stringify(batch, null, 2));
-};
-
-const processSupplementary = async batchId => {
-  // Loads:
-  // - transactions in current batch
-  // - historical transactions relating to licences in current batch
-  const [batchTransactions, historicalTransactions] = await Promise.all([
-    newRepos.billingTransactions.findByBatchId(batchId),
-    newRepos.billingTransactions.findHistoryByBatchId(batchId)
-  ]);
-
-  // Create indexes on the unique transaction keys
-  const indexes = {
-    batch: indexByTransactionKey(batchTransactions),
-    historical: indexByTransactionKey(historicalTransactions)
-  };
-
-  // Create a list of delete/credit actions required
-  const actions = getSupplementaryActions(indexes);
-
-  await Promise.all([
-    newRepos.billingTransactions.delete(actions.delete),
-    addCreditsToBatch(batchId, actions.credit)
-  ]);
-
-  // @TODO clean batch - remove any licences/invoices with zero children
-};
-
 exports.getTransactionsForBatch = getTransactionsForBatch;
 exports.getTransactionsForBatchInvoice = getTransactionsForBatchInvoice;
 exports.saveTransactionToDB = saveTransactionToDB;
 exports.getById = getById;
-exports._getSupplementaryActions = getSupplementaryActions;
-exports.processSupplementary = processSupplementary;

--- a/test/lib/connectors/repos/billing-batches.js
+++ b/test/lib/connectors/repos/billing-batches.js
@@ -28,7 +28,9 @@ experiment('lib/connectors/repos/billing-batches', () => {
     stub = {
       fetch: sandbox.stub().resolves(model),
       orderBy: sandbox.stub().returnsThis(),
-      fetchPage: sandbox.stub().resolves(model)
+      fetchPage: sandbox.stub().resolves(model),
+      set: sandbox.stub().returnsThis(),
+      save: sandbox.stub().resolves(model)
     };
     sandbox.stub(BillingBatch, 'forge').returns(stub);
   });
@@ -96,6 +98,26 @@ experiment('lib/connectors/repos/billing-batches', () => {
         perPage: 15,
         totalRows: 53
       });
+    });
+  });
+
+  experiment('.update', () => {
+    beforeEach(async () => {
+      await billingBatches.update('test-id', { foo: 'bar' });
+    });
+
+    test('calls model.forge with correct id', async () => {
+      const [params] = BillingBatch.forge.lastCall.args;
+      expect(params).to.equal({ billing_batch_id: 'test-id' });
+    });
+
+    test('calls model.set with correct data', async () => {
+      const [data] = stub.set.lastCall.args;
+      expect(data).to.equal({ foo: 'bar' });
+    });
+
+    test('calls model.save', async () => {
+      expect(stub.save.callCount).to.equal(1);
     });
   });
 });

--- a/test/lib/connectors/repos/billing-invoice-licences.js
+++ b/test/lib/connectors/repos/billing-invoice-licences.js
@@ -1,0 +1,58 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const billingInvoiceLicences = require('../../../../src/lib/connectors/repos/billing-invoice-licences');
+const { bookshelf } = require('../../../../src/lib/connectors/bookshelf');
+const raw = require('../../../../src/lib/connectors/repos/lib/raw');
+const queries = require('../../../../src/lib/connectors/repos/queries/billing-invoice-licences');
+
+experiment('lib/connectors/repos/billing-invoice-licences', () => {
+  beforeEach(async () => {
+    sandbox.stub(bookshelf.knex, 'raw');
+    sandbox.stub(raw, 'singleRow');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.upsert', () => {
+    const data = {
+      billingInvoiceId: '7d702412-46a4-4a88-bb59-cd770d3eaa3f',
+      companyId: 'cfe824a3-2a5e-457e-82ae-bd4bcc43dbe3',
+      addressId: 'f3597ab0-3e6f-4564-82a7-939aa2a7e5d6',
+      licenceRef: '01/123/ABC'
+    };
+
+    beforeEach(async () => {
+      await billingInvoiceLicences.upsert(data);
+    });
+
+    test('calls raw.singleRow with correct argumements', async () => {
+      const { args } = raw.singleRow.lastCall;
+      expect(args[0]).to.equal(queries.upsert);
+      expect(args[1]).to.equal(data);
+    });
+  });
+
+  experiment('.deleteEmptyByBatchId', () => {
+    const batchId = '23181afd-25aa-4a8e-9342-7734dd844f7b';
+
+    beforeEach(async () => {
+      await billingInvoiceLicences.deleteEmptyByBatchId(batchId);
+    });
+
+    test('calls bookshelf.knex.raw with correct params', async () => {
+      const { args } = bookshelf.knex.raw.lastCall;
+      expect(args[0]).to.equal(queries.deleteEmptyByBatchId);
+      expect(args[1]).to.equal({ batchId });
+    });
+  });
+});

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -12,7 +12,6 @@ const { bookshelf } = require('../../../../src/lib/connectors/bookshelf');
 const queries = require('../../../../src/lib/connectors/repos/queries/billing-invoices');
 
 const billingInvoices = require('../../../../src/lib/connectors/repos/billing-invoices');
-const { BillingBatch } = require('../../../../src/lib/connectors/bookshelf/');
 
 const result = {
   rows: [{
@@ -21,8 +20,6 @@ const result = {
 };
 
 experiment('lib/connectors/repos/billing-invoices', () => {
-  let model, stub;
-
   beforeEach(async () => {
     sandbox.stub(bookshelf.knex, 'raw').resolves(result);
   });

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -1,0 +1,71 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { bookshelf } = require('../../../../src/lib/connectors/bookshelf');
+const queries = require('../../../../src/lib/connectors/repos/queries/billing-invoices');
+
+const billingInvoices = require('../../../../src/lib/connectors/repos/billing-invoices');
+const { BillingBatch } = require('../../../../src/lib/connectors/bookshelf/');
+
+const result = {
+  rows: [{
+    billing_invoice_id: 'test-invoice-id'
+  }]
+};
+
+experiment('lib/connectors/repos/billing-invoices', () => {
+  let model, stub;
+
+  beforeEach(async () => {
+    sandbox.stub(bookshelf.knex, 'raw').resolves(result);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.upsert', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await billingInvoices.upsert({
+        invoiceAccountId: 'test-invoice-account-id'
+      });
+    });
+
+    test('calls knex.raw with the correct arguments', async () => {
+      const [query, params] = bookshelf.knex.raw.lastCall.args;
+      expect(query).to.equal(queries.upsert);
+      expect(params).to.equal({
+        invoiceAccountId: 'test-invoice-account-id'
+      });
+    });
+
+    test('returns the first found row with camelCased keys', async () => {
+      expect(result).to.equal({
+        billingInvoiceId: 'test-invoice-id'
+      });
+    });
+  });
+
+  experiment('.deleteEmptyBatchById', () => {
+    beforeEach(async () => {
+      await billingInvoices.deleteEmptyByBatchId('test-batch-id');
+    });
+
+    test('calls knex.raw with the correct arguments', async () => {
+      const [query, params] = bookshelf.knex.raw.lastCall.args;
+      expect(query).to.equal(queries.deleteEmptyByBatchId);
+      expect(params).to.equal({
+        batchId: 'test-batch-id'
+      });
+    });
+  });
+});

--- a/test/lib/connectors/repos/lib/raw.js
+++ b/test/lib/connectors/repos/lib/raw.js
@@ -1,0 +1,85 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const { bookshelf } = require('../../../../../src/lib/connectors/bookshelf/');
+const raw = require('../../../../../src/lib/connectors/repos/lib/raw');
+
+const sqlQuery = 'select * from ...';
+const params = {
+  foo: 'bar'
+};
+const rows = [{
+  snake_case: 'value'
+}, {
+  snake_case: 'another-value'
+}];
+experiment('lib/connectors/repos/lib/raw', () => {
+  beforeEach(async () => {
+    sandbox.stub(bookshelf.knex, 'raw').resolves({ rows });
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.multiRow', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await raw.multiRow(sqlQuery, params);
+    });
+
+    test('calls bookshelf.knex.raw with correct params', async () => {
+      const { args } = bookshelf.knex.raw.lastCall;
+      expect(args[0]).to.equal(sqlQuery);
+      expect(args[1]).to.equal(params);
+    });
+
+    test('row data has keys camel-cased', async () => {
+      expect(result).to.equal([{
+        snakeCase: 'value'
+      }, {
+        snakeCase: 'another-value'
+      }]);
+    });
+  });
+
+  experiment('.singleRow', () => {
+    let result;
+
+    experiment('when a row is returned', () => {
+      beforeEach(async () => {
+        result = await raw.singleRow(sqlQuery, params);
+      });
+
+      test('calls bookshelf.knex.raw with correct params', async () => {
+        const { args } = bookshelf.knex.raw.lastCall;
+        expect(args[0]).to.equal(sqlQuery);
+        expect(args[1]).to.equal(params);
+      });
+
+      test('the first row of data is returned with keys camel-cased', async () => {
+        expect(result).to.equal({
+          snakeCase: 'value'
+        });
+      });
+    });
+
+    experiment('when no rows are found', () => {
+      beforeEach(async () => {
+        bookshelf.knex.raw.resolves({ rows: [] });
+        result = await raw.singleRow(sqlQuery, params);
+      });
+
+      test('returns null', async () => {
+        expect(result).to.equal(null);
+      });
+    });
+  });
+});

--- a/test/lib/make-array.js
+++ b/test/lib/make-array.js
@@ -1,0 +1,19 @@
+const { expect } = require('@hapi/code');
+const {
+  experiment,
+  test
+} = exports.lab = require('@hapi/lab').script();
+
+const makeArray = require('../../src/lib/make-array.js');
+
+experiment('lib/make-array', () => {
+  test('when the argument is an array, the result is the array', async () => {
+    const result = makeArray([1, 2]);
+    expect(result).to.equal([1, 2]);
+  });
+
+  test('when the argument is not an array, it is converted to an array with one element', async () => {
+    const result = makeArray(5);
+    expect(result).to.equal([5]);
+  });
+});

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -321,4 +321,24 @@ experiment('lib/models/batch', () => {
       expect(batch.isTwoPartTariff()).to.be.true();
     });
   });
+
+  experiment('.isSupplementary', () => {
+    test('returns true when the batch type is supplementary', async () => {
+      const batch = new Batch();
+      batch.type = Batch.types.supplementary;
+      expect(batch.isSupplementary()).to.be.true();
+    });
+
+    test('returns false when the batch type is two-part-tariff', async () => {
+      const batch = new Batch();
+      batch.type = Batch.types.twoPartTariff;
+      expect(batch.isSupplementary()).to.be.false();
+    });
+
+    test('returns false when the batch type is annual', async () => {
+      const batch = new Batch();
+      batch.type = Batch.types.annual;
+      expect(batch.isSupplementary()).to.be.false();
+    });
+  });
 });

--- a/test/modules/billing/jobs/prepare-transactions.js
+++ b/test/modules/billing/jobs/prepare-transactions.js
@@ -13,6 +13,11 @@ const { logger } = require('../../../../src/logger');
 const prepareTransactions = require('../../../../src/modules/billing/jobs/prepare-transactions');
 const repos = require('../../../../src/lib/connectors/repository');
 
+const batchService = require('../../../../src/modules/billing/services/batch-service');
+const supplementaryBillingService = require('../../../../src/modules/billing/services/supplementary-billing-service');
+
+const Batch = require('../../../../src/lib/models/batch');
+
 const data = {
   eventId: 'test-event-id',
   transactions: [{
@@ -24,10 +29,17 @@ const data = {
 };
 
 experiment('modules/billing/jobs/process-charge-version', () => {
+  let batch;
+
   beforeEach(async () => {
     sandbox.stub(logger, 'info');
 
+    batch = new Batch(data.batch.billing_batch_id);
+    sandbox.stub(batchService, 'getBatchById').resolves(batch);
+    sandbox.stub(batchService, 'setErrorStatus').resolves();
     sandbox.stub(repos.billingTransactions, 'getByBatchId').resolves(data.transactions);
+    sandbox.stub(supplementaryBillingService, 'processBatch');
+    sandbox.stub(batch, 'isSupplementary');
   });
 
   afterEach(async () => {
@@ -67,23 +79,47 @@ experiment('modules/billing/jobs/process-charge-version', () => {
           batch: data.batch
         }
       };
-
-      result = await prepareTransactions.handler(job);
     });
 
-    test('a message is logged', async () => {
-      const [message] = logger.info.lastCall.args;
-      expect(message).to.equal('Handling billing.prepare-transactions');
+    experiment('for a supplementary batch', () => {
+      beforeEach(async () => {
+        batch.isSupplementary.returns(true);
+        result = await prepareTransactions.handler(job);
+      });
+
+      test('a message is logged', async () => {
+        const [message] = logger.info.firstCall.args;
+        expect(message).to.equal('Handling billing.prepare-transactions');
+      });
+
+      test('the supplementary batch service is called', async () => {
+        expect(
+          supplementaryBillingService.processBatch.calledWith(data.batch.billing_batch_id)
+        ).to.be.true();
+      });
+
+      test('calls repos.billingTransactions.getByBatchId with batch ID', async () => {
+        const [batchId] = repos.billingTransactions.getByBatchId.lastCall.args;
+        expect(batchId).to.equal(data.batch.billing_batch_id);
+      });
+
+      test('resolves with batch and transactions', async () => {
+        expect(result.batch).to.equal(data.batch);
+        expect(result.transactions).to.equal(data.transactions);
+      });
     });
 
-    test('calls repos.billingTransactions.getByBatchId with batch ID', async () => {
-      const [batchId] = repos.billingTransactions.getByBatchId.lastCall.args;
-      expect(batchId).to.equal(data.batch.billing_batch_id);
-    });
+    experiment('for a non-supplementary batch', () => {
+      beforeEach(async () => {
+        batch.isSupplementary.returns(false);
+        result = await prepareTransactions.handler(job);
+      });
 
-    test('resolves with batch and transactions', async () => {
-      expect(result.batch).to.equal(data.batch);
-      expect(result.transactions).to.equal(data.transactions);
+      test('the supplementary batch service is not called', async () => {
+        expect(
+          supplementaryBillingService.processBatch.callCount
+        ).to.equal(0);
+      });
     });
   });
 });

--- a/test/modules/billing/mappers/invoice-licence.js
+++ b/test/modules/billing/mappers/invoice-licence.js
@@ -14,7 +14,18 @@ const InvoiceLicence = require('../../../../src/lib/models/invoice-licence');
 const Address = require('../../../../src/lib/models/address');
 const Company = require('../../../../src/lib/models/company');
 const Contact = require('../../../../src/lib/models/contact-v2');
-const Region = require('../../../../src/lib/models/region');
+const Licence = require('../../../../src/lib/models/licence');
+
+const createLicence = () => ({
+  licenceId: 'd563b2b9-e87e-4a9c-8990-1acc96fe2c17',
+  licenceRef: '01/123',
+  region: {
+    regionId: '80bb8d61-786c-4b86-9bb4-8959fa6a2d20',
+    name: 'Anglian',
+    chargeRegionId: 'A'
+  },
+  regions: { historicalAreaCode: 'ARCA', regionalChargeArea: 'Anglian' }
+});
 
 experiment('modules/billing/mappers/invoice-licence', () => {
   experiment('.dbToModel', () => {
@@ -23,7 +34,8 @@ experiment('modules/billing/mappers/invoice-licence', () => {
       const dbRow = {
         billingInvoiceLicenceId: '4e44ea0b-62fc-4a3d-82ed-6ff563f1e39b',
         companyId: '40283a80-766f-481f-ba54-484ac0b7ea6d',
-        addressId: '399282c3-f9b4-4a4b-af1b-0019e040ad61'
+        addressId: '399282c3-f9b4-4a4b-af1b-0019e040ad61',
+        licence: createLicence()
       };
 
       beforeEach(async () => {
@@ -48,6 +60,10 @@ experiment('modules/billing/mappers/invoice-licence', () => {
       test('the contact is not set', async () => {
         expect(result.contact).to.be.undefined();
       });
+
+      test('the invoiceLicence has a Licence', async () => {
+        expect(result.licence instanceof Licence).to.be.true();
+      });
     });
 
     experiment('when there contact ID is set', () => {
@@ -55,7 +71,8 @@ experiment('modules/billing/mappers/invoice-licence', () => {
         billingInvoiceLicenceId: '4e44ea0b-62fc-4a3d-82ed-6ff563f1e39b',
         companyId: '40283a80-766f-481f-ba54-484ac0b7ea6d',
         addressId: '399282c3-f9b4-4a4b-af1b-0019e040ad61',
-        contactId: 'b21a7769-942e-4166-a787-a16701f25e4e'
+        contactId: 'b21a7769-942e-4166-a787-a16701f25e4e',
+        licence: createLicence()
       };
 
       beforeEach(async () => {

--- a/test/modules/billing/mappers/invoice-licence.js
+++ b/test/modules/billing/mappers/invoice-licence.js
@@ -15,6 +15,7 @@ const Address = require('../../../../src/lib/models/address');
 const Company = require('../../../../src/lib/models/company');
 const Contact = require('../../../../src/lib/models/contact-v2');
 const Licence = require('../../../../src/lib/models/licence');
+const Region = require('../../../../src/lib/models/region');
 
 const createLicence = () => ({
   licenceId: 'd563b2b9-e87e-4a9c-8990-1acc96fe2c17',

--- a/test/modules/billing/mappers/transaction.js
+++ b/test/modules/billing/mappers/transaction.js
@@ -327,11 +327,11 @@ experiment('modules/billing/mappers/transaction', () => {
 
       test('the result is mapped correctly', async () => {
         expect(result).to.equal({
-          billing_invoice_licence_id: 'c4fd4bf6-9565-4ff8-bdba-e49355446d7b',
-          charge_element_id: '29328315-9b24-473b-bde7-02c60e881501',
-          start_date: '2019-04-01',
-          end_date: '2020-03-31',
-          abstraction_period: {
+          billingInvoiceLicenceId: 'c4fd4bf6-9565-4ff8-bdba-e49355446d7b',
+          chargeElementId: '29328315-9b24-473b-bde7-02c60e881501',
+          startDate: '2019-04-01',
+          endDate: '2020-03-31',
+          abstractionPeriod: {
             startDay: 1,
             startMonth: 1,
             endDay: 31,
@@ -340,19 +340,19 @@ experiment('modules/billing/mappers/transaction', () => {
           source: 'supported',
           loss: 'low',
           season: 'summer',
-          is_credit: false,
-          charge_type: 'standard',
-          authorised_quantity: 12.5,
-          billable_quantity: 10,
-          authorised_days: 366,
-          billable_days: 366,
+          isCredit: false,
+          chargeType: 'standard',
+          authorisedQuantity: 12.5,
+          billableQuantity: 10,
+          authorisedDays: 366,
+          billableDays: 366,
           description: 'Tiny pond',
           status: Transaction.statuses.candidate,
           volume: 5.64,
-          section_126_factor: null,
-          section_127_agreement: false,
-          section_130_agreement: null,
-          transaction_key: '0123456789ABCDEF0123456789ABCDEF'
+          section126Factor: null,
+          section127Agreement: false,
+          section130Agreement: null,
+          transactionKey: 'standard.29328315-9b24-473b-bde7-02c60e881501'
         });
       });
     });
@@ -366,7 +366,7 @@ experiment('modules/billing/mappers/transaction', () => {
       });
 
       test('the charge type is "compensation"', async () => {
-        expect(result.charge_type).to.equal('compensation');
+        expect(result.chargeType).to.equal('compensation');
       });
     });
 
@@ -380,9 +380,9 @@ experiment('modules/billing/mappers/transaction', () => {
       });
 
       test('the correct agreement fields are set', async () => {
-        expect(result.section_126_factor).to.equal(null);
-        expect(result.section_127_agreement).to.equal(true);
-        expect(result.section_130_agreement).to.equal(null);
+        expect(result.section126Factor).to.equal(null);
+        expect(result.section127Agreement).to.equal(true);
+        expect(result.section130Agreement).to.equal(null);
       });
     });
 
@@ -396,9 +396,9 @@ experiment('modules/billing/mappers/transaction', () => {
       });
 
       test('the correct agreement fields are set', async () => {
-        expect(result.section_126_factor).to.equal(null);
-        expect(result.section_127_agreement).to.equal(false);
-        expect(result.section_130_agreement).to.equal('S130U');
+        expect(result.section126Factor).to.equal(null);
+        expect(result.section127Agreement).to.equal(false);
+        expect(result.section130Agreement).to.equal('S130U');
       });
     });
 
@@ -412,9 +412,9 @@ experiment('modules/billing/mappers/transaction', () => {
       });
 
       test('the correct agreement fields are set', async () => {
-        expect(result.section_126_factor).to.equal(0.4);
-        expect(result.section_127_agreement).to.equal(false);
-        expect(result.section_130_agreement).to.equal(null);
+        expect(result.section126Factor).to.equal(0.4);
+        expect(result.section127Agreement).to.equal(false);
+        expect(result.section130Agreement).to.equal(null);
       });
     });
   });

--- a/test/modules/billing/mappers/transaction.js
+++ b/test/modules/billing/mappers/transaction.js
@@ -352,7 +352,7 @@ experiment('modules/billing/mappers/transaction', () => {
           section126Factor: null,
           section127Agreement: false,
           section130Agreement: null,
-          transactionKey: 'standard.29328315-9b24-473b-bde7-02c60e881501'
+          transactionKey: '0123456789ABCDEF0123456789ABCDEF'
         });
       });
     });

--- a/test/modules/billing/service/charge-version-year.js
+++ b/test/modules/billing/service/charge-version-year.js
@@ -10,11 +10,8 @@ const {
 const { expect } = require('@hapi/code');
 
 const sandbox = require('sinon').createSandbox();
-const { Address, Batch, Company, Invoice, InvoiceAccount, InvoiceLicence, Licence, Transaction } = require('../../../../src/lib/models');
-const DateRange = require('../../../../src/lib/models/date-range');
+const { Batch, Licence } = require('../../../../src/lib/models');
 const Region = require('../../../../src/lib/models/region');
-const ChargeElement = require('../../../../src/lib/models/charge-element');
-const Contact = require('../../../../src/lib/models/contact-v2');
 
 const chargeVersionYear = require('../../../../src/modules/billing/service/charge-version-year');
 const chargeProcessor = require('../../../../src/modules/billing/service/charge-processor');
@@ -79,24 +76,24 @@ const data = {
   }
 };
 
-const createCompany = () =>
-  Object.assign(new Company(), data.company);
+// const createCompany = () =>
+//   Object.assign(new Company(), data.company);
 
-const createLicence = () => {
-  return new Licence().fromHash({
-    region: new Region().fromHash({ code: 'A' }),
-    ...data.licence
-  });
-};
+// const createLicence = () => {
+//   return new Licence().fromHash({
+//     region: new Region().fromHash({ code: 'A' }),
+//     ...data.licence
+//   });
+// };
 
-const createContact = () =>
-  Object.assign(new Contact(), data.contact);
+// const createContact = () =>
+//   Object.assign(new Contact(), data.contact);
 
-const createAddress = () =>
-  Object.assign(new Address(), data.address);
+// const createAddress = () =>
+//   Object.assign(new Address(), data.address);
 
-const createInvoiceAccount = () =>
-  Object.assign(new InvoiceAccount(), data.invoiceAccount);
+// const createInvoiceAccount = () =>
+//   Object.assign(new InvoiceAccount(), data.invoiceAccount);
 
 experiment('modules/billing/service/charge-version-year.js', () => {
   beforeEach(async () => {
@@ -176,6 +173,7 @@ experiment('modules/billing/service/charge-version-year.js', () => {
     });
   });
 
+  /*
   experiment('.persistChargeVersionYearBatch', async () => {
     let batch;
 
@@ -305,4 +303,5 @@ experiment('modules/billing/service/charge-version-year.js', () => {
       });
     });
   });
+  */
 });

--- a/test/modules/billing/service/charge-version-year.js
+++ b/test/modules/billing/service/charge-version-year.js
@@ -10,8 +10,7 @@ const {
 const { expect } = require('@hapi/code');
 
 const sandbox = require('sinon').createSandbox();
-const { Batch, Licence } = require('../../../../src/lib/models');
-const Region = require('../../../../src/lib/models/region');
+const { Batch } = require('../../../../src/lib/models');
 
 const chargeVersionYear = require('../../../../src/modules/billing/service/charge-version-year');
 const chargeProcessor = require('../../../../src/modules/billing/service/charge-processor');

--- a/test/modules/billing/services/invoice-licences-service.js
+++ b/test/modules/billing/services/invoice-licences-service.js
@@ -9,51 +9,43 @@ const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 
 const invoiceLicencesService = require('../../../../src/modules/billing/services/invoice-licences-service');
-const licenceService = require('../../../../src/modules/billing/services/licence-service');
 
+const Invoice = require('../../../../src/lib/models/invoice');
 const InvoiceLicence = require('../../../../src/lib/models/invoice-licence');
-const Licence = require('../../../../src/lib/models/licence');
 
-const repos = require('../../../../src/lib/connectors/repository');
+const newRepos = require('../../../../src/lib/connectors/repos');
+const mappers = require('../../../../src/modules/billing/mappers');
 
 experiment('modules/billing/services/invoice-licences-service', () => {
   beforeEach(async () => {
-    sandbox.stub(repos.billingInvoiceLicences, 'findOneByTransactionId');
-    sandbox.stub(licenceService, 'getByLicenceNumber');
+    sandbox.stub(newRepos.billingInvoiceLicences, 'upsert');
+    sandbox.stub(mappers.invoiceLicence, 'modelToDB').returns({
+      licenceRef: '01/123'
+    });
   });
 
   afterEach(async () => {
     sandbox.restore();
   });
 
-  experiment('.getByTransactionId', () => {
-    let result;
-
-    const dbRow = {
-      billingInvoiceLicenceId: '4e44ea0b-62fc-4a3d-82ed-6ff563f1e39b',
-      companyId: '40283a80-766f-481f-ba54-484ac0b7ea6d',
-      addressId: '399282c3-f9b4-4a4b-af1b-0019e040ad61'
-    };
-
-    const licence = new Licence();
+  experiment('.saveInvoiceLicenceToDB', () => {
+    const invoice = new Invoice('40283a80-766f-481f-ba54-484ac0b7ea6d');
+    const invoiceLicence = new InvoiceLicence('399282c3-f9b4-4a4b-af1b-0019e040ad61');
 
     beforeEach(async () => {
-      repos.billingInvoiceLicences.findOneByTransactionId.resolves(dbRow);
-      licenceService.getByLicenceNumber.resolves(licence);
-      result = await invoiceLicencesService.getByTransactionId('transaction-id');
+      await invoiceLicencesService.saveInvoiceLicenceToDB(invoice, invoiceLicence);
     });
 
-    test('calls .findOneByTransactionId with correct ID', async () => {
-      const [id] = repos.billingInvoiceLicences.findOneByTransactionId.lastCall.args;
-      expect(id).to.equal('transaction-id');
+    test('passes the models to the correct mapper', async () => {
+      const { args } = mappers.invoiceLicence.modelToDB.lastCall;
+      expect(args).to.equal([invoice, invoiceLicence]);
     });
 
-    test('resolves with an InvoiceLicence model', async () => {
-      expect(result instanceof InvoiceLicence).to.be.true();
-    });
-
-    test('the invoice licence has a licence property', async () => {
-      expect(result.licence).to.equal(licence);
+    test('passes the result of the mapping to the repo for upsert', async () => {
+      const [data] = newRepos.billingInvoiceLicences.upsert.lastCall.args;
+      expect(data).to.equal({
+        licenceRef: '01/123'
+      });
     });
   });
 });

--- a/test/modules/billing/services/supplementary-billing-service.js
+++ b/test/modules/billing/services/supplementary-billing-service.js
@@ -1,0 +1,203 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const { Batch } = require('../../../../src/lib/models');
+const batchService = require('../../../../src/modules/billing/services/batch-service');
+
+const crmV2Connector = require('../../../../src/lib/connectors/crm-v2');
+const newRepos = require('../../../../src/lib/connectors/repos');
+
+const supplementaryBillingService = require('../../../../src/modules/billing/services/supplementary-billing-service');
+
+const batchId = '398b6f31-ff01-4621-b939-e720f1a77deb';
+const invoiceAccountId = '398b6f31-ff01-4621-b939-e720f1a77deb';
+
+const createTransactionRow = (index, transactionKey, isCredit = false) => ({
+  billingTransactionId: `00000000-0000-0000-0000-00000000000${index}`,
+  isCredit,
+  transactionKey
+});
+
+const createFullTransaction = (...args) => ({
+  ...createTransactionRow(...args),
+  volume: 25.2,
+  description: 'Babbling brook',
+  chargeElement: {
+    chargeElementId: '0b76bf54-57f4-428e-8fc8-3494c84affc6',
+    source: 'supported',
+    season: 'summer',
+    loss: 'high'
+  },
+  billingInvoiceLicence: {
+    billingInvoice: {
+      invoiceAccountId
+    },
+    licence: {
+      licenceId: '4b4f2427-984e-48f6-8b20-f17380b870a8',
+      licenceRef: '01/123/ABC',
+      regions: { historicalAreaCode: 'ARCA', regionalChargeArea: 'Anglian' },
+      region: {
+        regionId: '74241f84-de5f-4ec5-b437-377af15289fd',
+        name: 'Anglian',
+        naldRegionId: 1,
+        chargeRegionId: 'A'
+      }
+    }
+  }
+});
+
+const data = {
+  batchId,
+  batchTransactions: [
+    createTransactionRow(0, '0000000000000000000000000000000A'),
+    createTransactionRow(1, '0000000000000000000000000000000B'),
+    createTransactionRow(2, '0000000000000000000000000000000C')
+  ],
+  historicalTransactions: [
+    createTransactionRow(3, '0000000000000000000000000000000B'),
+    createTransactionRow(4, '0000000000000000000000000000000C', true),
+    createTransactionRow(5, '0000000000000000000000000000000D'),
+    createTransactionRow(6, '0000000000000000000000000000000E', true)
+  ],
+  creditTransactions: [
+    createFullTransaction(5, '0000000000000000000000000000000D')
+  ],
+  crmResponse: [{
+    invoiceAccountId,
+    invoiceAccountNumber: 'A12345678A',
+    company: {
+      companyId: 'c3fea19d-f5da-4293-bf31-38d7b79d5bf5'
+    },
+    address: {
+      addressId: '3b0c8648-e6c0-41a4-aae0-4e1b5b8f7a3a',
+      address1: 'Daisy cottage',
+      address2: 'Long and winding road',
+      address3: null,
+      address4: null,
+      town: 'Testington',
+      county: 'Testingshire',
+      postcode: 'TT1 1TT'
+    }
+  }],
+  models: {
+    batch: new Batch(batchId)
+  }
+};
+
+experiment('modules/billing/services/supplementary-billing-service', () => {
+  beforeEach(async () => {
+    sandbox.stub(crmV2Connector.invoiceAccounts, 'getInvoiceAccountsByIds');
+    sandbox.stub(batchService, 'getBatchById');
+    sandbox.stub(batchService, 'saveInvoicesToDB');
+    sandbox.stub(newRepos.billingInvoiceLicences, 'deleteEmptyByBatchId');
+    sandbox.stub(newRepos.billingInvoices, 'deleteEmptyByBatchId');
+    sandbox.stub(newRepos.billingTransactions, 'find');
+    sandbox.stub(newRepos.billingTransactions, 'findByBatchId');
+    sandbox.stub(newRepos.billingTransactions, 'findHistoryByBatchId');
+    sandbox.stub(newRepos.billingTransactions, 'delete');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.processBatch', () => {
+    beforeEach(async () => {
+      newRepos.billingTransactions.findByBatchId.resolves(data.batchTransactions);
+      newRepos.billingTransactions.findHistoryByBatchId.resolves(data.historicalTransactions);
+      newRepos.billingTransactions.find.resolves(data.creditTransactions);
+      crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds.resolves(data.crmResponse);
+      batchService.getBatchById.resolves(
+        data.models.batch
+      );
+      await supplementaryBillingService.processBatch(data.batchId);
+    });
+
+    test('calls billingTransactions.findByBatchId with correct batch ID', async () => {
+      expect(newRepos.billingTransactions.findByBatchId.calledWith(
+        data.batchId
+      )).to.be.true();
+    });
+
+    test('calls billingTransactions.findHistoryByBatchId with correct batch ID', async () => {
+      expect(newRepos.billingTransactions.findHistoryByBatchId.calledWith(
+        data.batchId
+      )).to.be.true();
+    });
+
+    test('current batch transactions which have already been charged are deleted', async () => {
+      expect(newRepos.billingTransactions.delete.calledWith(
+        ['00000000-0000-0000-0000-000000000001']
+      )).to.be.true();
+    });
+
+    experiment('historical charges which have no charge in the current batch', () => {
+      test('are fetched from the repo', async () => {
+        expect(newRepos.billingTransactions.find.calledWith(
+          ['00000000-0000-0000-0000-000000000005']
+        )).to.be.true();
+      });
+
+      test('have their invoice account fetched from the CRM', async () => {
+        expect(crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds.calledWith(
+          [data.creditTransactions[0].billingInvoiceLicence.billingInvoice.invoiceAccountId]
+        )).to.be.true();
+      });
+
+      experiment('persist the batch', () => {
+        let batch;
+
+        beforeEach(async () => {
+          batch = batchService.saveInvoicesToDB.lastCall.args[0];
+        });
+
+        test('to the correct batch', async () => {
+          expect(batch.id).to.equal(batchId);
+        });
+
+        test('only the correct number of transactions are credited', async () => {
+          expect(batch.invoices).to.have.length(1);
+          expect(batch.invoices[0].invoiceLicences).to.have.length(1);
+          expect(batch.invoices[0].invoiceLicences[0].transactions).to.have.length(1);
+        });
+
+        test('the invoice details are correctly loaded from the CRM', async () => {
+          expect(batch.invoices[0].invoiceAccount.id).to.equal(data.crmResponse[0].invoiceAccountId);
+          expect(batch.invoices[0].invoiceAccount.accountNumber).to.equal(data.crmResponse[0].invoiceAccountNumber);
+          expect(batch.invoices[0].invoiceAccount.company.id).to.equal(data.crmResponse[0].company.companyId);
+          expect(batch.invoices[0].address.id).to.equal(data.crmResponse[0].address.addressId);
+        });
+
+        test('the licence details are taken from the historical transaction', async () => {
+          const [invoiceAccountLicence] = batch.invoices[0].invoiceLicences;
+          expect(invoiceAccountLicence.licence.id).to.equal(data.creditTransactions[0].billingInvoiceLicence.licence.licenceId);
+          expect(invoiceAccountLicence.licence.licenceNumber).to.equal(data.creditTransactions[0].billingInvoiceLicence.licence.licenceRef);
+        });
+
+        test('the new credit transaction has the correct details', async () => {
+          const [transaction] = batch.invoices[0].invoiceLicences[0].transactions;
+          expect(transaction.id).to.be.undefined();
+          expect(transaction.isCredit).to.be.true();
+          expect(transaction.status).to.equal('candidate');
+          expect(transaction.description).to.equal(data.creditTransactions[0].description);
+          expect(transaction.chargeElement.id).to.equal(data.creditTransactions[0].chargeElement.chargeElementId);
+        });
+      });
+    });
+
+    test('empty billing records are removed from the DB', async () => {
+      expect(
+        newRepos.billingInvoiceLicences.deleteEmptyByBatchId.calledWith(batchId)
+      ).to.be.true();
+      expect(
+        newRepos.billingInvoices.deleteEmptyByBatchId.calledWith(batchId)
+      ).to.be.true();
+    });
+  });
+});

--- a/test/modules/billing/services/transactions-service.js
+++ b/test/modules/billing/services/transactions-service.js
@@ -10,7 +10,7 @@ const sandbox = sinon.createSandbox();
 
 const transactionsService = require('../../../../src/modules/billing/services/transactions-service');
 const chargeModuleTransactionsConnector = require('../../../../src/lib/connectors/charge-module/transactions');
-const repos = require('../../../../src/lib/connectors/repository');
+const repos = require('../../../../src/lib/connectors/repos');
 
 // Models
 const ChargeModuleTransaction = require('../../../../src/lib/models/charge-module-transaction');
@@ -208,20 +208,21 @@ experiment('modules/billing/services/transactions-service', () => {
     test('an object of the correct shape is passed to the create() method of the repo', async () => {
       const [data] = repos.billingTransactions.create.lastCall.args;
       expect(data).to.be.an.object();
-      expect(Object.keys(data)).to.include(['billing_invoice_licence_id',
-        'charge_element_id',
-        'start_date',
-        'end_date',
-        'abstraction_period',
+      expect(Object.keys(data)).to.include([
+        'billingInvoiceLicenceId',
+        'chargeElementId',
+        'startDate',
+        'endDate',
+        'abstractionPeriod',
         'source',
         'season',
         'loss',
-        'is_credit',
-        'charge_type',
-        'authorised_quantity',
-        'billable_quantity',
-        'authorised_days',
-        'billable_days',
+        'isCredit',
+        'chargeType',
+        'authorisedQuantity',
+        'billableQuantity',
+        'authorisedDays',
+        'billableDays',
         'description'
       ]);
     });


### PR DESCRIPTION
For supplementary billing:
- identifies transactions in the current batch that are already charged and deletes them
- identifies historical transactions that are no longer needed and credits them
This is done by comparing the transactionKey properties of each transaction (transactions with the same transactionKey are considered duplicates).