### PR TITLE
Fixes issue with status of water.billing_batch_charge_version_years

### DIFF
--- a/src/lib/connectors/bookshelf/BillingBatchChargeVersionYear.js
+++ b/src/lib/connectors/bookshelf/BillingBatchChargeVersionYear.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const { bookshelf } = require('./bookshelf.js');
+
+module.exports = bookshelf.model('ChargeVersionYear', {
+  idAttribute: 'billing_batch_charge_version_year_id',
+  tableName: 'billing_batch_charge_version_years',
+  hasTimestamps: ['date_created', 'date_updated']
+});

--- a/src/lib/connectors/bookshelf/index.js
+++ b/src/lib/connectors/bookshelf/index.js
@@ -1,4 +1,5 @@
 exports.BillingBatch = require('./BillingBatch');
+exports.BillingBatchChargeVersionYear = require('./BillingBatchChargeVersionYear');
 exports.BillingInvoice = require('./BillingInvoice');
 exports.BillingInvoiceLicence = require('./BillingInvoiceLicence');
 exports.BillingTransaction = require('./BillingTransaction');

--- a/src/lib/connectors/repos/billing-batch-charge-version-years.js
+++ b/src/lib/connectors/repos/billing-batch-charge-version-years.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { BillingBatchChargeVersionYear } = require('../bookshelf');
+
+const setStatus = (id, status) =>
+  BillingBatchChargeVersionYear
+    .forge({ billingBatchChargeVersionYearId: id })
+    .save({ status });
+
+exports.setStatus = setStatus;

--- a/src/lib/connectors/repos/billing-batch-charge-version-years.js
+++ b/src/lib/connectors/repos/billing-batch-charge-version-years.js
@@ -2,9 +2,9 @@
 
 const { BillingBatchChargeVersionYear } = require('../bookshelf');
 
-const setStatus = (id, status) =>
+const update = (id, data) =>
   BillingBatchChargeVersionYear
     .forge({ billingBatchChargeVersionYearId: id })
-    .save({ status });
+    .save(data);
 
-exports.setStatus = setStatus;
+exports.update = update;

--- a/src/lib/connectors/repos/index.js
+++ b/src/lib/connectors/repos/index.js
@@ -1,4 +1,5 @@
 exports.billingBatches = require('./billing-batches');
+exports.billingBatchChargeVersionYears = require('./billing-batch-charge-version-years');
 exports.billingInvoices = require('./billing-invoices');
 exports.billingInvoiceLicences = require('./billing-invoice-licences');
 exports.billingTransactions = require('./billing-transactions');

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -13,7 +13,7 @@ join (
   where b.billing_batch_id=:batchId
 ) il_2 on il.licence_id=il_2.licence_id
 where 
-  b.status='complete' 
+  b.status='sent' 
   and b.billing_batch_id<>:batchId
   and b.batch_type<>'two_part_tariff' 
   and t.start_date>=il_2.min_date

--- a/src/lib/connectors/repository/BillingBatchChargeVersionYearsRepository.js
+++ b/src/lib/connectors/repository/BillingBatchChargeVersionYearsRepository.js
@@ -10,13 +10,6 @@ class BillingBatchChargeVersionYearsRepository extends Repository {
     }, config));
   }
 
-  setStatus (id, status) {
-    return this.update(
-      { billing_batch_charge_version_year_id: id },
-      { status, date_updated: new Date() }
-    );
-  }
-
   /**
    * Finds all rows in the water.billing_batch_charge_version_years table for
    * a given billing_batch_id where the status is 'processing'

--- a/src/lib/models/charge-version-year.js
+++ b/src/lib/models/charge-version-year.js
@@ -1,0 +1,18 @@
+/**
+ * For now this doesn't implement the full model,
+ * however following the pattern for batches, the available
+ * statuses would be defined here.
+ */
+
+/**
+ * Statuses that a charge version year (water.billing_batch_charge_version_years) may have. These
+ * are here to help enforce that only one batch per region may
+ * be run at a time.
+ */
+const CHARGE_VERSION_YEAR_STATUS = {
+  processing: 'processing', // processing trasactions
+  ready: 'ready', // processing completed - awaiting approval
+  error: 'error'
+};
+
+module.exports.CHARGE_VERSION_YEAR_STATUS = CHARGE_VERSION_YEAR_STATUS;

