### PR TITLE
Fix: Allow missing serial number in returns xml

### DIFF
--- a/src/modules/returns/lib/xml-adapter/mapper.js
+++ b/src/modules/returns/lib/xml-adapter/mapper.js
@@ -13,7 +13,10 @@ const options = {
   tns: 'http://www.environment-agency.gov.uk/XMLSchemas/GOR/SAPMultiReturn/06'
 };
 
-const getText = (from, path) => from.get(path, options).text();
+const getText = (from, path, defaultValue) => {
+  const node = from.get(path, options);
+  return node ? node.text() : defaultValue;
+};
 
 const getChildNames = node => node.childNodes().map(node => node.name());
 
@@ -61,7 +64,7 @@ const getMeterDetails = (ret) => {
 
     return {
       manufacturer: getText(meter, 'tns:EaListedManufacturer'),
-      serialNumber: getText(meter, 'tns:SerialNumber'),
+      serialNumber: getText(meter, 'tns:SerialNumber', '-'),
       meterDetailsProvided: true,
       multiplier: 1
     };


### PR DESCRIPTION
WATER-2443

If the serial number element is missing then default to a dash.