### PR TITLE
Feat: Billing batch error handling

### DIFF
--- a/migrations/20200227152725-batch-error-code.js
+++ b/migrations/20200227152725-batch-error-code.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200227152725-batch-error-code-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200227152725-batch-error-code-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200227152725-batch-error-code-down.sql
+++ b/migrations/sqls/20200227152725-batch-error-code-down.sql
@@ -1,0 +1,2 @@
+alter table water.billing_batches
+  drop column error_code;

--- a/migrations/sqls/20200227152725-batch-error-code-up.sql
+++ b/migrations/sqls/20200227152725-batch-error-code-up.sql
@@ -1,0 +1,2 @@
+alter table water.billing_batches
+  add column error_code integer;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -8,7 +8,7 @@ const Totals = require('./totals');
 const { assert } = require('@hapi/hoek');
 const { isArray } = require('lodash');
 
-const { assertIsInstanceOf, assertEnum, assertIsArrayOfType, assertPositiveInteger } = require('./validators');
+const validators = require('./validators');
 
 /**
  * Statuses that the batch (water.billing_batches) may have. These
@@ -21,6 +21,13 @@ const BATCH_STATUS = {
   ready: 'ready', // processing completed - awaiting approval
   sent: 'sent', // approved & sent to Charge Module
   error: 'error'
+};
+
+const BATCH_ERROR_CODE = {
+  failedToPopulateChargeVersions: 10,
+  failedToProcessChargeVersions: 20,
+  failedToPrepareTransactions: 30,
+  failedToCreateCharge: 40
 };
 
 const VALID_SEASON = Joi.string().valid('summer', 'winter', 'all year').required();
@@ -44,7 +51,7 @@ class Batch extends Model {
    * @param {String} batchType
    */
   set type (batchType) {
-    assertEnum(batchType, Object.values(BATCH_TYPE));
+    validators.assertEnum(batchType, Object.values(BATCH_TYPE));
     this._type = batchType;
   }
 