--- a/src/modules/billing/jobs/process-charge-version.js
+++ b/src/modules/billing/jobs/process-charge-version.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const evt = require('../../../lib/event');
-const { jobStatus } = require('../lib/batch');
-const repos = require('../../../lib/connectors/repository');
 const service = require('../service');
+const chargeVersionYearService = require('../services/charge-version-year');
 const { logger } = require('../../../logger');
 
 const JOB_NAME = 'billing.process-charge-version';
@@ -33,7 +32,7 @@ const handleProcessChargeVersion = async job => {
     await service.chargeVersionYear.persistChargeVersionYearBatch(batch);
 
     // Update status in water.billing_batch_charge_version_year
-    await repos.billingBatchChargeVersionYears.setStatus(chargeVersionYear.billing_batch_charge_version_year_id, jobStatus.complete);
+    await chargeVersionYearService.setReadyStatus(chargeVersionYear.billing_batch_charge_version_year_id);
 
     return {
       chargeVersionYear,
@@ -45,7 +44,7 @@ const handleProcessChargeVersion = async job => {
       chargeVersionYear
     });
     // Mark as error
-    await repos.billingBatchChargeVersionYears.setStatus(chargeVersionYear.billing_batch_charge_version_year_id, jobStatus.error);
+    await chargeVersionYearService.setErrorStatus(chargeVersionYear.billing_batch_charge_version_year_id);
     // Rethrow
     throw err;
   }

--- a/src/modules/billing/services/charge-version-year.js
+++ b/src/modules/billing/services/charge-version-year.js
@@ -1,11 +1,21 @@
-const newRepos = require('../../../lib/connectors/repos');
+const repos = require('../../../lib/connectors/repos');
 const { CHARGE_VERSION_YEAR_STATUS } = require('../../../lib/models/charge-version-year.js');
 
+/**
+ * Sets water.billing_batch_charge_version_years to "ready"
+ * @param {String} id
+ * @return {Promise}
+ */
 const setReadyStatus = id =>
-  newRepos.billingBatchChargeVersionYears.setStatus(id, CHARGE_VERSION_YEAR_STATUS.ready);
+  repos.billingBatchChargeVersionYears.update(id, { status: CHARGE_VERSION_YEAR_STATUS.ready });
 
+/**
+ * Sets water.billing_batch_charge_version_years to "error"
+ * @param {String} id
+ * @return {Promise}
+ */
 const setErrorStatus = id =>
-  newRepos.billingBatchChargeVersionYears.setStatus(id, CHARGE_VERSION_YEAR_STATUS.error);
+  repos.billingBatchChargeVersionYears.update(id, { status: CHARGE_VERSION_YEAR_STATUS.error });
 
 exports.setReadyStatus = setReadyStatus;
 exports.setErrorStatus = setErrorStatus;

--- a/src/modules/billing/services/charge-version-year.js
+++ b/src/modules/billing/services/charge-version-year.js
@@ -1,0 +1,11 @@
+const newRepos = require('../../../lib/connectors/repos');
+const { CHARGE_VERSION_YEAR_STATUS } = require('../../../lib/models/charge-version-year.js');
+
+const setReadyStatus = id =>
+  newRepos.billingBatchChargeVersionYears.setStatus(id, CHARGE_VERSION_YEAR_STATUS.ready);
+
+const setErrorStatus = id =>
+  newRepos.billingBatchChargeVersionYears.setStatus(id, CHARGE_VERSION_YEAR_STATUS.error);
+
+exports.setReadyStatus = setReadyStatus;
+exports.setErrorStatus = setErrorStatus;

