### PR TITLE
Bugfix/water 2530 batch total

### DIFF
--- a/migrations/20200214170503-batch-totals.js
+++ b/migrations/20200214170503-batch-totals.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200214170503-batch-totals-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200214170503-batch-totals-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200214170503-batch-totals-down.sql
+++ b/migrations/sqls/20200214170503-batch-totals-down.sql
@@ -1,0 +1,12 @@
+/* Replace with your SQL commands */
+alter table water.billing_batches
+  drop column invoice_count;
+
+alter table water.billing_batches
+  drop column credit_note_count;
+
+alter table water.billing_batches
+  drop column net_total;
+
+alter table water.billing_batches
+  drop column external_id;

--- a/migrations/sqls/20200214170503-batch-totals-up.sql
+++ b/migrations/sqls/20200214170503-batch-totals-up.sql
@@ -1,0 +1,12 @@
+/* Replace with your SQL commands */
+alter table water.billing_batches
+  add column invoice_count int;
+
+alter table water.billing_batches
+  add column credit_note_count int;
+
+alter table water.billing_batches
+  add column net_total bigint;
+
+alter table water.billing_batches
+  add column external_id int;

--- a/src/lib/connectors/repos/billing-transactions.js
+++ b/src/lib/connectors/repos/billing-transactions.js
@@ -80,9 +80,12 @@ const create = async data => {
   return model.toJSON();
 };
 
+const findStatusCountsByBatchId = batchId => raw.multiRow(queries.findStatusCountsByBatchId, { batchId });
+
 exports.findOne = findOne;
 exports.find = find;
 exports.findHistoryByBatchId = findHistoryByBatchId;
 exports.findByBatchId = findByBatchId;
 exports.delete = deleteRecords;
 exports.create = create;