@@ -120,7 +127,7 @@ class Batch extends Model {
    * @param {String} status
    */
   set status (status) {
-    assertEnum(status, Object.keys(BATCH_STATUS));
+    validators.assertEnum(status, Object.keys(BATCH_STATUS));
     this._status = status;
   }
 
@@ -191,7 +198,7 @@ class Batch extends Model {
   }
 
   set invoices (invoices) {
-    assertIsArrayOfType(invoices, Invoice);
+    validators.assertIsArrayOfType(invoices, Invoice);
     this._invoices = invoices;
   }
 
@@ -205,7 +212,7 @@ class Batch extends Model {
   }
 
   set region (region) {
-    assertIsInstanceOf(region, Region);
+    validators.assertIsInstanceOf(region, Region);
     this._region = region;
   }
 
@@ -219,7 +226,7 @@ class Batch extends Model {
    * @param {Totals} totals
    */
   set totals (totals) {
-    assertIsInstanceOf(totals, Totals);
+    validators.assertIsInstanceOf(totals, Totals);
     this._totals = totals;
   }
 
@@ -236,11 +243,19 @@ class Batch extends Model {
   }
 
   set externalId (externalId) {
-    assertPositiveInteger(externalId);
+    validators.assertPositiveInteger(externalId);
     this._externalId = externalId;
+  }
+
+  get errorCode () { return this._errorCode; }
+
+  set errorCode (errorCode) {
+    validators.assertNullableEnum(errorCode, Object.values(BATCH_ERROR_CODE));
+    this._errorCode = errorCode;
   }
 }
 
 module.exports = Batch;
 module.exports.BATCH_TYPE = BATCH_TYPE;
 module.exports.BATCH_STATUS = BATCH_STATUS;
+module.exports.BATCH_ERROR_CODE = BATCH_ERROR_CODE;

--- a/src/lib/models/event.js
+++ b/src/lib/models/event.js
@@ -1,10 +1,8 @@
+'use strict';
+
 const Model = require('./model');
-const {
-  assertIsArrayOfNullableStrings,
-  assertIsInstanceOf,
-  assertNullableString,
-  assertString
-} = require('./validators');
+
+const validators = require('./validators');
 
 class Event extends Model {
   constructor (id) {
@@ -34,7 +32,7 @@ class Event extends Model {
    * @param {String} type
    */
   set type (type) {
-    assertString(type);
+    validators.assertString(type);
     this._type = type;
   }
 
@@ -51,7 +49,7 @@ class Event extends Model {
    * @param {String} subtype
    */
   set subtype (subtype) {
-    assertString(subtype);
+    validators.assertString(subtype);
     this._subtype = subtype;
   }
 
@@ -68,7 +66,7 @@ class Event extends Model {
      * @param {String} issuer
      */
   set issuer (issuer) {
-    assertNullableString(issuer);
+    validators.assertNullableString(issuer);
     this._issuer = issuer;
   }
 
@@ -85,7 +83,7 @@ class Event extends Model {
      * @param {Licence} Licence
      */
   set licences (licences) {
-    assertIsArrayOfNullableStrings(licences);
+    validators.assertIsArrayOfNullableStrings(licences);
     this._licences = licences;
   }
 
@@ -102,7 +100,7 @@ class Event extends Model {
      * @param {Object} entities
      */
   set entities (entities) {
-    assertIsInstanceOf(entities, Object);
+    validators.assertIsNullableInstanceOf(entities, Object);
     this._entities = entities;
   }
 
@@ -119,7 +117,7 @@ class Event extends Model {
    * @param {String} comment
    */
   set comment (comment) {
-    assertNullableString(comment);
+    validators.assertNullableString(comment);
     this._comment = comment;
   }
 
@@ -136,7 +134,7 @@ class Event extends Model {
      * @param {Object} metadata
      */
   set metadata (metadata) {
-    assertIsInstanceOf(metadata, Object);
+    validators.assertIsInstanceOf(metadata, Object);
     this._metadata = metadata;
   }
 
@@ -153,7 +151,7 @@ class Event extends Model {
    * @param {String} status
    */
   set status (status) {
-    assertNullableString(status);
+    validators.assertNullableString(status);
     this._status = status;
   }
 

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -45,6 +45,12 @@ const assertIsInstanceOf = (value, Type) => {
   hoek.assert(value instanceof Type, `${new Type().constructor.name} expected`);
 };
 
+const assertIsNullableInstanceOf = (value, Type) => {
+  if (value !== null) {
+    assertIsInstanceOf(value, Type);
+  }
+};
+
 const assertAccountNumber = accountNumber => assert(accountNumber, VALID_ACCOUNT_NUMBER);
 const assertLicenceNumber = licenceNumber => assert(licenceNumber, VALID_LICENCE_NUMBER);
 const assertId = id => assert(id, VALID_GUID);
@@ -54,6 +60,7 @@ const assertIsBoolean = value => assert(value, Joi.boolean().required());
 const assertDate = date => assert(date, VALID_DATE);
 const assertNullableDate = date => assert(date, VALID_NULLABLE_DATE);
 const assertEnum = (str, values) => assert(str, VALID_STRING.valid(values));
+const assertNullableEnum = (str, values) => assert(str, VALID_NULLABLE_STRING.valid(values));
 const assertAuthorisedDays = value => assert(value, VALID_POSITIVE_INTEGER.max(366));
 const assertBillableDays = value => assert(value, VALID_INTEGER.min(0).max(366));
 const assertPositiveInteger = value => assert(value, VALID_POSITIVE_INTEGER);
@@ -71,6 +78,7 @@ const assertInteger = value => assert(value, VALID_INTEGER);
 
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
+exports.assertIsNullableInstanceOf = assertIsNullableInstanceOf;
 exports.assertIsArrayOfType = assertIsArrayOfType;
 exports.assertIsArrayOfNullableStrings = assertIsArrayOfNullableStrings;
 exports.assertAccountNumber = assertAccountNumber;
@@ -81,6 +89,7 @@ exports.assertNullableString = assertNullableString;
 exports.assertDate = assertDate;
 exports.assertNullableDate = assertNullableDate;
 exports.assertEnum = assertEnum;
+exports.assertNullableEnum = assertNullableEnum;
 exports.assertAuthorisedDays = assertAuthorisedDays;
 exports.assertBillableDays = assertBillableDays;
 exports.assertPositiveInteger = assertPositiveInteger;

--- a/src/lib/services/events.js
+++ b/src/lib/services/events.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const repo = require('../connectors/repos');
 const Event = require('../models/event');
 

--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const createChargeJob = require('./create-charge');
 const refreshTotalsJob = require('./refresh-totals');
 const jobService = require('../services/job-service');
 
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 const batchService = require('../services/batch-service');
-
-const { logger } = require('../../../logger');
+const batchJob = require('./lib/batch-job');
 
 const isProcessingTransactions = async batchId => {
   const statuses = await batchService.getTransactionStatusCounts(batchId);
@@ -14,11 +13,15 @@ const isProcessingTransactions = async batchId => {
 };
 
 const handleCreateChargeComplete = async (job, messageQueue) => {
+  batchJob.logOnComplete(job);
+
+  if (batchJob.hasJobFailed(job)) {
+    return batchJob.failBatch(job, messageQueue, BATCH_ERROR_CODE.failedToCreateCharge);
+  }
+
   const { eventId } = job.data.request.data;
   const { batch } = job.data.response;
   const { billing_batch_id: batchId } = batch;
-
-  logger.info(`onComplete - ${createChargeJob.jobName}`);
 
   try {
     if (await isProcessingTransactions(batchId)) {
@@ -29,25 +32,10 @@ const handleCreateChargeComplete = async (job, messageQueue) => {
     // read batch totals in the CM
     await messageQueue.publish(refreshTotalsJob.createMessage(eventId, batch));
 
-    /**
-     * Placeholder
-     *
-     * Find billing_transactions for the batch that are
-     * not completed
-     *
-     * If there are transactions left to process do nothing
-     *
-     * If there are no more transactions to process then
-     * the batch is complete. Update the batch status and the
-     * event status
-     */
-
     await jobService.setReadyJob(eventId, batchId);
   } catch (err) {
-    logger.error(`Error handling onComplete - ${createChargeJob.jobName}`, err, {
-      batchId
-    });
-    await batchService.setErrorStatus(batchId);
+    batchJob.logOnCompleteError(job);
+    await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToCreateCharge);
     throw err;
   }
 };

--- a/src/modules/billing/jobs/lib/batch-job.js
+++ b/src/modules/billing/jobs/lib/batch-job.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const { get } = require('lodash');
+
+const batchService = require('../../services/batch-service');
+const { logger } = require('../../../../logger');
+
+const getRequestName = job => job.data.request.name;
+
+const logHandling = job => {
+  logger.info(`Handling: ${job.name}`);
+};
+
+const logOnComplete = job => {
+  logger.info(`onComplete: ${getRequestName(job)} - ${job.failed ? 'Error' : 'Success'}`);
+};
+
+const logOnCompleteError = (job, error) => {
+  logger.error(`Error handling onComplete: ${getRequestName(job)}`, error, get(job, 'data.request.data'));
+};
+
+const logHandlingError = (job, error) => {
+  logger.error(`Error: ${job.name}`, error, job.data);
+};
+
+/**
+ * In the event that a job fails when processing a batch,
+ * this function tidies up so that no further processing
+ * happens.
+ *
+ * The batch record is put in an error state
+ * and the queue is deleted to prevent further work.
+ *
+ * @param {Object<PgBoss.Job>} job The job that has failed
+ * @param {Object<PgBoss>} messageQueue The PgBoss message queue
+ * @param {number|BATCH_ERROR_CODE} errorCode Why has the batch failed?
+ */
+const failBatch = (job, messageQueue, errorCode) => {
+  const name = getRequestName(job);
+  const {
+    batch: { billing_batch_id: batchId }
+  } = job.data.request.data;
+
+  return Promise.all([
+    batchService.setErrorStatus(batchId, errorCode),
+    messageQueue.deleteQueue(name)
+  ]);
+};
+
+/**
+ * Creates a message to be added to the PG Boss job queue.
+ *
+ * @param {String} nameTemplate The queue name including a asterisk that will be replace with the batch id
+ * @param {Object<Batch>} batch The batch being processed
+ * @param {?Object} data Optional additional data
+ * @param {Object?} options Optional options
+ */
+const createMessage = (nameTemplate, batch, data, options) => {
+  return {
+    name: nameTemplate.replace('*', batch.billing_batch_id),
+    data: {
+      batch,
+      ...(data && data)
+    },
+    ...(options && { options })
+  };
+};
+
+/**
+ * Determines if the job has failed
+ *
+ * @param {Object<PgBoss.Job} job The job passed to the onComplete handler
+ */
+const hasJobFailed = job => job.data.failed === true;
+
+exports.createMessage = createMessage;
+exports.failBatch = failBatch;
+exports.hasJobFailed = hasJobFailed;
+exports.logHandling = logHandling;
+exports.logHandlingError = logHandlingError;
+exports.logOnComplete = logOnComplete;
+exports.logOnCompleteError = logOnCompleteError;

--- a/src/modules/billing/jobs/populate-batch-charge-versions-complete.js
+++ b/src/modules/billing/jobs/populate-batch-charge-versions-complete.js
@@ -3,15 +3,13 @@
 const { get } = require('lodash');
 const repos = require('../../../lib/connectors/repository');
 
-const populateBatchChargeVersions = require('./populate-batch-charge-versions');
 const processChargeVersion = require('./process-charge-version');
 
-const { logger } = require('../../../logger');
-
-const { BATCH_STATUS } = require('../../../lib/models/batch');
+const { BATCH_STATUS, BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 const { FinancialYear } = require('../../../lib/models');
 const { isValidForFinancialYear } = require('../lib/charge-version');
 const jobService = require('../services/job-service');
+const batchJob = require('./lib/batch-job');
 
 /**
  * Create an object ready for saving to the
@@ -42,11 +40,11 @@ const createChargeVersionYear = async (billingBatchChargeVersion, financialYearE
  * @param {Object} messageQueue The PG-Boss message queue
  * @param {String} eventId The event id for use when publishing
  */
-const processBillingBatchChargeVersions = async (billingBatchChargeVersions, financialYears, messageQueue, eventId) => {
+const processBillingBatchChargeVersions = async (batch, billingBatchChargeVersions, messageQueue, eventId) => {
   for (const billingBatchChargeVersion of billingBatchChargeVersions) {
     // load the charge version and publish for each year it is valid for
     const chargeVersion = await repos.chargeVersions.findOneById(billingBatchChargeVersion.charge_version_id);
-    await publishForValidChargeVersion(chargeVersion, financialYears, billingBatchChargeVersion, messageQueue, eventId);
+    await publishForValidChargeVersion(batch, chargeVersion, billingBatchChargeVersion, messageQueue, eventId);
   }
 };
 
@@ -60,12 +58,13 @@ const processBillingBatchChargeVersions = async (billingBatchChargeVersions, fin
  * @param {Object} messageQueue The PG-Boss message queue
  * @param {String} eventId The event id used for publishing
  */
-const publishForValidChargeVersion = async (chargeVersion, financialYears, billingBatchChargeVersion, messageQueue, eventId) => {
+const publishForValidChargeVersion = async (batch, chargeVersion, billingBatchChargeVersion, messageQueue, eventId) => {
+  const financialYears = FinancialYear.getFinancialYears(batch.from_financial_year_ending, batch.to_financial_year_ending);
+
   for (const financialYear of financialYears) {
     if (isValidForFinancialYear(chargeVersion, financialYear)) {
       const chargeVersionYear = await createChargeVersionYear(billingBatchChargeVersion, financialYear.endYear);
-
-      const message = processChargeVersion.createMessage(eventId, chargeVersionYear);
+      const message = processChargeVersion.createMessage(eventId, chargeVersionYear, batch);
       await messageQueue.publish(message);
     }
   }
@@ -81,7 +80,11 @@ const publishForValidChargeVersion = async (chargeVersion, financialYears, billi
  * @param {Object} job PG Boss job (including response from populateBatchChargeVersions handler)
  */
 const handlePopulateBatchChargeVersionsComplete = async (job, messageQueue) => {
-  logger.info(`onComplete - ${populateBatchChargeVersions.jobName}`);
+  batchJob.logOnComplete(job);
+
+  if (batchJob.hasJobFailed(job)) {
+    return batchJob.failBatch(job, messageQueue, BATCH_ERROR_CODE.failedToPopulateChargeVersions);
+  }
 
   const { chargeVersions: billingBatchChargeVersions, batch } = job.data.response;
   const { eventId } = job.data.request.data;
@@ -91,10 +94,9 @@ const handlePopulateBatchChargeVersionsComplete = async (job, messageQueue) => {
   }
 
   try {
-    const financialYears = FinancialYear.getFinancialYears(batch.from_financial_year_ending, batch.to_financial_year_ending);
-    await processBillingBatchChargeVersions(billingBatchChargeVersions, financialYears, messageQueue, eventId);
+    await processBillingBatchChargeVersions(batch, billingBatchChargeVersions, messageQueue, eventId);
   } catch (err) {
-    logger.error('Failed to create charge version years', err);
+    batchJob.logOnCompleteError(job, err);
     throw err;
   }
 };

--- a/src/modules/billing/jobs/prepare-transactions-complete.js
+++ b/src/modules/billing/jobs/prepare-transactions-complete.js
@@ -1,11 +1,18 @@
-const prepareTransactionsJob = require('./prepare-transactions');
+'use strict';
+
 const createChargeJob = require('./create-charge');
 const jobService = require('../services/job-service');
+const batchJob = require('./lib/batch-job');
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 
 const { logger } = require('../../../logger');
 
 const handlePrepareTransactionsComplete = async (job, messageQueue) => {
-  logger.info(`onComplete - ${prepareTransactionsJob.jobName}`);
+  batchJob.logOnComplete(job);
+
+  if (batchJob.hasJobFailed(job)) {
+    return batchJob.failBatch(job, messageQueue, BATCH_ERROR_CODE.failedToPrepareTransactions);
+  }
 
   const { eventId } = job.data.request.data;
   const { batch, transactions } = job.data.response;

--- a/src/modules/billing/jobs/process-charge-version-complete.js
+++ b/src/modules/billing/jobs/process-charge-version-complete.js
@@ -1,11 +1,16 @@
 const repo = require('../../../lib/connectors/repository');
 
-const processChargeVersion = require('./process-charge-version');
 const prepareTransactionsJob = require('./prepare-transactions');
 const { logger } = require('../../../logger');
+const batchJob = require('./lib/batch-job');
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 
 const handleProcessChargeVersionComplete = async (job, messageQueue) => {
-  logger.info(`onComplete - ${processChargeVersion.jobName}`);
+  batchJob.logOnComplete(job);
+
+  if (batchJob.hasJobFailed(job)) {
+    return batchJob.failBatch(job, messageQueue, BATCH_ERROR_CODE.failedToProcessChargeVersions);
+  }
 
   const { eventId } = job.data.request.data;
   const { chargeVersionYear, batch } = job.data.response;

--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -1,8 +1,11 @@
-const { get } = require('lodash');
-const { logger } = require('../../../logger');
-const batchService = require('../services/batch-service');
+'use strict';
 
-const JOB_NAME = 'billing.refreshTotals';
+const { get } = require('lodash');
+
+const batchService = require('../services/batch-service');
+const batchJob = require('./lib/batch-job');
+
+const JOB_NAME = 'billing.refreshTotals.*';
 
 /**
  * Calls the CM to refresh the totals in water.billing_batches table
@@ -10,16 +13,17 @@ const JOB_NAME = 'billing.refreshTotals';
  * @param {String} eventId The UUID of the event
  * @param {Object} batch The object from the batch database table
  */
-const createMessage = (eventId, batch) => ({
-  name: JOB_NAME,
-  data: { eventId, batch },
-  options: {
-    singletonKey: batch.billing_batch_id
-  }
-});
+const createMessage = (eventId, batch) => {
+  return batchJob.createMessage(JOB_NAME, batch, { eventId }, {
+    singletonKey: batch.billing_batch_id,
+    retryLimit: 5,
+    retryDelay: 120,
+    retryBackoff: true
+  });
+};
 
 const handleRefreshTotals = async job => {
-  logger.info(`Handling ${JOB_NAME}`);
+  batchJob.logHandling(job);
 
   const batchId = get(job, 'data.batch.billing_batch_id');
 
@@ -29,10 +33,7 @@ const handleRefreshTotals = async job => {
     // Update batch with totals/bill run ID from charge module
     await batchService.refreshTotals(batch);
   } catch (err) {
-    // Log error
-    logger.error(`${JOB_NAME} error`, err, {
-      batchId
-    });
+    batchJob.logHandlingError(job, err);
     throw err;
   }
 

--- a/src/modules/billing/mappers/batch.js
+++ b/src/modules/billing/mappers/batch.js
@@ -19,7 +19,7 @@ const dbToModel = row => {
   batch.fromHash({
     id: row.billingBatchId,
     type: row.batchType,
-    ...pick(row, ['season', 'status', 'dateCreated', 'dateUpdated']),
+    ...pick(row, ['season', 'status', 'dateCreated', 'dateUpdated', 'errorCode']),
     startYear: new FinancialYear(row.fromFinancialYearEnding),
     endYear: new FinancialYear(row.toFinancialYearEnding),
     region: regionMapper.dbToModel(row.region),

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -6,6 +6,7 @@ const repos = require('../../../lib/connectors/repository');
 const newRepos = require('../../../lib/connectors/repos');
 
 const mappers = require('../mappers');
+const { logger } = require('../../../logger');
 
 // Connectors
 const chargeModuleBatchConnector = require('../../../lib/connectors/charge-module/batches');
@@ -177,14 +178,18 @@ const getInvoicesForBatch = async batchId => {
   // Load Batch instance from repo with invoices
   const data = await newRepos.billingBatches.findOneWithInvoices(batchId);
 
-  // Load Charge Module summary data
-  const chargeModuleSummary = await chargeModuleBatchConnector.send(data.region.chargeRegionId, batchId, true);
-
   // Map data to Invoice models
   const invoices = data.billingInvoices.map(mapInvoice);
 
-  // Decorate with Charge Module summary data and CRM company data
-  invoices.forEach(invoice => decorateInvoiceWithTotals(invoice, chargeModuleSummary));
+  try {
+    // Load Charge Module summary data
+    const chargeModuleSummary = await chargeModuleBatchConnector.send(data.region.chargeRegionId, batchId, true);
+    // Decorate with Charge Module summary data and CRM company data
+    invoices.forEach(invoice => decorateInvoiceWithTotals(invoice, chargeModuleSummary));
+  } catch (err) {
+    logger.info('CM error', err);
+  }
+
   await decorateInvoicesWithCompanies(invoices);
   return invoices;
 };

--- a/src/modules/billing/services/job-service.js
+++ b/src/modules/billing/services/job-service.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const evt = require('../../../lib/event');
 const { jobStatus } = require('../lib/batch');
 const { BATCH_STATUS } = require('../../../lib/models/batch');
 
+const eventService = require('../../../lib/services/events');
 const batchService = require('./batch-service');
 
 const setStatuses = (eventId, eventStatus, batchId, batchStatus) => {
   return Promise.all([
-    evt.updateStatus(eventId, eventStatus),
+    eventService.updateStatus(eventId, eventStatus),
     batchService.setStatus(batchId, batchStatus)
   ]);
 };

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -446,4 +446,27 @@ experiment('lib/models/batch', () => {
       expect(func).to.throw();
     });
   });
+
+  experiment('.errorCode', () => {
+    Object.values(Batch.BATCH_ERROR_CODE).forEach(code => {
+      test(`can be set to ${code}`, async () => {
+        const batch = new Batch();
+        batch.errorCode = code;
+
+        expect(batch.errorCode).to.equal(code);
+      });
+    });
+
+    test('can be null', async () => {
+      const batch = new Batch();
+      batch.errorCode = null;
+      expect(batch.errorCode).to.equal(null);
+    });
+    test('cannot be other values', async () => {
+      expect(() => {
+        const batch = new Batch();
+        batch.errorCode = -1;
+      }).to.throw();
+    });
+  });
 });

--- a/test/lib/models/event.js
+++ b/test/lib/models/event.js
@@ -52,7 +52,7 @@ experiment('lib/models/event', () => {
     event.subtype = 'test-subtype';
     event.issuer = 'test-issuer';
     event.comment = 'test-comment';
-    event.metaData = { test: 'data' };
+    event.metadata = { test: 'data' };
     event.status = 'test-status';
 
     test('referenceCode', () => {
@@ -71,7 +71,7 @@ experiment('lib/models/event', () => {
       expect(event.comment).to.equal('test-comment');
     });
     test('metadata', () => {
-      expect(event.metaData).to.equal({ test: 'data' });
+      expect(event.metadata).to.equal({ test: 'data' });
     });
     test('status', () => {
       expect(event.status).to.equal('test-status');

--- a/test/lib/models/validators.js
+++ b/test/lib/models/validators.js
@@ -6,9 +6,7 @@ const uuid = require('uuid/v4');
 
 const validators = require('../../../src/lib/models/validators');
 
-class TestClass {
-
-}
+class TestClass {}
 
 experiment('lib/models/validators', () => {
   experiment('assertIsArrayOfType', () => {
@@ -43,9 +41,35 @@ experiment('lib/models/validators', () => {
       expect(func).not.to.throw();
     });
 
-    test('does not throw when the value is not of the specified type', async () => {
+    test('throws when the value is not of the specified type', async () => {
       const func = () => validators.assertIsInstanceOf('Not valid', TestClass);
       expect(func).to.throw();
+    });
+
+    test('reports the error with the Type name', async () => {
+      try {
+        validators.assertIsInstanceOf(123, TestClass);
+        fail('Should not get here');
+      } catch (err) {
+        expect(err.message).to.equal('TestClass expected');
+      }
+    });
+  });
+
+  experiment('assertIsNullableInstanceOf', () => {
+    test('does not throw when the value is of the specified type', async () => {
+      const func = () => validators.assertIsNullableInstanceOf(new TestClass(), TestClass);
+      expect(func).not.to.throw();
+    });
+
+    test('throws when the value is not of the specified type', async () => {
+      const func = () => validators.assertIsNullableInstanceOf('Not valid', TestClass);
+      expect(func).to.throw();
+    });
+
+    test('allows null', async () => {
+      const func = () => validators.assertIsNullableInstanceOf(null, TestClass);
+      expect(func).not.to.throw();
     });
 
     test('reports the error with the Type name', async () => {
@@ -197,6 +221,29 @@ experiment('lib/models/validators', () => {
       const invalid = '0123456789ABCDEF0123456789ABCDEF0';
       const func = () => validators.assertTransactionKey(invalid);
       expect(func).to.throw();
+    });
+  });
+
+  experiment('.assertNullableEnum', () => {
+    test('allows null', async () => {
+      const numberEnum = { one: 1, two: 2 };
+      expect(() => {
+        validators.assertNullableEnum(null, Object.values(numberEnum));
+      }).not.to.throw();
+    });
+
+    test('allows a value from the defined enum', async () => {
+      const numberEnum = { one: 1, two: 2 };
+      expect(() => {
+        validators.assertNullableEnum(numberEnum.two, Object.values(numberEnum));
+      }).not.to.throw();
+    });
+
+    test('rejects a value from outside the defined enum', async () => {
+      const numberEnum = { one: 1, two: 2 };
+      expect(() => {
+        validators.assertNullableEnum(1123, Object.values(numberEnum));
+      }).to.throw();
     });
   });
 });

--- a/test/modules/billing/controller.js
+++ b/test/modules/billing/controller.js
@@ -17,7 +17,7 @@ const Batch = require('../../../src/lib/models/batch');
 
 const newRepos = require('../../../src/lib/connectors/repos');
 const repos = require('../../../src/lib/connectors/repository');
-const event = require('../../../src/lib/event');
+const eventService = require('../../../src/lib/services/events');
 const invoiceService = require('../../../src/modules/billing/services/invoice-service');
 const batchService = require('../../../src/modules/billing/services/batch-service');
 const controller = require('../../../src/modules/billing/controller');
@@ -52,10 +52,8 @@ experiment('modules/billing/controller', () => {
     sandbox.stub(invoiceService, 'getInvoiceForBatch').resolves();
     sandbox.stub(invoiceService, 'getInvoicesForBatch').resolves();
 
-    sandbox.stub(event, 'save').resolves({
-      rows: [
-        { event_id: '11111111-1111-1111-1111-111111111111' }
-      ]
+    sandbox.stub(eventService, 'create').resolves({
+      eventId: '11111111-1111-1111-1111-111111111111'
     });
 
     sandbox.stub(mappers.api.invoice, 'modelToBatchInvoices');
@@ -104,7 +102,7 @@ experiment('modules/billing/controller', () => {
       });
 
       test('no event is created', async () => {
-        expect(event.save.called).to.be.false();
+        expect(eventService.create.called).to.be.false();
       });
 
       test('no job is published', async () => {
@@ -143,7 +141,7 @@ experiment('modules/billing/controller', () => {
       });
 
       test('creates a new event with the created batch', async () => {
-        const [savedEvent] = event.save.lastCall.args;
+        const [savedEvent] = eventService.create.lastCall.args;
         expect(savedEvent.type).to.equal('billing-batch');
         expect(savedEvent.subtype).to.equal(request.payload.batchType);
         expect(savedEvent.issuer).to.equal(request.payload.userEmail);
@@ -158,7 +156,7 @@ experiment('modules/billing/controller', () => {
 
       test('the response contains the event', async () => {
         const [{ data }] = h.response.lastCall.args;
-        expect(data.event.event_id).to.equal('11111111-1111-1111-1111-111111111111');
+        expect(data.event.eventId).to.equal('11111111-1111-1111-1111-111111111111');
       });
 
       test('the response contains a URL to the event', async () => {

--- a/test/modules/billing/jobs/create-charge-complete.js
+++ b/test/modules/billing/jobs/create-charge-complete.js
@@ -13,10 +13,10 @@ const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const uuid = require('uuid/v4');
 
-const { logger } = require('../../../../src/logger');
 const createChargeComplete = require('../../../../src/modules/billing/jobs/create-charge-complete');
 const jobService = require('../../../../src/modules/billing/services/job-service');
 const batchService = require('../../../../src/modules/billing/services/batch-service');
+const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
 const Batch = require('../../../../src/lib/models/batch');
 
 const BATCH_ID = uuid();
@@ -42,13 +42,14 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
       }
     };
 
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
-
     sandbox.stub(jobService, 'setReadyJob').resolves();
     sandbox.stub(batchService, 'getBatchById').resolves(batch);
     sandbox.stub(batchService, 'getTransactionStatusCounts').resolves({});
     sandbox.stub(batchService, 'setErrorStatus').resolves();
+
+    sandbox.stub(batchJob, 'failBatch').resolves();
+    sandbox.stub(batchJob, 'logOnComplete').resolves();
+    sandbox.stub(batchJob, 'logOnCompleteError').resolves();
 
     messageQueue = {
       publish: sandbox.stub().resolves()
@@ -57,6 +58,23 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
 
   afterEach(async () => {
     sandbox.restore();
+  });
+
+  experiment('when the job fails', () => {
+    test('the batch is set to error and cancelled ', async () => {
+      const job = {
+        name: 'testing',
+        data: {
+          failed: true
+        }
+      };
+      await createChargeComplete(job, messageQueue);
+
+      const failArgs = batchJob.failBatch.lastCall.args;
+      expect(failArgs[0]).to.equal(job);
+      expect(failArgs[1]).to.equal(messageQueue);
+      expect(failArgs[2]).to.equal(Batch.BATCH_ERROR_CODE.failedToCreateCharge);
+    });
   });
 
   experiment('when there are still candidate transactions to process', () => {
@@ -109,14 +127,14 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
     });
 
     test('a message is logged', async () => {
-      const [msg, , params] = logger.error.lastCall.args;
-      expect(msg).to.be.a.string();
-      expect(params.batchId).to.equal(BATCH_ID);
+      const args = batchJob.logOnCompleteError.lastCall.args;
+      expect(args[0]).to.equal(job);
     });
 
     test('the batch is set to error status', async () => {
-      const [batchId] = batchService.setErrorStatus.lastCall.args;
+      const [batchId, errorCode] = batchService.setErrorStatus.lastCall.args;
       expect(batchId).to.equal(BATCH_ID);
+      expect(errorCode).to.equal(Batch.BATCH_ERROR_CODE.failedToCreateCharge);
     });
   });
 });

--- a/test/modules/billing/jobs/lib/batch-job.js
+++ b/test/modules/billing/jobs/lib/batch-job.js
@@ -1,0 +1,293 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const batchJob = require('../../../../../src/modules/billing/jobs/lib/batch-job');
+const batchService = require('../../../../../src/modules/billing/services/batch-service');
+const { logger } = require('../../../../../src/logger');
+
+experiment('modules/billing/jobs/lib/batch-job', () => {
+  let messageQueue;
+
+  beforeEach(async () => {
+    sandbox.stub(batchService, 'setErrorStatus').resolves();
+
+    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'error');
+
+    messageQueue = {
+      deleteQueue: sandbox.spy()
+    };
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.failBatch', () => {
+    let job;
+    let batchId;
+    let eventId;
+
+    beforeEach(async () => {
+      batchId = '00000000-0000-0000-0000-000000000000';
+      eventId = '11111111-1111-1111-1111-111111111111';
+      job = {
+        data: {
+          request: {
+            name: `failed-job.${batchId}`,
+            data: {
+              eventId,
+              batch: {
+                billing_batch_id: batchId
+              }
+            }
+          }
+        }
+      };
+      await batchJob.failBatch(job, messageQueue, 10);
+    });
+
+    test('sets the batch to error', async () => {
+      const [id, code] = batchService.setErrorStatus.lastCall.args;
+      expect(id).to.equal(batchId);
+      expect(code).to.equal(10);
+    });
+
+    test('deletes the queue', async () => {
+      const [name] = messageQueue.deleteQueue.lastCall.args;
+      expect(name).to.equal(`failed-job.${batchId}`);
+    });
+  });
+
+  experiment('.logHandling', () => {
+    let job;
+
+    beforeEach(async () => {
+      job = {
+        name: 'test-name'
+      };
+    });
+
+    test('create the expected message', async () => {
+      batchJob.logHandling(job);
+
+      const [message] = logger.info.lastCall.args;
+      expect(message).to.equal('Handling: test-name');
+    });
+  });
+
+  experiment('.logHandlingError', () => {
+    let job;
+    let error;
+
+    beforeEach(async () => {
+      job = {
+        name: 'test-name',
+        data: {
+          batch: {
+            billing_batch_id: 'test-batch-id'
+          }
+        }
+      };
+
+      error = new Error('oops');
+      batchJob.logHandlingError(job, error);
+    });
+
+    test('creates the expected message', async () => {
+      const [message] = logger.error.lastCall.args;
+      expect(message).to.equal('Error: test-name');
+    });
+
+    test('passes the error', async () => {
+      const [, err] = logger.error.lastCall.args;
+      expect(err).to.equal(error);
+    });
+
+    test('logs the data', async () => {
+      const [, , context] = logger.error.lastCall.args;
+      expect(context).to.equal(job.data);
+    });
+  });
+
+  experiment('.logOnComplete', () => {
+    let job;
+
+    beforeEach(async () => {
+      job = {
+        data: {
+          request: {
+            name: 'test-name'
+          }
+        },
+        failed: false
+      };
+    });
+
+    test('create the expected message for a success', async () => {
+      batchJob.logOnComplete(job);
+
+      const [message] = logger.info.lastCall.args;
+      expect(message).to.equal('onComplete: test-name - Success');
+    });
+
+    test('create the expected message for a failure', async () => {
+      job.failed = true;
+      batchJob.logOnComplete(job);
+
+      const [message] = logger.info.lastCall.args;
+      expect(message).to.equal('onComplete: test-name - Error');
+    });
+  });
+
+  experiment('.logOnCompleteError', () => {
+    let job;
+    let error;
+
+    beforeEach(async () => {
+      job = {
+        data: {
+          request: {
+            name: 'test-name',
+            data: {
+              batch: {
+                billing_batch_id: 'test-batch-id'
+              }
+            }
+          }
+        },
+        failed: false
+      };
+
+      error = new Error('oops');
+
+      batchJob.logOnCompleteError(job, error);
+    });
+
+    test('create the expected message', async () => {
+      const [message] = logger.error.lastCall.args;
+      expect(message).to.equal('Error handling onComplete: test-name');
+    });
+
+    test('passes the error', async () => {
+      const [, err] = logger.error.lastCall.args;
+      expect(err).to.equal(error);
+    });
+
+    test('passes the request data', async () => {
+      const [, , context] = logger.error.lastCall.args;
+      expect(context).to.equal(job.data.request.data);
+    });
+  });
+
+  experiment('.createMessage', () => {
+    let batch;
+
+    beforeEach(async () => {
+      batch = {
+        billing_batch_id: 'test-batch-id'
+      };
+    });
+
+    test('creates a basic message', async () => {
+      const template = 'hello.*';
+      const message = batchJob.createMessage(template, batch);
+
+      expect(message).to.equal({
+        name: 'hello.test-batch-id',
+        data: {
+          batch: {
+            billing_batch_id: 'test-batch-id'
+          }
+        }
+      });
+    });
+
+    test('can include additional data', async () => {
+      const template = 'more-data.*';
+      const data = {
+        licence: {
+          id: 'test-licence-id'
+        },
+        chargeVersion: {
+          id: 'test-charge-version-id'
+        }
+      };
+      const message = batchJob.createMessage(template, batch, data);
+
+      expect(message).to.equal({
+        name: 'more-data.test-batch-id',
+        data: {
+          licence: {
+            id: 'test-licence-id'
+          },
+          chargeVersion: {
+            id: 'test-charge-version-id'
+          },
+          batch: {
+            billing_batch_id: 'test-batch-id'
+          }
+        }
+      });
+    });
+
+    test('can include additional options', async () => {
+      const template = 'with-options.*';
+      const data = {
+        licence: {
+          id: 'test-licence-id'
+        }
+      };
+
+      const options = {
+        singletonKey: 'key'
+      };
+
+      const message = batchJob.createMessage(template, batch, data, options);
+
+      expect(message).to.equal({
+        name: 'with-options.test-batch-id',
+        data: {
+          licence: {
+            id: 'test-licence-id'
+          },
+          batch: {
+            billing_batch_id: 'test-batch-id'
+          }
+        },
+        options: {
+          singletonKey: 'key'
+        }
+      });
+    });
+  });
+
+  experiment('.hasJobFailed', () => {
+    test('returns true if the job has failed', async () => {
+      const job = {
+        data: {
+          failed: true
+        }
+      };
+      expect(batchJob.hasJobFailed(job)).to.equal(true);
+    });
+
+    test('returns true if the job is OK', async () => {
+      const job = {
+        data: {
+          failed: false
+        }
+      };
+      expect(batchJob.hasJobFailed(job)).to.equal(false);
+    });
+  });
+});

--- a/test/modules/billing/jobs/populate-batch-charge-versions.js
+++ b/test/modules/billing/jobs/populate-batch-charge-versions.js
@@ -13,17 +13,14 @@ const sandbox = require('sinon').createSandbox();
 const { logger } = require('../../../../src/logger');
 const repos = require('../../../../src/lib/connectors/repository');
 const messageQueue = require('../../../../src/lib/message-queue');
-const event = require('../../../../src/lib/event');
 const populateBatchChargeVersionsJob = require('../../../../src/modules/billing/jobs/populate-batch-charge-versions');
+const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
 
 experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
   beforeEach(async () => {
     sandbox.stub(logger, 'info');
+    sandbox.stub(batchJob, 'logHandling');
     sandbox.stub(messageQueue, 'publish').resolves();
-    sandbox.stub(event, 'save').resolves();
-    sandbox.stub(event, 'load').resolves({
-      event_id: '00000000-0000-0000-0000-000000000000'
-    });
     sandbox.stub(repos.chargeVersions, 'createSupplementaryChargeVersions').resolves([]);
     sandbox.stub(repos.chargeVersions, 'createTwoPartTariffChargeVersions').resolves([]);
     sandbox.stub(repos.chargeVersions, 'createAnnualChargeVersions').resolves([]);
@@ -34,18 +31,18 @@ experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
   });
 
   test('exports the expected job name', async () => {
-    expect(populateBatchChargeVersionsJob.jobName).to.equal('billing.populate-batch-charge-versions');
+    expect(populateBatchChargeVersionsJob.jobName).to.equal('billing.populate-batch-charge-versions.*');
   });
 
   experiment('.createMessage', () => {
     test('creates the expected request object', async () => {
-      const batch = { id: 'test-batch' };
+      const batch = { billing_batch_id: 'test-batch' };
       const message = populateBatchChargeVersionsJob.createMessage('test-event-id', batch);
-      expect(message.name).to.equal('billing.populate-batch-charge-versions');
+      expect(message.name).to.equal('billing.populate-batch-charge-versions.test-batch');
       expect(message.data).to.equal({
         eventId: 'test-event-id',
         batch: {
-          id: 'test-batch'
+          billing_batch_id: 'test-batch'
         }
       });
     });
@@ -58,19 +55,19 @@ experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
       beforeEach(async () => {
         job = {
           data: {
-            eventId: '22222222-2222-2222-2222-222222222222'
-          },
-          done: sandbox.spy()
-        };
-
-        event.load.resolves({
-          metadata: {
+            eventId: '22222222-2222-2222-2222-222222222222',
             batch: {
               batch_type: 'supplementary',
               billing_batch_id: 'test-batch-id'
             }
-          }
-        });
+          },
+          done: sandbox.spy()
+        };
+      });
+
+      test('the handling of the job is logged', async () => {
+        await populateBatchChargeVersionsJob.handler(job);
+        expect(batchJob.logHandling.calledWith(job)).to.be.true();
       });
 
       experiment('if there are charge versions for the batch', () => {
@@ -123,20 +120,16 @@ experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
       beforeEach(async () => {
         job = {
           data: {
-            eventId: '22222222-2222-2222-2222-222222222222'
-          },
-          done: sandbox.spy()
-        };
-
-        event.load.resolves({
-          metadata: {
+            eventId: '22222222-2222-2222-2222-222222222222',
             batch: {
               batch_type: 'two_part_tariff',
               billing_batch_id: 'test-batch-id'
             }
-          }
-        });
+          },
+          done: sandbox.spy()
+        };
       });
+
       experiment('if there are charge versions for the batch', () => {
         let result;
 
@@ -161,6 +154,7 @@ experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
           expect(batch.billing_batch_id).to.equal('test-batch-id');
         });
       });
+
       experiment('if there are no charge versions for the batch', () => {
         let result;
 
@@ -186,20 +180,16 @@ experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
       beforeEach(async () => {
         job = {
           data: {
-            eventId: '22222222-2222-2222-2222-222222222222'
-          },
-          done: sandbox.spy()
-        };
-
-        event.load.resolves({
-          metadata: {
+            eventId: '22222222-2222-2222-2222-222222222222',
             batch: {
               batch_type: 'annual',
               billing_batch_id: 'test-batch-id'
             }
-          }
-        });
+          },
+          done: sandbox.spy()
+        };
       });
+
       experiment('if there are charge versions for the batch', () => {
         let result;
 

--- a/test/modules/billing/jobs/prepare-transactions-complete.js
+++ b/test/modules/billing/jobs/prepare-transactions-complete.js
@@ -8,11 +8,12 @@ const {
 } = exports.lab = require('@hapi/lab').script();
 
 const { expect } = require('@hapi/code');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sandbox = require('sinon').createSandbox();
 
 const { logger } = require('../../../../src/logger');
 const jobService = require('../../../../src/modules/billing/services/job-service');
+const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
+const { BATCH_ERROR_CODE } = require('../../../../src/lib/models/batch');
 
 const handlePrepareTransactionsComplete = require('../../../../src/modules/billing/jobs/prepare-transactions-complete');
 
@@ -21,6 +22,8 @@ experiment('modules/billing/jobs/prepare-transactions-complete', () => {
 
   beforeEach(async () => {
     sandbox.stub(logger, 'info');
+    sandbox.stub(batchJob, 'logOnComplete');
+    sandbox.stub(batchJob, 'failBatch');
     sandbox.stub(jobService, 'setReadyJob');
 
     messageQueue = {
@@ -30,6 +33,23 @@ experiment('modules/billing/jobs/prepare-transactions-complete', () => {
 
   afterEach(async () => {
     sandbox.restore();
+  });
+
+  experiment('when the job has failed', () => {
+    test('the batch is set to error and cancelled ', async () => {
+      const job = {
+        name: 'testing',
+        data: {
+          failed: true
+        }
+      };
+      await handlePrepareTransactionsComplete(job, messageQueue);
+
+      const failArgs = batchJob.failBatch.lastCall.args;
+      expect(failArgs[0]).to.equal(job);
+      expect(failArgs[1]).to.equal(messageQueue);
+      expect(failArgs[2]).to.equal(BATCH_ERROR_CODE.failedToPrepareTransactions);
+    });
   });
 
   experiment('when there are no transactions to create', () => {
@@ -93,7 +113,7 @@ experiment('modules/billing/jobs/prepare-transactions-complete', () => {
       const [message2] = messageQueue.publish.secondCall.args;
 
       expect(message1).to.equal({
-        name: 'billing.create-charge',
+        name: 'billing.create-charge.test-batch-id',
         data: {
           eventId: 'test-event-id',
           batch: {
@@ -106,7 +126,7 @@ experiment('modules/billing/jobs/prepare-transactions-complete', () => {
       });
 
       expect(message2).to.equal({
-        name: 'billing.create-charge',
+        name: 'billing.create-charge.test-batch-id',
         data: {
           eventId: 'test-event-id',
           batch: {

--- a/test/modules/billing/jobs/process-charge-version.js
+++ b/test/modules/billing/jobs/process-charge-version.js
@@ -7,15 +7,13 @@ const {
 } = exports.lab = require('@hapi/lab').script();
 
 const { expect } = require('@hapi/code');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sandbox = require('sinon').createSandbox();
 
-const { logger } = require('../../../../src/logger');
-const event = require('../../../../src/lib/event');
 const processChargeVersion = require('../../../../src/modules/billing/jobs/process-charge-version');
 
 const chargeVersionYearService = require('../../../../src/modules/billing/services/charge-version-year');
 
+const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
 const service = require('../../../../src/modules/billing/service');
 const { Batch } = require('../../../../src/lib/models');
 
@@ -25,23 +23,12 @@ experiment('modules/billing/jobs/process-charge-version', () => {
   let batch;
 
   beforeEach(async () => {
-    sandbox.stub(logger, 'info');
-    sandbox.stub(event, 'save').resolves();
-    sandbox.stub(event, 'load').resolves({
-      event_id: eventId,
-      metadata: {
-        batch: {
-          billing_batch_id: 'test-billing-batch-id'
-        }
-      }
-    });
-
-    sandbox.stub(logger, 'error');
+    sandbox.stub(batchJob, 'logHandling');
+    sandbox.stub(batchJob, 'logHandlingError');
 
     batch = new Batch();
     sandbox.stub(service.chargeVersionYear, 'createBatchFromChargeVersionYear').resolves(batch);
     sandbox.stub(service.chargeVersionYear, 'persistChargeVersionYearBatch');
-    // sandbox.stub(repository.billingBatchChargeVersionYears, 'setStatus');
 
     sandbox.stub(chargeVersionYearService, 'setErrorStatus').resolves();
     sandbox.stub(chargeVersionYearService, 'setReadyStatus').resolves();
@@ -52,20 +39,26 @@ experiment('modules/billing/jobs/process-charge-version', () => {
   });
 
   test('exports the expected job name', async () => {
-    expect(processChargeVersion.jobName).to.equal('billing.process-charge-version');
+    expect(processChargeVersion.jobName).to.equal('billing.process-charge-version.*');
   });
 
   experiment('.createMessage', () => {
     let message;
+    let chargeVersionYear;
+    let batch;
 
     beforeEach(async () => {
-      message = processChargeVersion.createMessage('test-event-id', {
-        billing_batch_charge_version_year_id: 1
-      });
+      chargeVersionYear = { billing_batch_charge_version_year_id: 1 };
+      batch = { billing_batch_id: 'test-batch-id' };
+      message = processChargeVersion.createMessage('test-event-id', chargeVersionYear, batch);
     });
 
     test('using the expected job name', async () => {
-      expect(message.name).to.equal(processChargeVersion.jobName);
+      expect(message.name).to.equal('billing.process-charge-version.test-batch-id');
+    });
+
+    test('includes a data object with the batch', async () => {
+      expect(message.data.batch).to.equal(batch);
     });
 
     test('includes a data object with the event id', async () => {
@@ -91,7 +84,8 @@ experiment('modules/billing/jobs/process-charge-version', () => {
       job = {
         data: {
           eventId,
-          chargeVersionYear
+          chargeVersionYear,
+          batch: { billing_batch_id: 'test-batch-id' }
         }
       };
 
@@ -103,7 +97,7 @@ experiment('modules/billing/jobs/process-charge-version', () => {
     });
 
     test('resolves including the batch details', async () => {
-      expect(result.batch.billing_batch_id).to.equal('test-billing-batch-id');
+      expect(result.batch.billing_batch_id).to.equal('test-batch-id');
     });
 
     experiment('when there are no errors', () => {
@@ -131,8 +125,10 @@ experiment('modules/billing/jobs/process-charge-version', () => {
     });
 
     experiment('when there is an error', () => {
+      let error;
       beforeEach(async () => {
-        chargeVersionYearService.setReadyStatus.rejects();
+        error = new Error('oops');
+        chargeVersionYearService.setReadyStatus.rejects(error);
         try {
           await processChargeVersion.handler(job);
           fail();
@@ -142,13 +138,9 @@ experiment('modules/billing/jobs/process-charge-version', () => {
       });
 
       test('a message is logged', async () => {
-        const [msg, err, data] = logger.error.lastCall.args;
-        expect(msg).to.equal('Error processing charge version year');
-        expect(err).to.be.an.error();
-        expect(data).to.equal({
-          eventId,
-          chargeVersionYear
-        });
+        const errorArgs = batchJob.logHandlingError.lastCall.args;
+        expect(errorArgs[0]).to.equal(job);
+        expect(errorArgs[1]).to.equal(error);
       });
 
       test('the billing batch charge version year status is updated to "error"', async () => {

--- a/test/modules/billing/mappers/batch.js
+++ b/test/modules/billing/mappers/batch.js
@@ -33,7 +33,8 @@ const data = {
     externalId: null,
     netTotal: 3552,
     creditNoteCount: 4,
-    invoiceCount: 3
+    invoiceCount: 3,
+    errorCode: 10
   }
 };
 
@@ -79,6 +80,10 @@ experiment('modules/billing/mappers/batch', () => {
 
       test('totals are not set', async () => {
         expect(batch.totals).to.be.undefined();
+      });
+
+      test('sets the errorCode property', async () => {
+        expect(batch.errorCode).to.equal(10);
       });
     });
 

--- a/test/modules/billing/services/job-service.js
+++ b/test/modules/billing/services/job-service.js
@@ -15,11 +15,11 @@ const { BATCH_STATUS } = require('../../../../src/lib/models/batch');
 const { jobStatus } = require('../../../../src/modules/billing/lib/batch');
 const jobService = require('../../../../src/modules/billing/services/job-service');
 const batchService = require('../../../../src/modules/billing/services/batch-service');
-const event = require('../../../../src/lib/event');
+const eventService = require('../../../../src/lib/services/events');
 
 experiment('modules/billing/services/jobService', () => {
   beforeEach(async () => {
-    sandbox.stub(event, 'updateStatus').resolves();
+    sandbox.stub(eventService, 'updateStatus').resolves();
     sandbox.stub(batchService, 'setStatus').resolves();
   });
 
@@ -33,7 +33,7 @@ experiment('modules/billing/services/jobService', () => {
     });
 
     test('updates the event status', async () => {
-      const [eventId, status] = event.updateStatus.lastCall.args;
+      const [eventId, status] = eventService.updateStatus.lastCall.args;
       expect(eventId).to.equal('test-event-id');
       expect(status).to.equal(jobStatus.complete);
     });
@@ -51,7 +51,7 @@ experiment('modules/billing/services/jobService', () => {
     });
 
     test('updates the event status', async () => {
-      const [eventId, status] = event.updateStatus.lastCall.args;
+      const [eventId, status] = eventService.updateStatus.lastCall.args;
       expect(eventId).to.equal('test-event-id');
       expect(status).to.equal(jobStatus.error);
     });


### PR DESCRIPTION
WATER-2554

Changes the bill run jobs to include the batch id in the queue name so
that a queue can be deleted more easily if some part of the process
errors

Adds new error_code field to billing_batches table

Changes the batch processing to fail a batch if the complete handler
detects that the underlying job has failed.

Use new event service in the billing module

Changes the Event validation to allow null entities