### PR TITLE
Feat/water 2511 bill run summary cm api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3288,8 +3288,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3307,13 +3306,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3326,18 +3323,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3440,8 +3434,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3451,7 +3444,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3464,20 +3456,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3494,7 +3483,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3567,8 +3555,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3578,7 +3565,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3654,8 +3640,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3685,7 +3670,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3703,7 +3687,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3742,13 +3725,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5339,7 +5320,7 @@
         },
         "jsonwebtoken": {
           "version": "8.2.1",
-          "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
           "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
           "requires": {
             "jws": "^3.1.4",
@@ -5486,6 +5467,11 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object-mapper": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/object-mapper/-/object-mapper-6.2.0.tgz",
+      "integrity": "sha512-kGa23lcUwnTbT0W2GqRipoiPax734TbXVTUF3vaWlAXY5baMQES323B9NHJODvxhn9sVMZmzeenD74PnCZZuHA=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "node-cron": "^1.2.1",
     "notifications-node-client": "^4.7.0",
     "nunjucks": "^3.2.0",
+    "object-mapper": "^6.2.0",
     "path": "^0.12.7",
     "pg": "^7.18.1",
     "pg-boss": "^3.2.2",

--- a/src/lib/connectors/repos/billing-batches.js
+++ b/src/lib/connectors/repos/billing-batches.js
@@ -54,7 +54,11 @@ const findOneWithInvoices = async (id) => {
     .fetch({
       withRelated: [
         'region',
-        'billingInvoices'
+        'billingInvoices',
+        'billingInvoices.billingInvoiceLicences',
+        'billingInvoices.billingInvoiceLicences.licence',
+        'billingInvoices.billingInvoiceLicences.licence.region'
+
       ]
     });
 

--- a/src/lib/connectors/repos/billing-batches.js
+++ b/src/lib/connectors/repos/billing-batches.js
@@ -13,8 +13,7 @@ const findOne = async (id) => {
     });
 
   return model.toJSON();
-}
-;
+};
 
 const findPage = async (page, pageSize) => {
   const result = await BillingBatch
@@ -49,7 +48,21 @@ const deleteById = batchId => BillingBatch
   .forge({ billingBatchId: batchId })
   .destroy();
 
+const findOneWithInvoices = async (id) => {
+  const model = await BillingBatch
+    .forge({ billingBatchId: id })
+    .fetch({
+      withRelated: [
+        'region',
+        'billingInvoices'
+      ]
+    });
+
+  return model.toJSON();
+};
+
 exports.delete = deleteById;
 exports.findOne = findOne;
 exports.findPage = findPage;
 exports.update = update;
+exports.findOneWithInvoices = findOneWithInvoices;

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -1,4 +1,4 @@
-const { bookshelf, BillingInvoice } = require('../bookshelf');
+const { bookshelf } = require('../bookshelf');
 const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoices');
 

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -1,4 +1,4 @@
-const { bookshelf } = require('../bookshelf');
+const { bookshelf, BillingInvoice } = require('../bookshelf');
 const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoices');
 

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -4,6 +4,7 @@ const Joi = require('@hapi/joi');
 const Invoice = require('./invoice');
 const FinancialYear = require('./financial-year');
 const Region = require('./region');
+const Totals = require('./totals');
 const { assert } = require('@hapi/hoek');
 const { isArray } = require('lodash');
 
@@ -202,6 +203,20 @@ class Batch extends Model {
 
   isTwoPartTariff () {
     return this.type === BATCH_TYPE.twoPartTariff;
+  }
+
+  /**
+   * The charge module summary contains data on
+   * invoice/credit count, invoice/credit totals, net total
+   * @param {Totals} totals
+   */
+  set totals (totals) {
+    assertIsInstanceOf(totals, Totals);
+    this._totals = totals;
+  }
+
+  get totals () {
+    return this._totals;
   }
 }
 

--- a/src/lib/models/index.js
+++ b/src/lib/models/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   Address: require('./address'),
   Batch: require('./batch'),
+  Totals: require('./totals'),
   Company: require('./company'),
   Contact: require('./contact'),
   FinancialYear: require('./financial-year'),

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -7,33 +7,7 @@ const Model = require('./model');
 const Address = require('./address');
 const InvoiceAccount = require('./invoice-account');
 const InvoiceLicence = require('./invoice-licence');
-
-const MINIMUM_PAYMENT = 25 * 100; // £25
-
-const getTotalsCredit = (totals, value) => {
-  return {
-    totalCredits: totals.totalCredits + value,
-    numberOfCredits: totals.numberOfCredits + 1
-  };
-};
-
-const getTotalsInvoice = (totals, value) => {
-  return {
-    totalInvoices: totals.totalInvoices + value,
-    numberOfInvoices: totals.numberOfInvoices + 1
-  };
-};
-
-const getTotalsChange = (totals, value, isCredit) => {
-  const change = isCredit
-    ? getTotalsCredit(totals, value)
-    : getTotalsInvoice(totals, value);
-
-  return {
-    ...change,
-    totalValue: totals.totalValue + (isCredit ? -1 * value : value)
-  };
-};
+const Totals = require('./totals');
 
 class Invoice extends Model {
   constructor (id) {
@@ -101,35 +75,6 @@ class Invoice extends Model {
   }
 
   /**
-   * Gets an object containing the total values and number
-   * of charge types for this invoice in the shape:
-   *
-   * {
-   *   totalValue: Number,
-   *   totalInvoices: Number,
-   *   totalCredits: Number,
-   *   numberOfInvoices: Number,
-   *   numberOfCredits: Number
-   * }
-   */
-  getTotals () {
-    const transactions = this.invoiceLicences.reduce((acc, invoiceLicence) => {
-      return [...acc, ...invoiceLicence.transactions];
-    }, []);
-
-    return transactions.reduce((totals, { isCredit, value }) => {
-      const change = getTotalsChange(totals, value, isCredit);
-      return { ...totals, ...change };
-    }, {
-      totalValue: 0,
-      totalInvoices: 0,
-      totalCredits: 0,
-      numberOfInvoices: 0,
-      numberOfCredits: 0
-    });
-  }
-
-  /**
    * Get the licence numbers for this invoice by inspecting
    * the Licence objects associated with each InvoiceLicence
    * object associated with this invoice
@@ -141,18 +86,22 @@ class Invoice extends Model {
   }
 
   /**
-   * Gets the number of pence that are required to add to the invoice
-   * to satisfy the minimum charge of £25.
+   * The charge module summary contains data on
+   * invoice/credit count, invoice/credit totals, net total
+   * @param {Totals} totals
    */
-  getMinimumPaymentTopUp () {
-    const { totalValue } = this.getTotals();
-    return totalValue < MINIMUM_PAYMENT ? MINIMUM_PAYMENT - totalValue : 0;
+  set totals (totals) {
+    assertIsInstanceOf(totals, Totals);
+    this._totals = totals;
+  }
+
+  get totals () {
+    return this._totals;
   }
 
   toJSON () {
     return {
-      ...super.toJSON(),
-      totals: this.getTotals()
+      ...super.toJSON()
     };
   }
 }

--- a/src/lib/models/model.js
+++ b/src/lib/models/model.js
@@ -30,6 +30,7 @@ class Model {
 
   pickFrom (source, keys) {
     this.fromHash(_pick(source, keys));
+    return this;
   }
 
   /**

--- a/src/lib/models/totals.js
+++ b/src/lib/models/totals.js
@@ -1,5 +1,9 @@
 const Model = require('./model');
-const { assertPositiveOrZeroInteger } = require('./validators');
+const {
+  assertPositiveOrZeroInteger,
+  assertNegativeOrZeroInteger,
+  assertInteger
+} = require('./validators');
 
 class Totals extends Model {
   /**
@@ -20,7 +24,7 @@ class Totals extends Model {
    * @param {Number} value - in pence
    */
   set creditNoteValue (value) {
-    assertPositiveOrZeroInteger(value);
+    assertNegativeOrZeroInteger(value);
     this._creditNoteValue = value;
   }
 
@@ -72,7 +76,7 @@ class Totals extends Model {
    * @param {Number} value - in pence
    */
   set creditLineValue (value) {
-    assertPositiveOrZeroInteger(value);
+    assertNegativeOrZeroInteger(value);
     this._creditLineValue = value;
   }
 
@@ -111,7 +115,7 @@ class Totals extends Model {
    * @param {Number} value - in pence
    */
   set netTotal (value) {
-    assertPositiveOrZeroInteger(value);
+    assertInteger(value);
     this._netTotal = value;
   }
 

--- a/src/lib/models/totals.js
+++ b/src/lib/models/totals.js
@@ -1,0 +1,123 @@
+const Model = require('./model');
+const { assertPositiveOrZeroInteger } = require('./validators');
+
+class Totals extends Model {
+  /**
+   * Number of credit notes
+   * @param {Number} count
+   */
+  set creditNoteCount (count) {
+    assertPositiveOrZeroInteger(count);
+    this._creditNoteCount = count;
+  }
+
+  get creditNoteCount () {
+    return this._creditNoteCount;
+  }
+
+  /**
+   * Value of credit notes
+   * @param {Number} value - in pence
+   */
+  set creditNoteValue (value) {
+    assertPositiveOrZeroInteger(value);
+    this._creditNoteCount = value;
+  }
+
+  get creditNoteValue () {
+    return this._creditNoteValue;
+  }
+
+  /**
+   * Number of invoices
+   * @param {Number} count
+   */
+  set invoiceCount (count) {
+    assertPositiveOrZeroInteger(count);
+    this._invoiceCount = count;
+  }
+
+  get invoiceCount () {
+    return this._invoiceCount;
+  }
+
+  /**
+   * Value of invoices
+   * @param {Number} value - in pence
+   */
+  set invoiceValue (value) {
+    assertPositiveOrZeroInteger(value);
+    this._invoiceValue = value;
+  }
+
+  get invoiceValue () {
+    return this._invoiceValue;
+  }
+
+  /**
+   * Number of credit lines
+   * @param {Number} count
+   */
+  set creditLineCount (count) {
+    assertPositiveOrZeroInteger(count);
+    this._creditLineCount = count;
+  }
+
+  get creditLineCount () {
+    return this._creditLineCount;
+  }
+
+  /**
+   * Value of credit lines
+   * @param {Number} value - in pence
+   */
+  set creditLineValue (value) {
+    assertPositiveOrZeroInteger(value);
+    this._creditLineValue = value;
+  }
+
+  get creditLineValue () {
+    return this._creditLineValue;
+  }
+
+  /**
+   * Number of debit lines
+   * @param {Number} count
+   */
+  set debitLineCount (count) {
+    assertPositiveOrZeroInteger(count);
+    this._debitLineCount = count;
+  }
+
+  get debitLineCount () {
+    return this._debitLineCount;
+  }
+
+  /**
+   * Value of debit lines
+   * @param {Number} value - in pence
+   */
+  set debitLineValue (value) {
+    assertPositiveOrZeroInteger(value);
+    this._debitLineValue = value;
+  }
+
+  get debitLineValue () {
+    return this._debitLineValue;
+  }
+
+  /**
+   * Net total
+   * @param {Number} value - in pence
+   */
+  set netTotal (value) {
+    assertPositiveOrZeroInteger(value);
+    this._netTotal = value;
+  }
+
+  get netTotal () {
+    return this._netTotal;
+  }
+}
+
+module.exports = Totals;

--- a/src/lib/models/totals.js
+++ b/src/lib/models/totals.js
@@ -21,7 +21,7 @@ class Totals extends Model {
    */
   set creditNoteValue (value) {
     assertPositiveOrZeroInteger(value);
-    this._creditNoteCount = value;
+    this._creditNoteValue = value;
   }
 
   get creditNoteValue () {

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -25,6 +25,7 @@ const VALID_NULLABLE_QUANTITY = VALID_QUANTITY.allow(null);
 const VALID_ISO_DATE_STRING = Joi.string().isoDate();
 const VALID_FACTOR = Joi.number().min(0).max(1);
 const VALID_TRANSACTION_KEY = Joi.string().hex().length(32).allow(null);
+const VALID_NEGATIVE_INTEGER = VALID_INTEGER.negative();
 
 const assertIsArrayOfType = (values, Type) => {
   hoek.assert(isArray(values), 'Array expected');
@@ -58,6 +59,8 @@ const assertIsoString = value => assert(value, VALID_ISO_DATE_STRING);
 const assertFactor = value => assert(value, VALID_FACTOR);
 const assertTransactionKey = value => assert(value, VALID_TRANSACTION_KEY);
 const assertPositiveOrZeroInteger = value => assert(value, VALID_POSITIVE_INTEGER.allow(0));
+const assertNegativeOrZeroInteger = value => assert(value, VALID_NEGATIVE_INTEGER.allow(0));
+const assertInteger = value => assert(value, VALID_INTEGER);
 
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
@@ -82,3 +85,5 @@ exports.assertIsoString = assertIsoString;
 exports.assertFactor = assertFactor;
 exports.assertTransactionKey = assertTransactionKey;
 exports.assertPositiveOrZeroInteger = assertPositiveOrZeroInteger;
+exports.assertNegativeOrZeroInteger = assertNegativeOrZeroInteger;
+exports.assertInteger = assertInteger;

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -57,6 +57,7 @@ const assertNullableQuantity = value => assert(value, VALID_NULLABLE_QUANTITY);
 const assertIsoString = value => assert(value, VALID_ISO_DATE_STRING);
 const assertFactor = value => assert(value, VALID_FACTOR);
 const assertTransactionKey = value => assert(value, VALID_TRANSACTION_KEY);
+const assertPositiveOrZeroInteger = value => assert(value, VALID_POSITIVE_INTEGER.allow(0));
 
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
@@ -80,3 +81,4 @@ exports.assertNullableQuantity = assertNullableQuantity;
 exports.assertIsoString = assertIsoString;
 exports.assertFactor = assertFactor;
 exports.assertTransactionKey = assertTransactionKey;
+exports.assertPositiveOrZeroInteger = assertPositiveOrZeroInteger;

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -11,6 +11,8 @@ const { jobStatus } = require('./lib/batch');
 const invoiceService = require('./services/invoice-service');
 const batchService = require('./services/batch-service');
 
+const mappers = require('./mappers');
+
 const createBatchEvent = async (userEmail, batch) => {
   const batchEvent = event.create({
     type: 'billing-batch',
@@ -87,7 +89,8 @@ const getBatches = async request => {
 
 const getBatchInvoices = async request => {
   const { batchId } = request.params;
-  return invoiceService.getInvoicesForBatch(batchId);
+  const invoices = await invoiceService.getInvoicesForBatch(batchId);
+  return invoices.map(mappers.api.invoice.modelToBatchInvoices);
 };
 
 const getBatchInvoiceDetail = async request => {

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -79,9 +79,7 @@ const getBatches = async request => {
 
 const getBatchInvoices = async request => {
   const { batchId } = request.params;
-  const invoices = await invoiceService.getInvoicesForBatch(batchId);
-
-  return envelope(invoices, true);
+  return invoiceService.getInvoicesForBatch(batchId);
 };
 
 const getBatchInvoiceDetail = async request => {

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -69,7 +69,15 @@ const postCreateBatch = async (request, h) => {
   })).code(202);
 };
 
-const getBatch = async request => envelope(request.pre.batch, true);
+/**
+ * Get batch with region, and optionally include batch totals
+ * @param {Boolean} request.query.totals - indicates that batch totals should be included in response
+ * @return {Promise<Batch>}
+ */
+const getBatch = async request => {
+  const { totals } = request.query;
+  return totals ? batchService.decorateBatchWithTotals(request.pre.batch) : request.pre.batch;
+};
 
 const getBatches = async request => {
   const { page, perPage } = request.query;

--- a/src/modules/billing/mappers/api/index.js
+++ b/src/modules/billing/mappers/api/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  invoice: require('./invoice')
+};

--- a/src/modules/billing/mappers/api/invoice.js
+++ b/src/modules/billing/mappers/api/invoice.js
@@ -1,0 +1,14 @@
+const objectMapper = require('object-mapper');
+
+const modelToBatchInvoice = invoices => {
+  const map = {
+    id: 'id',
+    'invoiceAccount.accountNumber': 'accountNumber',
+    'invoiceAccount.company.name': 'name',
+    'totals.netTotal': 'netTotal',
+    'invoiceLicences[].licence.licenceNumber': 'licenceNumbers[]'
+  };
+  return objectMapper(invoices, map);
+};
+
+exports.modelToBatchInvoices = modelToBatchInvoice;

--- a/src/modules/billing/mappers/index.js
+++ b/src/modules/billing/mappers/index.js
@@ -3,6 +3,7 @@ exports.abstractionPeriod = require('./abstraction-period');
 exports.batch = require('./batch');
 exports.agreement = require('./agreement');
 exports.chargeElement = require('./charge-element');
+exports.totals = require('./totals');
 exports.company = require('./company');
 exports.contact = require('./contact');
 exports.invoice = require('./invoice');

--- a/src/modules/billing/mappers/index.js
+++ b/src/modules/billing/mappers/index.js
@@ -1,5 +1,6 @@
 exports.address = require('./address');
 exports.abstractionPeriod = require('./abstraction-period');
+exports.api = require('./api');
 exports.batch = require('./batch');
 exports.agreement = require('./agreement');
 exports.chargeElement = require('./charge-element');

--- a/src/modules/billing/mappers/totals.js
+++ b/src/modules/billing/mappers/totals.js
@@ -1,0 +1,47 @@
+const Totals = require('../../../lib/models/totals');
+
+const chargeModuleBatchSummaryToModel = data => {
+  const totals = new Totals();
+  return totals.pickFrom(data, [
+    'creditNoteCount',
+    'creditNoteValue',
+    'invoiceCount',
+    'invoiceValue',
+    'creditLineCount',
+    'creditLineValue',
+    'debitLineCount',
+    'debitLineValue',
+    'netTotal'
+  ]);
+};
+
+const sumProperties = arr => arr.reduce((acc, row) => {
+  return {
+    creditLineCount: acc.creditLineCount + row.creditLineCount,
+    creditLineValue: acc.creditLineValue + row.creditLineValue,
+    debitLineCount: acc.debitLineCount + row.debitLineCount,
+    debitLineValue: acc.debitLineValue + row.debitLineValue,
+    netTotal: acc.netTotal + row.netTotal
+  };
+}, {
+  creditLineCount: 0,
+  creditLineValue: 0,
+  debitLineCount: 0,
+  debitLineValue: 0,
+  netTotal: 0
+});
+
+const chargeModuleSummaryByFinancialYearToModel = arr => {
+  const data = sumProperties(arr);
+  const totals = new Totals();
+  return totals.pickFrom(data, [
+    'creditLineCount',
+    'creditLineValue',
+    'debitLineCount',
+    'debitLineValue',
+    'netTotal'
+  ]);
+};
+
+exports.chargeModuleBatchSummaryToModel = chargeModuleBatchSummaryToModel;
+exports.chargeModuleSummaryByFinancialYearToModel = chargeModuleSummaryByFinancialYearToModel;

--- a/src/modules/billing/mappers/totals.js
+++ b/src/modules/billing/mappers/totals.js
@@ -1,6 +1,7 @@
+const { find } = require('lodash');
 const Totals = require('../../../lib/models/totals');
 
-const chargeModuleBatchSummaryToModel = data => {
+const chargeModuleBillRunToBatchModel = data => {
   const totals = new Totals();
   return totals.pickFrom(data, [
     'creditNoteCount',
@@ -31,8 +32,19 @@ const sumProperties = arr => arr.reduce((acc, row) => {
   netTotal: 0
 });
 
-const chargeModuleSummaryByFinancialYearToModel = arr => {
-  const data = sumProperties(arr);
+/**
+ * Sums all transaction summaries for the supplied invoice account
+ * number and returns as a Totals instance
+ * @param {Object} billRun - response from Charge Module bill run call
+ * @param {String} invoiceAccountNumber
+ * @return {Totals} - totals for the supplied invoice account
+ */
+const chargeModuleBillRunToInvoiceModel = (billRun, invoiceAccountNumber) => {
+  const customer = find(billRun.customers, row => row.customerReference === invoiceAccountNumber);
+  if (!customer) {
+    return null;
+  }
+  const data = sumProperties(customer.summaryByFinancialYear);
   const totals = new Totals();
   return totals.pickFrom(data, [
     'creditLineCount',
@@ -43,5 +55,5 @@ const chargeModuleSummaryByFinancialYearToModel = arr => {
   ]);
 };
 
-exports.chargeModuleBatchSummaryToModel = chargeModuleBatchSummaryToModel;
-exports.chargeModuleSummaryByFinancialYearToModel = chargeModuleSummaryByFinancialYearToModel;
+exports.chargeModuleBillRunToBatchModel = chargeModuleBillRunToBatchModel;
+exports.chargeModuleBillRunToInvoiceModel = chargeModuleBillRunToInvoiceModel;

--- a/src/modules/billing/pre-handlers.js
+++ b/src/modules/billing/pre-handlers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
-const newRepos = require('../../lib/connectors/repos');
+const batchService = require('./services/batch-service');
 const { BATCH_STATUS } = require('../../lib/models/batch');
 
 /**
@@ -13,7 +13,7 @@ const { BATCH_STATUS } = require('../../lib/models/batch');
  */
 const loadBatch = async request => {
   const { batchId } = request.params;
-  const batch = await newRepos.billingBatches.findOne(batchId);
+  const batch = batchService.getBatchById(batchId);
 
   if (!batch) {
     throw Boom.notFound(`No batch found with id: ${batchId}`);

--- a/src/modules/billing/pre-handlers.js
+++ b/src/modules/billing/pre-handlers.js
@@ -13,7 +13,7 @@ const { BATCH_STATUS } = require('../../lib/models/batch');
  */
 const loadBatch = async request => {
   const { batchId } = request.params;
-  const batch = batchService.getBatchById(batchId);
+  const batch = await batchService.getBatchById(batchId);
 
   if (!batch) {
     throw Boom.notFound(`No batch found with id: ${batchId}`);

--- a/src/modules/billing/routes.js
+++ b/src/modules/billing/routes.js
@@ -44,6 +44,9 @@ const getBatch = {
     validate: {
       params: {
         batchId: Joi.string().uuid().required()
+      },
+      query: {
+        totals: Joi.boolean().truthy('1').falsy('0').default(false)
       }
     },
     pre: [

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -10,7 +10,6 @@ const event = require('../../../lib/event');
 const chargeModuleBatchConnector = require('../../../lib/connectors/charge-module/batches');
 const Batch = require('../../../lib/models/batch');
 
-const invoiceService = require('./invoice-service');
 const invoiceLicenceService = require('./invoice-licences-service');
 const transactionsService = require('./transactions-service');
 

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -117,7 +117,7 @@ const saveInvoicesToDB = async batch => {
 
 const decorateBatchWithTotals = async batch => {
   const chargeModuleSummary = await chargeModuleBatchConnector.send(batch.region.code, batch.id, true);
-  batch.totals = mappers.totals.chargeModuleBatchSummaryToModel(chargeModuleSummary.summary);
+  batch.totals = mappers.totals.chargeModuleBillRunToBatchModel(chargeModuleSummary.summary);
   return batch;
 };
 

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -21,7 +21,7 @@ const invoiceService = require('./invoice-service');
  */
 const getBatchById = async id => {
   const row = await newRepos.billingBatches.findOne(id);
-  return mappers.batch.dbToModel(row);
+  return row ? mappers.batch.dbToModel(row) : null;
 };
 
 const getBatches = async (page = 1, perPage = Number.MAX_SAFE_INTEGER) => {

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -12,6 +12,7 @@ const Batch = require('../../../lib/models/batch');
 
 const invoiceLicenceService = require('./invoice-licences-service');
 const transactionsService = require('./transactions-service');
+const invoiceService = require('./invoice-service');
 
 /**
  * Loads a Batch instance by ID
@@ -114,6 +115,12 @@ const saveInvoicesToDB = async batch => {
   }
 };
 
+const decorateBatchWithTotals = async batch => {
+  const chargeModuleSummary = await chargeModuleBatchConnector.send(batch.region.code, batch.id, true);
+  batch.totals = mappers.totals.chargeModuleBatchSummaryToModel(chargeModuleSummary.summary);
+  return batch;
+};
+
 exports.approveBatch = approveBatch;
 exports.deleteBatch = deleteBatch;
 exports.getBatchById = getBatchById;
@@ -121,3 +128,4 @@ exports.getBatches = getBatches;
 exports.saveInvoicesToDB = saveInvoicesToDB;
 exports.setErrorStatus = setErrorStatus;
 exports.setStatus = setStatus;
+exports.decorateBatchWithTotals = decorateBatchWithTotals;

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { first, find } = require('lodash');
+const { first } = require('lodash');
 
 const repos = require('../../../lib/connectors/repository');
 const newRepos = require('../../../lib/connectors/repos');
@@ -157,12 +157,7 @@ const saveInvoiceToDB = async (batch, invoice) => {
  */
 const decorateInvoiceWithTotals = (invoice, chargeModuleBillRun) => {
   const { accountNumber } = invoice.invoiceAccount;
-  const cmInvoice = find(chargeModuleBillRun.customers, row => row.customerReference === accountNumber);
-  if (!cmInvoice) {
-    throw new Error('Customer not found in charge module draft batch', { accountNumber });
-  }
-  invoice.totals = mappers.totals.chargeModuleSummaryByFinancialYearToModel(cmInvoice.summaryByFinancialYear);
-  return invoice;
+  invoice.totals = mappers.totals.chargeModuleBillRunToInvoiceModel(chargeModuleBillRun, accountNumber);
 };
 
 /**

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -160,6 +160,12 @@ const decorateInvoiceWithTotals = (invoice, chargeModuleBillRun) => {
   invoice.totals = mappers.totals.chargeModuleBillRunToInvoiceModel(chargeModuleBillRun, accountNumber);
 };
 
+const mapInvoice = row => {
+  const invoice = mappers.invoice.dbToModel(row);
+  invoice.invoiceLicences = row.billingInvoiceLicences.map(mappers.invoiceLicence.dbToModel);
+  return invoice;
+};
+
 /**
  * Converts a row of invoice row data from water.billing_invoices to Invoice models
  * And decorates with charge module summaries and company data from CRM
@@ -175,7 +181,7 @@ const getInvoicesForBatch = async batchId => {
   const chargeModuleSummary = await chargeModuleBatchConnector.send(data.region.chargeRegionId, batchId, true);
 
   // Map data to Invoice models
-  const invoices = data.billingInvoices.map(mappers.invoice.dbToModel);
+  const invoices = data.billingInvoices.map(mapInvoice);
 
   // Decorate with Charge Module summary data and CRM company data
   invoices.forEach(invoice => decorateInvoiceWithTotals(invoice, chargeModuleSummary));

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -3,7 +3,7 @@ const uuid = require('uuid/v4');
 const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
 const { expect } = require('@hapi/code');
 
-const { Batch, FinancialYear, Invoice, InvoiceAccount, Region } =
+const { Batch, FinancialYear, Invoice, InvoiceAccount, Region, Totals } =
   require('../../../src/lib/models');
 
 const TEST_GUID = 'add1cf3b-7296-4817-b013-fea75a928580';
@@ -339,6 +339,23 @@ experiment('lib/models/batch', () => {
       const batch = new Batch();
       batch.type = Batch.BATCH_TYPE.annual;
       expect(batch.isSupplementary()).to.be.false();
+    });
+  });
+
+  experiment('.totals', () => {
+    test('can be set to a totals instance', async () => {
+      const batch = new Batch();
+      const totals = new Totals();
+      batch.totals = new Totals();
+      expect(batch.totals).to.equal(totals);
+    });
+
+    test('throws an error if set to a different type', async () => {
+      const batch = new Batch();
+      const func = () => {
+        batch.totals = new Region();
+      };
+      expect(func).to.throw();
     });
   });
 });

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -8,7 +8,6 @@ const InvoiceAccount = require('../../../src/lib/models/invoice-account');
 const Address = require('../../../src/lib/models/address');
 const InvoiceLicence = require('../../../src/lib/models/invoice-licence');
 const Licence = require('../../../src/lib/models/licence');
-const Transaction = require('../../../src/lib/models/transaction');
 
 const TEST_GUID = 'add1cf3b-7296-4817-b013-fea75a928580';
 
@@ -88,55 +87,6 @@ experiment('lib/models/invoice', () => {
     });
   });
 
-  experiment('.getTotals', () => {
-    let invoice;
-    let totals;
-
-    beforeEach(async () => {
-      const tx1 = new Transaction('00000000-0000-0000-0000-000000000001', 100, true);
-      const tx2 = new Transaction('00000000-0000-0000-0000-000000000002', 200, false);
-      const tx3 = new Transaction('00000000-0000-0000-0000-000000000003', 300, false);
-      const tx4 = new Transaction('00000000-0000-0000-0000-000000000004', 400, true);
-      const tx5 = new Transaction('00000000-0000-0000-0000-000000000005', 500, false);
-      const tx6 = new Transaction('00000000-0000-0000-0000-000000000006', 600, false);
-      const invoiceLicence1 = new InvoiceLicence();
-      const invoiceLicence2 = new InvoiceLicence();
-      invoiceLicence1.transactions = [tx1, tx2, tx3, tx4];
-      invoiceLicence2.transactions = [tx5, tx6];
-
-      invoice = new Invoice();
-      invoice.invoiceLicences = [invoiceLicence1, invoiceLicence2];
-
-      totals = invoice.getTotals();
-    });
-
-    test('includes the total invoice value', async () => {
-      const expectedTotal =
-        (200 + 300 + 500 + 600) - // invoices
-        (100 + 400); // credits
-
-      expect(totals.totalValue).to.equal(expectedTotal);
-    });
-
-    test('includes the total value of credits', async () => {
-      const expectedTotal = 100 + 400;
-      expect(totals.totalCredits).to.equal(expectedTotal);
-    });
-
-    test('includes the number of credits', async () => {
-      expect(totals.numberOfCredits).to.equal(2);
-    });
-
-    test('includes the total value of invoices', async () => {
-      const expectedTotal = 200 + 300 + 500 + 600;
-      expect(totals.totalInvoices).to.equal(expectedTotal);
-    });
-
-    test('includes the number of invoices', async () => {
-      expect(totals.numberOfInvoices).to.equal(4);
-    });
-  });
-
   experiment('.getLicenceNumbers', () => {
     test('returns the licence numbers as an array', async () => {
       const licence1 = new Licence();
@@ -163,46 +113,6 @@ experiment('lib/models/invoice', () => {
     test('returns an empty array if there is no licence data', async () => {
       const invoice = new Invoice();
       expect(invoice.getLicenceNumbers()).to.equal([]);
-    });
-  });
-
-  experiment('.getMinimumPaymentTopUp', () => {
-    let invoice;
-
-    beforeEach(async () => {
-      const invoiceLicence = new InvoiceLicence();
-      invoice = new Invoice();
-      invoice.invoiceLicences = [invoiceLicence];
-    });
-
-    experiment('when the invoice has £25 of transactions', () => {
-      test('no top up is required', async () => {
-        const tx = new Transaction('00000000-0000-0000-0000-000000000001', 25 * 100);
-        invoice.invoiceLicences[0].transactions = [tx];
-
-        const topUp = invoice.getMinimumPaymentTopUp();
-        expect(topUp).to.equal(0);
-      });
-    });
-
-    experiment('when the invoice has more than £25 of transactions', () => {
-      test('no top up is required', async () => {
-        const tx = new Transaction('00000000-0000-0000-0000-000000000001', 35 * 100);
-        invoice.invoiceLicences[0].transactions = [tx];
-
-        const topUp = invoice.getMinimumPaymentTopUp();
-        expect(topUp).to.equal(0);
-      });
-    });
-
-    experiment('when the invoice has less than £25 of transactions', () => {
-      test('a top up is required', async () => {
-        const tx = new Transaction('00000000-0000-0000-0000-000000000001', 24 * 100);
-        invoice.invoiceLicences[0].transactions = [tx];
-
-        const topUp = invoice.getMinimumPaymentTopUp();
-        expect(topUp).to.equal(100);
-      });
     });
   });
 });

--- a/test/lib/models/totals.js
+++ b/test/lib/models/totals.js
@@ -1,0 +1,46 @@
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const Totals = require('../../../src/lib/models/totals');
+
+experiment('lib/models/totals', () => {
+  let totals;
+
+  beforeEach(async () => {
+    totals = new Totals();
+  });
+
+  const positiveOrZeroIntegerExperiment = key => experiment(`.${key}`, () => {
+    test('can be set to positive integer', async () => {
+      totals[key] = 5;
+      expect(totals[key]).to.equal(5);
+    });
+
+    test('can be set to zero', async () => {
+      totals[key] = 0;
+      expect(totals[key]).to.equal(0);
+    });
+
+    test('cannot be set to a decimal', async () => {
+      const func = () => { totals[key] = 0.55; };
+      expect(func).to.throw();
+    });
+
+    test('cannot be set to a negative number', async () => {
+      const func = () => { totals[key] = -1; };
+      expect(func).to.throw();
+    });
+  });
+
+  [
+    'creditNoteCount',
+    'creditNoteValue',
+    'invoiceCount',
+    'invoiceValue',
+    'creditLineCount',
+    'creditLineValue',
+    'debitLineCount',
+    'debitLineValue',
+    'netTotal'
+  ].map(positiveOrZeroIntegerExperiment);
+});

--- a/test/lib/models/totals.js
+++ b/test/lib/models/totals.js
@@ -32,15 +32,61 @@ experiment('lib/models/totals', () => {
     });
   });
 
+  const negativeOrZeroIntegerExperiment = key => experiment(`.${key}`, () => {
+    test('can be set to negative integer', async () => {
+      totals[key] = -5;
+      expect(totals[key]).to.equal(-5);
+    });
+
+    test('can be set to zero', async () => {
+      totals[key] = 0;
+      expect(totals[key]).to.equal(0);
+    });
+
+    test('cannot be set to a decimal', async () => {
+      const func = () => { totals[key] = -0.55; };
+      expect(func).to.throw();
+    });
+
+    test('cannot be set to a positive number', async () => {
+      const func = () => { totals[key] = 1; };
+      expect(func).to.throw();
+    });
+  });
+
   [
     'creditNoteCount',
-    'creditNoteValue',
     'invoiceCount',
     'invoiceValue',
     'creditLineCount',
-    'creditLineValue',
     'debitLineCount',
-    'debitLineValue',
-    'netTotal'
+    'debitLineValue'
   ].map(positiveOrZeroIntegerExperiment);
+
+  [
+    'creditNoteValue',
+    'creditLineValue'
+  ].map(negativeOrZeroIntegerExperiment);
+
+  experiment('.netTotal', () => {
+    test('can be set to positive integer', async () => {
+      totals.netTotal = 5;
+      expect(totals.netTotal).to.equal(5);
+    });
+
+    test('can be set to zero', async () => {
+      totals.netTotal = 0;
+      expect(totals.netTotal).to.equal(0);
+    });
+
+    test('cannot be set to a decimal', async () => {
+      const func = () => { totals.netTotal = 0.55; };
+      expect(func).to.throw();
+    });
+
+    test('can be set to a negative number', async () => {
+      totals.netTotal = -1;
+      expect(totals.netTotal).to.equal(-1);
+    });
+  });
 });

--- a/test/modules/billing/mappers/api/invoice.js
+++ b/test/modules/billing/mappers/api/invoice.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
+
+const Company = require('../../../../../src/lib/models/company');
+const Invoice = require('../../../../../src/lib/models/invoice');
+const InvoiceAccount = require('../../../../../src/lib/models/invoice-account');
+const InvoiceLicence = require('../../../../../src/lib/models/invoice-licence');
+const Licence = require('../../../../../src/lib/models/licence');
+const Totals = require('../../../../../src/lib/models/totals');
+
+const apiInvoiceMapper = require('../../../../../src/modules/billing/mappers/api/invoice');
+
+const INVOICE_ID = uuid();
+
+const createInvoice = () => {
+  const invoice = new Invoice(INVOICE_ID);
+  invoice.invoiceAccount = new InvoiceAccount();
+  invoice.invoiceAccount.accountNumber = 'A12345678A';
+  invoice.invoiceAccount.company = new Company();
+  invoice.invoiceAccount.company.name = 'Test Co Ltd.';
+  invoice.invoiceLicences = [
+    new InvoiceLicence()
+  ];
+  const licence = new Licence();
+  licence.licenceNumber = '01/123/ABC';
+  invoice.invoiceLicences[0].licence = licence;
+  invoice.totals = new Totals();
+  invoice.totals.netTotal = 3634654;
+  return invoice;
+};
+
+experiment('modules/billing/mappers/api/invoice', () => {
+  let result, invoice;
+  beforeEach(async () => {
+    invoice = createInvoice();
+    result = apiInvoiceMapper.modelToBatchInvoices(invoice);
+  });
+
+  test('the model is mapped to the API response shape', async () => {
+    expect(result).to.equal({
+      id: INVOICE_ID,
+      accountNumber: 'A12345678A',
+      name: 'Test Co Ltd.',
+      netTotal: 3634654,
+      licenceNumbers: ['01/123/ABC']
+    });
+  });
+});

--- a/test/modules/billing/pre-handlers.js
+++ b/test/modules/billing/pre-handlers.js
@@ -27,7 +27,7 @@ experiment('modules/billing/pre-handlers', () => {
     batch = new Batch();
     batch.fromHash({
       id: '7bfdb410-8fe2-41df-bb3a-e85984112f3b',
-      status: 'complete'
+      status: 'ready'
     });
     batch.region = new Region();
     batch.region.fromHash({

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -134,6 +134,16 @@ experiment('modules/billing/services/batch-service', () => {
         expect(result.status).to.equal(data.batch.status);
       });
     });
+
+    experiment('when no batch is found', () => {
+      beforeEach(async () => {
+        newRepos.billingBatches.findOne.resolves(null);
+        result = await batchService.getBatchById(BATCH_ID);
+      });
+      test('resolves null', async () => {
+        expect(result).to.be.null();
+      });
+    });
   });
 
   experiment('.getBatches', () => {

--- a/test/modules/billing/services/invoice-service.js
+++ b/test/modules/billing/services/invoice-service.js
@@ -115,7 +115,7 @@ const createChargeModuleData = () => ({
         {
           financialYear: 2020,
           creditLineCount: 3,
-          creditLineValue: 15324,
+          creditLineValue: -15324,
           debitLineCount: 4,
           debitLineValue: 234,
           netTotal: -15090
@@ -197,7 +197,7 @@ experiment('modules/billing/services/invoiceService', () => {
       const { totals } = invoices[1];
 
       expect(totals.creditLineCount).to.equal(3);
-      expect(totals.creditLineValue).to.equal(15324);
+      expect(totals.creditLineValue).to.equal(-15324);
       expect(totals.debitLineCount).to.equal(10);
       expect(totals.debitLineValue).to.equal(120267);
       expect(totals.netTotal).to.equal(104943);

--- a/test/modules/billing/services/invoice-service.js
+++ b/test/modules/billing/services/invoice-service.js
@@ -31,6 +31,12 @@ let invoiceAccount2;
 
 const BATCH_ID = '00000000-0000-0000-0000-000000000000';
 
+const REGION_ID = '00000000-0000-0000-0000-000000000001';
+const REGION_NAME = 'Anglian';
+const CHARGE_REGION_ID = 'A';
+
+const LICENCE_ID = '00000000-0000-0000-0000-000000000002';
+
 const createBatchData = () => ({
   batchId: BATCH_ID,
   region: {
@@ -38,10 +44,45 @@ const createBatchData = () => ({
   },
   billingInvoices: [{
     invoiceAccountId: INVOICE_1_ACCOUNT_ID,
-    invoiceAccountNumber: INVOICE_1_ACCOUNT_NUMBER
+    invoiceAccountNumber: INVOICE_1_ACCOUNT_NUMBER,
+    billingInvoiceLicences: [{
+      licence: {
+        licenceId: LICENCE_ID,
+        licenceRef: '01/123/ABC',
+        regions: { historicalAreaCode: 'ARCA', regionalChargeArea: 'Anglian' },
+        region: {
+          regionId: REGION_ID,
+          name: REGION_NAME,
+          chargeRegionId: CHARGE_REGION_ID
+        }
+      }
+    }, {
+      licence: {
+        licenceId: LICENCE_ID,
+        licenceRef: '02/345',
+        regions: { historicalAreaCode: 'ARCA', regionalChargeArea: 'Anglian' },
+        region: {
+          regionId: REGION_ID,
+          name: REGION_NAME,
+          chargeRegionId: CHARGE_REGION_ID
+        }
+      }
+    }]
   }, {
     invoiceAccountId: INVOICE_2_ACCOUNT_ID,
-    invoiceAccountNumber: INVOICE_2_ACCOUNT_NUMBER
+    invoiceAccountNumber: INVOICE_2_ACCOUNT_NUMBER,
+    billingInvoiceLicences: [{
+      licence: {
+        licenceId: LICENCE_ID,
+        licenceRef: '04/563',
+        regions: { historicalAreaCode: 'ARCA', regionalChargeArea: 'Anglian' },
+        region: {
+          regionId: REGION_ID,
+          name: REGION_NAME,
+          chargeRegionId: CHARGE_REGION_ID
+        }
+      }
+    }]
   }]
 });
 


### PR DESCRIPTION
- Uses Charge Module summary API to provide batch level/invoice level totals in batch invoices API call.
- Removes envelope from batch invoices API response 
- Adjusts the pre-handler to attach a Batch model instance to the request rather than a POJO from the database response.
- Adjusts single batch endpoint to return Batch model instance without envelope