### PR TITLE
Feat: Updates batch creation for better 409 response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5339,7 +5339,7 @@
         },
         "jsonwebtoken": {
           "version": "8.2.1",
-          "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
           "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
           "requires": {
             "jws": "^3.1.4",

--- a/src/lib/connectors/repos/billing-batches.js
+++ b/src/lib/connectors/repos/billing-batches.js
@@ -13,8 +13,7 @@ const findOne = async (id) => {
     });
 
   return model.toJSON();
-}
-;
+};
 
 const findPage = async (page, pageSize) => {
   const result = await BillingBatch
@@ -28,6 +27,15 @@ const findPage = async (page, pageSize) => {
       ]
     });
   return paginatedEnvelope(result);
+};
+
+const findByStatus = async status => {
+  const batches = await BillingBatch
+    .forge()
+    .where({ status })
+    .fetchAll({ withRelated: ['region'] });
+
+  return batches.toJSON();
 };
 
 /**
@@ -50,6 +58,7 @@ const deleteById = batchId => BillingBatch
   .destroy();
 
 exports.delete = deleteById;
+exports.findByStatus = findByStatus;
 exports.findOne = findOne;
 exports.findPage = findPage;
 exports.update = update;

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -5,7 +5,7 @@ const Boom = require('@hapi/boom');
 const config = require('../../../config');
 const repos = require('../../lib/connectors/repository');
 const event = require('../../lib/event');
-const { envelope, errorEnvelope } = require('../../lib/response');
+const { envelope } = require('../../lib/response');
 const populateBatchChargeVersionsJob = require('./jobs/populate-batch-charge-versions');
 const { jobStatus } = require('./lib/batch');
 const invoiceService = require('./services/invoice-service');
@@ -51,7 +51,10 @@ const postCreateBatch = async (request, h) => {
   const batch = await createBatch(regionId, batchType, financialYearEnding, season);
 
   if (!batch) {
-    const data = errorEnvelope(`Batch already processing for region ${regionId}`);
+    const data = {
+      message: `Batch already processing for region ${regionId}`,
+      existingBatch: await batchService.getProcessingBatchByRegion(regionId)
+    };
     return h.response(data).code(409);
   }
 

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -32,6 +32,12 @@ const getBatches = async (page = 1, perPage = Number.MAX_SAFE_INTEGER) => {
   };
 };
 
+const getProcessingBatchByRegion = async regionId => {
+  const batches = await newRepos.billingBatches.findByStatus(BATCH_STATUS.processing);
+  const batch = batches.find(b => b.regionId === regionId);
+  return batch ? mappers.batch.dbToModel(batch) : null;
+};
+
 const saveEvent = (type, status, user, batch) => {
   return event.save(event.create({
     issuer: user.email,
@@ -117,8 +123,9 @@ const saveInvoicesToDB = async batch => {
 
 exports.approveBatch = approveBatch;
 exports.deleteBatch = deleteBatch;
-exports.getBatchById = getBatchById;
 exports.getBatches = getBatches;
+exports.getBatchById = getBatchById;
+exports.getProcessingBatchByRegion = getProcessingBatchByRegion;
 exports.saveInvoicesToDB = saveInvoicesToDB;
 exports.setErrorStatus = setErrorStatus;
 exports.setStatus = setStatus;

--- a/test/lib/connectors/repos/billing-batches.js
+++ b/test/lib/connectors/repos/billing-batches.js
@@ -29,9 +29,11 @@ experiment('lib/connectors/repos/billing-batches', () => {
 
     stub = {
       fetch: sandbox.stub().resolves(model),
+      fetchAll: sandbox.stub().resolves(model),
       orderBy: sandbox.stub().returnsThis(),
       fetchPage: sandbox.stub().resolves(model),
       set: sandbox.stub().returnsThis(),
+      where: sandbox.stub().returnsThis(),
       save: sandbox.stub().resolves(model),
       destroy: sandbox.spy()
     };
@@ -101,6 +103,29 @@ experiment('lib/connectors/repos/billing-batches', () => {
         perPage: 15,
         totalRows: 53
       });
+    });
+  });
+
+  experiment('.findByStatus', () => {
+    beforeEach(async () => {
+      await billingBatches.findByStatus('processing');
+    });
+
+    test('calls model.forge with no arguments', async () => {
+      const { args } = BillingBatch.forge.lastCall;
+      expect(args).to.equal([]);
+    });
+
+    test('calls where() to filter by status', async () => {
+      const [params] = stub.where.lastCall.args;
+      expect(params).to.equal({
+        status: 'processing'
+      });
+    });
+
+    test('calls fetchAll() with the relationships', async () => {
+      const [options] = stub.fetchAll.lastCall.args;
+      expect(options.withRelated).to.equal(['region']);
     });
   });
 

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -37,6 +37,7 @@ const batch = {
   billingBatchId: BATCH_ID,
   batchType: 'supplementary',
   season: 'summer',
+  regionId: region.regionId,
   fromFinancialYearEnding: 2014,
   toFinancialYearEnding: 2019,
   status: 'processing',
@@ -55,6 +56,7 @@ experiment('modules/billing/services/batch-service', () => {
   beforeEach(async () => {
     sandbox.stub(logger, 'error');
 
+    sandbox.stub(newRepos.billingBatches, 'findByStatus').resolves(data.batch);
     sandbox.stub(newRepos.billingBatches, 'findOne').resolves(data.batch);
     sandbox.stub(newRepos.billingBatches, 'findPage').resolves();
     sandbox.stub(newRepos.billingBatches, 'update').resolves();
@@ -522,6 +524,53 @@ experiment('modules/billing/services/batch-service', () => {
 
     test('the transaction model is updated with the returned ID', async () => {
       expect(models.transaction.id).to.equal(billingTransactionId);
+    });
+  });
+
+  experiment('.getProcessingBatchByRegion', () => {
+    let result;
+    let regionId;
+
+    beforeEach(async () => {
+      regionId = '44444444-0000-0000-0000-000000000000';
+      newRepos.billingBatches.findByStatus.resolves([
+        {
+          billingBatchId: '11111111-0000-0000-0000-000000000000',
+          regionId: '22222222-0000-0000-0000-000000000000',
+          batchType: 'supplementary',
+          season: 'all year',
+          status: 'processing',
+          region: {
+            regionId: '22222222-0000-0000-0000-000000000000',
+            chargeRegionId: 'A',
+            naldRegionId: 1,
+            name: 'Anglian'
+          }
+        },
+        {
+          billingBatchId: '33333333-0000-0000-0000-000000000000',
+          regionId: '44444444-0000-0000-0000-000000000000',
+          batchType: 'supplementary',
+          season: 'all year',
+          status: 'processing',
+          region: {
+            regionId: '22222222-0000-0000-0000-000000000000',
+            chargeRegionId: 'A',
+            naldRegionId: 1,
+            name: 'Anglian'
+          }
+        }
+      ]);
+
+      result = await batchService.getProcessingBatchByRegion(regionId);
+    });
+
+    test('returns the expected batch', async () => {
+      expect(result.id).to.equal('33333333-0000-0000-0000-000000000000');
+    });
+
+    test('returns a srvice layer model', async () => {
+      expect(result).to.be.instanceOf(Batch);
     });
   });
 });


### PR DESCRIPTION
WATER-2510

In order to provide more detail in the front end, this change updates
the endpoint responsible for creating a new batch so that if there is
already a batch that is processing for the region, a 409 is returned
including the batch that is already processing.