--- a/test/lib/connectors/repos/billing-batch-charge-version-years.js
+++ b/test/lib/connectors/repos/billing-batch-charge-version-years.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const repos = require('../../../../src/lib/connectors/repos');
+const { BillingBatchChargeVersionYear } = require('../../../../src/lib/connectors/bookshelf');
+
+experiment('lib/connectors/repos/billing-batch-charge-version-year', () => {
+  let model, stub;
+
+  beforeEach(async () => {
+    model = {
+      toJSON: sandbox.stub().returns({ foo: 'bar' })
+    };
+    stub = {
+      save: sandbox.stub().resolves(model)
+    };
+    sandbox.stub(BillingBatchChargeVersionYear, 'forge').returns(stub);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.update', () => {
+    const data = {
+      status: 'complete'
+    };
+    const testId = 'test-id';
+    beforeEach(async () => {
+      await repos.billingBatchChargeVersionYears.update(testId, data);
+    });
+
+    test('calls model.forge with correct id', async () => {
+      const [params] = BillingBatchChargeVersionYear.forge.lastCall.args;
+      expect(params).to.equal({ billingBatchChargeVersionYearId: testId });
+    });
+
+    test('calls save() with the supplied data', async () => {
+      const [params] = stub.save.lastCall.args;
+      expect(params).to.equal(data);
+    });
+  });
+});

--- a/test/lib/connectors/repository/BillingBatchChargeVersionYearsRepository.js
+++ b/test/lib/connectors/repository/BillingBatchChargeVersionYearsRepository.js
@@ -21,29 +21,6 @@ experiment('lib/connectors/repository/BillingBatchChargeVersionYearsRepository',
     sandbox.restore();
   });
 
-  experiment('.setStatus', () => {
-    test('updates by billing_batch_charge_version_year_id', async () => {
-      const repo = new BillingBatchChargeVersionYearsRepository();
-      await repo.setStatus('test-id', 'complete');
-
-      const [filter] = repo.update.lastCall.args;
-
-      expect(filter).to.equal({
-        billing_batch_charge_version_year_id: 'test-id'
-      });
-    });
-
-    test('updates the status', async () => {
-      const repo = new BillingBatchChargeVersionYearsRepository();
-      await repo.setStatus('test-id', 'complete');
-
-      const [, newData] = repo.update.lastCall.args;
-
-      expect(newData.status).to.equal('complete');
-      expect(newData.date_updated).to.be.a.date();
-    });
-  });
-
   experiment('.findProcessingByBatch', () => {
     test('searches by billing_batch_id', async () => {
       const repo = new BillingBatchChargeVersionYearsRepository();

--- a/test/lib/models/charge-element-year.js
+++ b/test/lib/models/charge-element-year.js
@@ -1,0 +1,13 @@
+const { experiment, test } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const ChargeVersionYear = require('../../../src/lib/models/charge-version-year');
+
+experiment('lib/models/charge-version-year', () => {
+  experiment('.CHARGE_VERSION_YEAR_STATUS', () => {
+    test('contains the expected keys for each status', async () => {
+      expect(Object.keys(ChargeVersionYear.CHARGE_VERSION_YEAR_STATUS))
+        .to.only.include(['processing', 'ready', 'error']);
+    });
+  });
+});

--- a/test/modules/billing/services/charge-version-year.js
+++ b/test/modules/billing/services/charge-version-year.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+const uuid = require('uuid/v4');
+
+const repos = require('../../../../src/lib/connectors/repos');
+const chargeVersionYearService = require('../../../../src/modules/billing/services/charge-version-year');
+
+const TEST_ID = uuid();
+
+experiment('modules/billing/services/charge-version-year', () => {
+  beforeEach(async () => {
+    sandbox.stub(repos.billingBatchChargeVersionYears, 'update').resolves();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.setReadyStatus', () => {
+    beforeEach(async () => {
+      await chargeVersionYearService.setReadyStatus(TEST_ID);
+    });
+
+    test('calls repo update() method with correct arguments', async () => {
+      const [id, data] = repos.billingBatchChargeVersionYears.update.lastCall.args;
+      expect(id).to.equal(TEST_ID);
+      expect(data).to.equal({
+        status: 'ready'
+      });
+    });
+  });
+
+  experiment('.setErrorStatus', () => {
+    beforeEach(async () => {
+      await chargeVersionYearService.setErrorStatus(TEST_ID);
+    });
+
+    test('calls repo update() method with correct arguments', async () => {
+      const [id, data] = repos.billingBatchChargeVersionYears.update.lastCall.args;
+      expect(id).to.equal(TEST_ID);
+      expect(data).to.equal({
+        status: 'error'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Some recent work has renamed the batch statuses, and also the enum type in the database.
This type was also used for the charge version year status, however this code had not been updated.
This PR:

- Begins work on a Bookshelf repo for charge version years
- Creates a service for it
- Updates the job to use the new service