+exports.findStatusCountsByBatchId = findStatusCountsByBatchId;

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -29,3 +29,14 @@ join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
 where b.billing_batch_id=:batchId
 `
 ;
+
+exports.findStatusCountsByBatchId = `
+select t.status, count(t.status)
+  from water.billing_batches b 
+  join water.billing_invoices i on b.billing_batch_id=i.billing_batch_id
+  join water.billing_invoice_licences il on i.billing_invoice_id=il.billing_invoice_id
+  join water.billing_transactions t on t.billing_invoice_licence_id=il.billing_invoice_licence_id
+  where b.billing_batch_id=:batchId
+  group by t.status
+`
+;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -140,6 +140,14 @@ class Batch extends Model {
     return this._dateCreated;
   }
 
+  set dateUpdated (value) {
+    this._dateUpdated = this.getDateTimeFromValue(value);
+  }
+
+  get dateUpdated () {
+    return this._dateUpdated;
+  }
+
   /**
    * Adds a single invoice to the batch
    * @return {Invoice}

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -8,7 +8,7 @@ const Totals = require('./totals');
 const { assert } = require('@hapi/hoek');
 const { isArray } = require('lodash');
 
-const { assertIsInstanceOf, assertEnum, assertIsArrayOfType } = require('./validators');
+const { assertIsInstanceOf, assertEnum, assertIsArrayOfType, assertPositiveInteger } = require('./validators');
 
 /**
  * Statuses that the batch (water.billing_batches) may have. These
@@ -217,6 +217,20 @@ class Batch extends Model {
 
   get totals () {
     return this._totals;
+  }
+
+  /**
+   * Sets the region for the batch.
+   * A batch can only be related to a single region at present
+   * @return {Region}
+   */
+  get externalId () {
+    return this._externalId;
+  }
+
+  set externalId (externalId) {
+    assertPositiveInteger(externalId);
+    this._externalId = externalId;
   }
 }
 

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -220,8 +220,7 @@ class Batch extends Model {
   }
 
   /**
-   * Sets the region for the batch.
-   * A batch can only be related to a single region at present
+   * Sets the external ID.  This is the bill run ID in the charge module.
    * @return {Region}
    */
   get externalId () {

--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -21,7 +21,7 @@ const handleCreateChargeComplete = async (job, messageQueue) => {
   logger.info(`onComplete - ${createChargeJob.jobName}`);
 
   try {
-    if (await isProcessingTransactions()) {
+    if (await isProcessingTransactions(batchId)) {
       return;
     }
 

--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -3,26 +3,43 @@
 const createChargeJob = require('./create-charge');
 const jobService = require('../services/job-service');
 
+const batchService = require('../services/batch-service');
+
 const { logger } = require('../../../logger');
 
 const handleCreateChargeComplete = async job => {
+  const { eventId } = job.data.request.data;
+  const { billing_batch_id: batchId } = job.data.response.batch;
+
   logger.info(`onComplete - ${createChargeJob.jobName}`);
 
-  /**
-   * Placeholder
-   *
-   * Find billing_transactions for the batch that are
-   * not completed
-   *
-   * If there are transactions left to process do nothing
-   *
-   * If there are no more transactions to process then
-   * the batch is complete. Update the batch status and the
-   * event status
-   */
-  const { eventId } = job.data.request.data;
-  const { batch } = job.data.response;
-  await jobService.setReadyJob(eventId, batch.billing_batch_id);
+  try {
+    const batch = await batchService.getBatchById(batchId);
+
+    // Update batch with totals/bill run ID from charge module
+    await batchService.refreshTotals(batch);
+
+    /**
+     * Placeholder
+     *
+     * Find billing_transactions for the batch that are
+     * not completed
+     *
+     * If there are transactions left to process do nothing
+     *
+     * If there are no more transactions to process then
+     * the batch is complete. Update the batch status and the
+     * event status
+     */
+
+    await jobService.setReadyJob(eventId, batch.id);
+  } catch (err) {
+    logger.error(`Error handling ${createChargeJob.jobName}`, err, {
+      batchId
+    });
+    await batchService.setErrorStatus(batchId);
+    throw err;
+  }
 };
 
 module.exports = handleCreateChargeComplete;

--- a/src/modules/billing/jobs/index.js
+++ b/src/modules/billing/jobs/index.js
@@ -17,3 +17,7 @@ exports.createCharge = {
   job: require('./create-charge'),
   onCompleteHandler: require('./create-charge-complete')
 };
+
+exports.refreshTotals = {
+  job: require('./refresh-totals')
+};

--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -1,0 +1,46 @@
+const { get } = require('lodash');
+const { logger } = require('../../../logger');
+const batchService = require('../services/batch-service');
+
+const JOB_NAME = 'billing.refreshTotals';
+
+/**
+ * Calls the CM to refresh the totals in water.billing_batches table
+ *
+ * @param {String} eventId The UUID of the event
+ * @param {Object} batch The object from the batch database table
+ */
+const createMessage = (eventId, batch) => ({
+  name: JOB_NAME,
+  data: { eventId, batch },
+  options: {
+    singletonKey: batch.billing_batch_id
+  }
+});
+
+const handleRefreshTotals = async job => {
+  logger.info(`Handling ${JOB_NAME}`);
+
+  const batchId = get(job, 'data.batch.billing_batch_id');
+
+  try {
+    const batch = await batchService.getBatchById(batchId);
+
+    // Update batch with totals/bill run ID from charge module
+    await batchService.refreshTotals(batch);
+  } catch (err) {
+    // Log error
+    logger.error(`${JOB_NAME} error`, err, {
+      batchId
+    });
+    throw err;
+  }
+
+  return {
+    batch: job.data.batch
+  };
+};
+
+exports.jobName = JOB_NAME;
+exports.createMessage = createMessage;
+exports.handler = handleRefreshTotals;

--- a/src/modules/billing/mappers/batch.js
+++ b/src/modules/billing/mappers/batch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { pick, compact, pickBy } = require('lodash');
+const { pick } = require('lodash');
 
 const Batch = require('../../../lib/models/batch');
 const FinancialYear = require('../../../lib/models/financial-year');

--- a/src/modules/billing/mappers/totals.js
+++ b/src/modules/billing/mappers/totals.js
@@ -40,7 +40,9 @@ const sumProperties = arr => arr.reduce((acc, row) => {
  * @return {Totals} - totals for the supplied invoice account
  */
 const chargeModuleBillRunToInvoiceModel = (billRun, invoiceAccountNumber) => {
-  const customer = find(billRun.customers, row => row.customerReference === invoiceAccountNumber);
+  const customer = find(billRun.customers, { customerReference: invoiceAccountNumber });
+
+  // row => row.customerReference === invoiceAccountNumber);
   if (!customer) {
     return null;
   }
@@ -61,7 +63,7 @@ const chargeModuleBillRunToInvoiceModel = (billRun, invoiceAccountNumber) => {
  * @return {Totals}
  */
 const dbToModel = row => {
-  if (!row.externalId) {
+  if (row.externalId === null) {
     return null;
   }
   const totals = new Totals();

--- a/src/modules/billing/mappers/totals.js
+++ b/src/modules/billing/mappers/totals.js
@@ -55,5 +55,20 @@ const chargeModuleBillRunToInvoiceModel = (billRun, invoiceAccountNumber) => {
   ]);
 };
 
+/**
+ * Maps a partial set of fields in water.billing_batches table to a Totals model
+ * @param {Object} row - row of data from water.billing_batches table
+ * @return {Totals}
+ */
+const dbToModel = row => {
+  if (!row.externalId) {
+    return null;
+  }
+  const totals = new Totals();
+  totals.pickFrom(row, ['creditNoteCount', 'invoiceCount', 'netTotal']);
+  return totals;
+};
+
 exports.chargeModuleBillRunToBatchModel = chargeModuleBillRunToBatchModel;
 exports.chargeModuleBillRunToInvoiceModel = chargeModuleBillRunToInvoiceModel;
+exports.dbToModel = dbToModel;

--- a/src/modules/billing/mappers/totals.js
+++ b/src/modules/billing/mappers/totals.js
@@ -42,7 +42,6 @@ const sumProperties = arr => arr.reduce((acc, row) => {
 const chargeModuleBillRunToInvoiceModel = (billRun, invoiceAccountNumber) => {
   const customer = find(billRun.customers, { customerReference: invoiceAccountNumber });
 
-  // row => row.customerReference === invoiceAccountNumber);
   if (!customer) {
     return null;
   }

--- a/src/modules/billing/register-subscribers.js
+++ b/src/modules/billing/register-subscribers.js
@@ -25,5 +25,6 @@ module.exports = {
     await createSubscription(server, jobs.processChargeVersion);
     await createSubscription(server, jobs.prepareTransactions);
     await createSubscription(server, jobs.createCharge);
+    await createSubscription(server, jobs.refreshTotals);
   }
 };

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { camelCase } = require('lodash');
+
 const newRepos = require('../../../lib/connectors/repos');
 const mappers = require('../mappers');
 const repos = require('../../../lib/connectors/repository');
@@ -142,6 +144,19 @@ const refreshTotals = async batch => {
   });
 };
 
+/**
+ * Gets counts of the number of transactions in each status for the
+ * supplied batch ID
+ * @param {String} batchId
+ */
+const getTransactionStatusCounts = async batchId => {
+  const data = await newRepos.billingTransactions.findStatusCountsByBatchId(batchId);
+  return data.reduce((acc, row) => ({
+    ...acc,
+    [camelCase(row.status)]: row.count
+  }), {});
+};
+
 exports.approveBatch = approveBatch;
 exports.deleteBatch = deleteBatch;
 exports.getBatches = getBatches;
@@ -152,3 +167,4 @@ exports.setErrorStatus = setErrorStatus;
 exports.setStatus = setStatus;
 exports.decorateBatchWithTotals = decorateBatchWithTotals;
 exports.refreshTotals = refreshTotals;
+exports.getTransactionStatusCounts = getTransactionStatusCounts;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -127,6 +127,21 @@ const decorateBatchWithTotals = async batch => {
   return batch;
 };
 
+/**
+ * Updates water.billing_batches with summary info from the charge module
+ * @param {Batch} batch
+ * @return {Promise}
+ */
+const refreshTotals = async batch => {
+  const { billRunId, summary } = await chargeModuleBatchConnector.send(batch.region.code, batch.id, true);
+  return newRepos.billingBatches.update(batch.id, {
+    invoiceCount: summary.invoiceCount,
+    creditNoteCount: summary.creditNoteCount,
+    netTotal: summary.netTotal,
+    externalId: billRunId
+  });
+};
+
 exports.approveBatch = approveBatch;
 exports.deleteBatch = deleteBatch;
 exports.getBatches = getBatches;
@@ -136,3 +151,4 @@ exports.saveInvoicesToDB = saveInvoicesToDB;
 exports.setErrorStatus = setErrorStatus;
 exports.setStatus = setStatus;
 exports.decorateBatchWithTotals = decorateBatchWithTotals;
+exports.refreshTotals = refreshTotals;

--- a/test/lib/connectors/repos/billing-transactions.js
+++ b/test/lib/connectors/repos/billing-transactions.js
@@ -198,4 +198,16 @@ experiment('lib/connectors/repos/billing-transactions', () => {
       expect(result).to.equal({ foo: 'bar' });
     });
   });
+
+  experiment('.findStatusCountsByBatchId', () => {
+    beforeEach(async () => {
+      await billingTransactions.findStatusCountsByBatchId('batch-id');
+    });
+
+    test('performs multi-row query with correct params', async () => {
+      expect(raw.multiRow.calledWith(
+        queries.findStatusCountsByBatchId, { batchId: 'batch-id' }
+      )).to.be.true();
+    });
+  });
 });

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -358,4 +358,42 @@ experiment('lib/models/batch', () => {
       expect(func).to.throw();
     });
   });
+
+  experiment('.externalId', () => {
+    test('can be set to a positive integer', async () => {
+      const batch = new Batch();
+      batch.externalId = 123;
+      expect(batch.externalId).to.equal(123);
+    });
+
+    test('cannot be set to zero', async () => {
+      const batch = new Batch();
+      const func = () => { batch.externalId = 0; };
+      expect(func).to.throw();
+    });
+
+    test('cannot be set to a decimal', async () => {
+      const batch = new Batch();
+      const func = () => { batch.externalId = 43.55; };
+      expect(func).to.throw();
+    });
+
+    test('cannot be set to a string', async () => {
+      const batch = new Batch();
+      const func = () => { batch.externalId = 'hello'; };
+      expect(func).to.throw();
+    });
+
+    test('cannot be set to a negative integer', async () => {
+      const batch = new Batch();
+      const func = () => { batch.externalId = -45; };
+      expect(func).to.throw();
+    });
+
+    test('cannot be set to null', async () => {
+      const batch = new Batch();
+      const func = () => { batch.externalId = null; };
+      expect(func).to.throw();
+    });
+  });
 });

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -305,6 +305,56 @@ experiment('lib/models/batch', () => {
     });
   });
 
+  experiment('.dateUpdated', () => {
+    test('converts an ISO date string to a moment internally', async () => {
+      const dateString = '2020-01-20T14:51:42.024Z';
+      const batch = new Batch();
+      batch.dateUpdated = dateString;
+
+      expect(batch.dateUpdated).to.equal(moment(dateString));
+    });
+
+    test('converts a JS Date to a moment internally', async () => {
+      const date = new Date();
+      const batch = new Batch();
+      batch.dateUpdated = date;
+
+      expect(batch.dateUpdated).to.equal(moment(date));
+    });
+
+    test('can be set using a moment', async () => {
+      const now = moment();
+
+      const batch = new Batch();
+      batch.dateUpdated = now;
+
+      expect(batch.dateUpdated).to.equal(now);
+    });
+
+    test('throws for an invalid string', async () => {
+      const dateString = 'not a date';
+      const batch = new Batch();
+
+      expect(() => {
+        batch.dateUpdated = dateString;
+      }).to.throw();
+    });
+
+    test('throws for a boolean value', async () => {
+      const batch = new Batch();
+
+      expect(() => {
+        batch.dateUpdated = true;
+      }).to.throw();
+    });
+
+    test('allows null', async () => {
+      const batch = new Batch();
+      batch.dateUpdated = null;
+      expect(batch.dateUpdated).to.be.null();
+    });
+  });
+
   experiment('.isTwoPartTariff', () => {
     test('returns false if the type is annual', async () => {
       const batch = new Batch().fromHash({ type: Batch.BATCH_TYPE.annual });

--- a/test/modules/billing/jobs/create-charge-complete.js
+++ b/test/modules/billing/jobs/create-charge-complete.js
@@ -4,7 +4,8 @@ const {
   experiment,
   test,
   beforeEach,
-  afterEach
+  afterEach,
+  fail
 } = exports.lab = require('@hapi/lab').script();
 
 const { expect } = require('@hapi/code');
@@ -19,43 +20,103 @@ const batchService = require('../../../../src/modules/billing/services/batch-ser
 const Batch = require('../../../../src/lib/models/batch');
 
 const BATCH_ID = uuid();
+const EVENT_ID = uuid();
 
 experiment('modules/billing/jobs/create-charge-complete', () => {
-  const batch = new Batch();
+  let messageQueue, job;
+  const batch = new Batch(BATCH_ID);
 
   beforeEach(async () => {
+    job = {
+      data: {
+        request: {
+          data: {
+            eventId: EVENT_ID
+          }
+        },
+        response: {
+          batch: {
+            billing_batch_id: BATCH_ID
+          }
+        }
+      }
+    };
+
     sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'error');
+
     sandbox.stub(jobService, 'setReadyJob').resolves();
     sandbox.stub(batchService, 'getBatchById').resolves(batch);
+    sandbox.stub(batchService, 'getTransactionStatusCounts').resolves({});
+    sandbox.stub(batchService, 'setErrorStatus').resolves();
+
+    messageQueue = {
+      publish: sandbox.stub().resolves()
+    };
   });
 
   afterEach(async () => {
     sandbox.restore();
   });
 
-  experiment('.when there are no more transactions to create', () => {
+  experiment('when there are still candidate transactions to process', () => {
     beforeEach(async () => {
-      const job = {
-        data: {
-          request: {
-            data: {
-              eventId: 'test-event-id'
-            }
-          },
-          response: {
-            batch: {
-              billing_batch_id: 'test-batch-id'
-            }
-          }
-        }
-      };
-      await createChargeComplete(job);
+      batchService.getTransactionStatusCounts.resolves({
+        candidate: 3
+      });
+      await createChargeComplete(job, messageQueue);
     });
 
-    test('the batch is marked as completed', async () => {
-      const [eventId, batchId] = jobService.setReadyJob.lastCall.args;
-      expect(eventId).to.equal('test-event-id');
-      expect(batchId).to.equal('test-batch-id');
+    test('no further jobs are published', async () => {
+      expect(messageQueue.publish.called).to.be.false();
+    });
+
+    test('the job is not marked as ready', async () => {
+      expect(jobService.setReadyJob.called).to.be.false();
+    });
+  });
+
+  experiment('when there are no candidate transactions to process', () => {
+    beforeEach(async () => {
+      batchService.getTransactionStatusCounts.resolves({
+      });
+      await createChargeComplete(job, messageQueue);
+    });
+
+    test('a job is published to get Charge Module totals', async () => {
+      const { data } = messageQueue.publish.lastCall.args[0];
+      expect(data.eventId).to.equal(EVENT_ID);
+      expect(data.batch).to.equal(job.data.response.batch);
+    });
+
+    test('the job is marked as ready', async () => {
+      expect(jobService.setReadyJob.calledWith(
+        EVENT_ID, BATCH_ID
+      )).to.be.true();
+    });
+  });
+
+  experiment('when an error occurs', () => {
+    beforeEach(async () => {
+      batchService.getTransactionStatusCounts.rejects();
+
+      try {
+        await createChargeComplete(job, messageQueue);
+        fail();
+      } catch (err) {
+
+      }
+    });
+
+    test('a message is logged', async () => {
+      const [msg, , params] = logger.error.lastCall.args;
+      expect(msg).to.be.a.string();
+      expect(params.batchId).to.equal(BATCH_ID);
+    });
+
+    test('the batch is set to error status', async () => {
+      const [batchId] = batchService.setErrorStatus.lastCall.args;
+      expect(batchId).to.equal(BATCH_ID);
     });
   });
 });

--- a/test/modules/billing/jobs/create-charge-complete.js
+++ b/test/modules/billing/jobs/create-charge-complete.js
@@ -10,15 +10,23 @@ const {
 const { expect } = require('@hapi/code');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
+const uuid = require('uuid/v4');
 
 const { logger } = require('../../../../src/logger');
 const createChargeComplete = require('../../../../src/modules/billing/jobs/create-charge-complete');
 const jobService = require('../../../../src/modules/billing/services/job-service');
+const batchService = require('../../../../src/modules/billing/services/batch-service');
+const Batch = require('../../../../src/lib/models/batch');
+
+const BATCH_ID = uuid();
 
 experiment('modules/billing/jobs/create-charge-complete', () => {
+  const batch = new Batch();
+
   beforeEach(async () => {
     sandbox.stub(logger, 'info');
     sandbox.stub(jobService, 'setReadyJob').resolves();
+    sandbox.stub(batchService, 'getBatchById').resolves(batch);
   });
 
   afterEach(async () => {

--- a/test/modules/billing/jobs/refresh-totals.js
+++ b/test/modules/billing/jobs/refresh-totals.js
@@ -1,0 +1,111 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { logger } = require('../../../../src/logger');
+const refreshTotals = require('../../../../src/modules/billing/jobs/refresh-totals');
+const batchService = require('../../../../src/modules/billing/services/batch-service');
+const Batch = require('../../../../src/lib/models/batch');
+
+const BATCH_ID = uuid();
+const EVENT_ID = uuid();
+
+experiment('modules/billing/jobs/refresh-totals', () => {
+  let batch, dbBatchRow;
+
+  beforeEach(async () => {
+    dbBatchRow = {
+      billing_batch_id: BATCH_ID
+    };
+    batch = new Batch();
+    sandbox.stub(batchService, 'getBatchById');
+    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'info');
+    sandbox.stub(batchService, 'refreshTotals');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.jobName', () => {
+    test('is set to the expected value', async () => {
+      expect(refreshTotals.jobName).to.equal('billing.refreshTotals');
+    });
+  });
+
+  experiment('.createMessage', () => {
+    test('creates an message object of the expected shape for PG boss', async () => {
+      const message = refreshTotals.createMessage(EVENT_ID, dbBatchRow);
+      expect(message).to.equal({
+        name: refreshTotals.jobName,
+        data: { eventId: EVENT_ID, batch: dbBatchRow },
+        options: {
+          singletonKey: BATCH_ID
+        }
+      });
+    });
+  });
+
+  experiment('.handler', () => {
+    let job;
+    beforeEach(async () => {
+      job = {
+        data: {
+          batch: {
+            billing_batch_id: BATCH_ID
+          }
+        }
+      };
+    });
+
+    experiment('when there are no errors', () => {
+      let result;
+
+      beforeEach(async () => {
+        result = await refreshTotals.handler(job);
+      });
+
+      test('logs an info message', async () => {
+        expect(logger.info.called).to.be.true();
+      });
+
+      test('gets the batch by ID', async () => {
+        expect(batchService.getBatchById.calledWith(BATCH_ID)).to.be.true();
+      });
+
+      test('passes the returned batch to the .refreshTotals() method', async () => {
+        expect(batchService.refreshTotals.calledWith(batch));
+      });
+
+      test('no error is logged', async () => {
+        expect(logger.error.called).to.be.false();
+      });
+
+      test('the batch is returned', async () => {
+        expect(result).to.equal({ batch: job.data.batch });
+      });
+    });
+
+    experiment('when there are errors', () => {
+      beforeEach(async () => {
+        batchService.getBatchById.rejects();
+        expect(refreshTotals.handler(job)).to.reject();
+      });
+
+      test('a message is logged', async () => {
+        const [msg, , params] = logger.error.lastCall.args;
+        expect(msg).to.be.a.string();
+        expect(params).to.equal({ batchId: BATCH_ID });
+      });
+    });
+  });
+});

--- a/test/modules/billing/mappers/batch.js
+++ b/test/modules/billing/mappers/batch.js
@@ -1,0 +1,101 @@
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+
+const batchMapper = require('../../../../src/modules/billing/mappers/batch');
+const uuid = require('uuid/v4');
+
+const Batch = require('../../../../src/lib/models/batch');
+const FinancialYear = require('../../../../src/lib/models/financial-year');
+const Region = require('../../../../src/lib/models/region');
+const Totals = require('../../../../src/lib/models/totals');
+
+const data = {
+  batch: {
+    billingBatchId: uuid(),
+    batchType: 'supplementary',
+    season: 'summer',
+    status: 'processing',
+    dateCreated: '2020-02-18T13:54:25+00:00',
+    dateUpdated: '2020-02-18T13:54:25+00:00',
+    fromFinancialYearEnding: 2019,
+    toFinancialYearEnding: 2020,
+    region: {
+      regionId: uuid(),
+      chargeRegionId: 'A',
+      name: 'Anglian'
+    },
+    externalId: null,
+    netTotal: 3552,
+    creditNoteCount: 4,
+    invoiceCount: 3
+  }
+};
+
+experiment('modules/billing/mappers/batch', () => {
+  let batch;
+
+  experiment('.dbToModel', () => {
+    experiment('when the external ID is null', () => {
+      beforeEach(async () => {
+        batch = batchMapper.dbToModel(data.batch);
+      });
+
+      test('returns a Batch instance', async () => {
+        expect(batch instanceof Batch).to.be.true();
+      });
+
+      test('scalar properties are mapped correctly', async () => {
+        expect(batch.id).to.equal(data.batch.billingBatchId);
+        expect(batch.type).to.equal(data.batch.batchType);
+        expect(batch.season).to.equal(data.batch.season);
+        expect(batch.status).to.equal(data.batch.status);
+        expect(batch.dateCreated.format()).to.equal(data.batch.dateCreated);
+        expect(batch.dateUpdated.format()).to.equal(data.batch.dateUpdated);
+      });
+
+      test('the start year is a FinancialYear instance', async () => {
+        expect(batch.startYear instanceof FinancialYear).to.be.true();
+        expect(batch.startYear.yearEnding).to.equal(2019);
+      });
+
+      test('the end year is a FinancialYear instance', async () => {
+        expect(batch.endYear instanceof FinancialYear).to.be.true();
+        expect(batch.endYear.yearEnding).to.equal(2020);
+      });
+
+      test('the region is a Region instance', async () => {
+        expect(batch.region instanceof Region).to.be.true();
+      });
+
+      test('externalId is not set', async () => {
+        expect(batch.externalId).to.be.undefined();
+      });
+
+      test('totals are not set', async () => {
+        expect(batch.totals).to.be.undefined();
+      });
+    });
+
+    experiment('when the external ID is null', () => {
+      beforeEach(async () => {
+        batch = batchMapper.dbToModel({
+          ...data.batch,
+          externalId: 2345
+        });
+      });
+
+      test('externalId is set', async () => {
+        expect(batch.externalId).to.equal(2345);
+      });
+
+      test('totals is a Totals instance', async () => {
+        expect(batch.totals instanceof Totals).to.be.true();
+      });
+    });
+  });
+});

--- a/test/modules/billing/mappers/totals.js
+++ b/test/modules/billing/mappers/totals.js
@@ -1,0 +1,148 @@
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const totalsMapper = require('../../../../src/modules/billing/mappers/totals');
+const Totals = require('../../../../src/lib/models/totals');
+
+const INVOICE_ACCOUNT_NUMBER = 'A12345678A';
+
+const data = {
+  chargeModuleSummary: {
+    creditNoteCount: 3,
+    creditNoteValue: -245,
+    invoiceCount: 2,
+    invoiceValue: 100,
+    creditLineCount: 6,
+    creditLineValue: -245,
+    debitLineCount: 4,
+    debitLineValue: 100,
+    netTotal: -145
+  },
+  billRun: {
+    customers: [
+      {
+        customerReference: INVOICE_ACCOUNT_NUMBER,
+        summaryByFinancialYear: [{
+          creditLineCount: 1,
+          creditLineValue: -100,
+          debitLineCount: 3,
+          debitLineValue: 55,
+          netTotal: -45
+        }, {
+          creditLineCount: 2,
+          creditLineValue: -10,
+          debitLineCount: 4,
+          debitLineValue: 75,
+          netTotal: 65
+        }]
+      }
+    ]
+  },
+  dbRow: {
+    externalId: 223,
+    invoiceCount: 4,
+    creditNoteCount: 7,
+    netTotal: 334
+  }
+
+};
+
+experiment('modules/billing/mappers/totals', () => {
+  experiment('.chargeModuleBillRunToBatchModel', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = totalsMapper.chargeModuleBillRunToBatchModel(data.chargeModuleSummary);
+    });
+
+    test('the result is a Totals instance', async () => {
+      expect(result instanceof Totals).to.be.true();
+    });
+
+    const keys = [
+      'creditNoteCount',
+      'creditNoteValue',
+      'invoiceCount',
+      'invoiceValue',
+      'creditLineCount',
+      'creditLineValue',
+      'debitLineCount',
+      'debitLineValue',
+      'netTotal'
+    ];
+
+    keys.forEach(key => {
+      test(`The ${key} property has been correctly mapped`, async () => {
+        expect(result[key]).to.equal(data.chargeModuleSummary[key]);
+      });
+    });
+  });
+
+  experiment('.sumProperties', () => {
+    let result;
+
+    experiment('when the customer is present in the bill run summary', () => {
+      beforeEach(async () => {
+        result = totalsMapper.chargeModuleBillRunToInvoiceModel(data.billRun, INVOICE_ACCOUNT_NUMBER);
+      });
+
+      test('the result is a Totals instance', async () => {
+        expect(result instanceof Totals).to.be.true();
+      });
+
+      test('the totals are summed over financial years', async () => {
+        expect(result.creditLineCount).to.equal(3);
+        expect(result.creditLineValue).to.equal(-110);
+        expect(result.debitLineCount).to.equal(7);
+        expect(result.debitLineValue).to.equal(130);
+        expect(result.netTotal).to.equal(20);
+      });
+    });
+
+    experiment('when the customer is not present in the bill run summary', () => {
+      beforeEach(async () => {
+        result = totalsMapper.chargeModuleBillRunToInvoiceModel(data.billRun, 'not-a-customer');
+      });
+
+      test('the result is null', async () => {
+        expect(result).to.be.null();
+      });
+    });
+  });
+
+  experiment('.dbToModel', () => {
+    let result;
+
+    experiment('when the external ID field is null', () => {
+      beforeEach(async () => {
+        result = totalsMapper.dbToModel({
+          externalId: null
+        });
+      });
+
+      test('returns null', async () => {
+        expect(result).to.be.null();
+      });
+    });
+
+    experiment('when the external ID field is not null', () => {
+      beforeEach(async () => {
+        result = totalsMapper.dbToModel(data.dbRow);
+      });
+
+      test('returns a Totals instance', async () => {
+        expect(result instanceof Totals).to.be.true();
+      });
+
+      test('has the relevant properties populated', async () => {
+        expect(result.creditNoteCount).to.equal(data.dbRow.creditNoteCount);
+        expect(result.invoiceCount).to.equal(data.dbRow.invoiceCount);
+        expect(result.netTotal).to.equal(data.dbRow.netTotal);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Adds a new 'refresh-totals' which gets summary data (net total, invoice count, credit note count) and stores in water.billing_batches table
- Publishes the 'refresh-totals' job when all charges are processed
- Adds the new data to the batch model (and hence the detail/list API endpoints)