### PR TITLE
Fix: Loosen delete batch status validation

### DIFF
--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -12,6 +12,7 @@ const { jobStatus } = require('./lib/batch');
 const invoiceService = require('./services/invoice-service');
 const batchService = require('./services/batch-service');
 const eventService = require('../../lib/services/events');
+const { BATCH_STATUS } = require('../../lib/models/batch');
 
 const mappers = require('./mappers');
 
@@ -140,6 +141,11 @@ const deleteAccountFromBatch = async request => {
 const deleteBatch = async (request, h) => {
   const { batch } = request.pre;
   const { internalCallingUser } = request.defra;
+  const validStatuses = [BATCH_STATUS.ready, BATCH_STATUS.review, BATCH_STATUS.error];
+
+  if (!validStatuses.includes(batch.status)) {
+    return h.response(`Cannot delete batch when status is ${batch.status}`).code(422);
+  }
 
   try {
     await batchService.deleteBatch(batch, internalCallingUser);

--- a/src/modules/billing/routes.js
+++ b/src/modules/billing/routes.js
@@ -114,8 +114,7 @@ const deleteBatch = {
       }
     },
     pre: [
-      { method: preHandlers.loadBatch, assign: 'batch' },
-      { method: preHandlers.ensureBatchInReviewState }
+      { method: preHandlers.loadBatch, assign: 'batch' }
     ]
   }
 };

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -58,23 +58,21 @@ const saveEvent = (type, status, user, batch) => {
 };
 
 const deleteBatch = async (batch, internalCallingUser) => {
-  const { batchId } = batch;
-
   try {
-    await chargeModuleBatchConnector.delete(batch.region.code, batchId);
+    await chargeModuleBatchConnector.delete(batch.region.code, batch.id);
 
-    await repos.billingBatchChargeVersionYears.deleteByBatchId(batchId);
-    await repos.billingBatchChargeVersions.deleteByBatchId(batchId);
-    await repos.billingTransactions.deleteByBatchId(batchId);
-    await repos.billingInvoiceLicences.deleteByBatchId(batchId);
-    await repos.billingInvoices.deleteByBatchId(batchId);
-    await newRepos.billingBatches.delete(batchId);
+    await repos.billingBatchChargeVersionYears.deleteByBatchId(batch.id);
+    await repos.billingBatchChargeVersions.deleteByBatchId(batch.id);
+    await repos.billingTransactions.deleteByBatchId(batch.id);
+    await repos.billingInvoiceLicences.deleteByBatchId(batch.id);
+    await repos.billingInvoices.deleteByBatchId(batch.id);
+    await newRepos.billingBatches.delete(batch.id);
 
     await saveEvent('billing-batch:cancel', 'delete', internalCallingUser, batch);
   } catch (err) {
     logger.error('Failed to delete the batch', err, batch);
     await saveEvent('billing-batch:cancel', 'error', internalCallingUser, batch);
-    await setStatus(batchId, BATCH_STATUS.error);
+    await setStatus(batch.id, BATCH_STATUS.error);
     throw err;
   }
 };

--- a/test/modules/billing/routes.js
+++ b/test/modules/billing/routes.js
@@ -351,12 +351,6 @@ experiment('modules/billing/routes', () => {
       expect(pre[0].method).to.equal(preHandlers.loadBatch);
       expect(pre[0].assign).to.equal('batch');
     });
-
-    test('contains a pre handler to ensure the batch is in the review state', async () => {
-      const { pre } = routes.deleteAccountFromBatch.config;
-      expect(pre).to.have.length(2);
-      expect(pre[1].method).to.equal(preHandlers.ensureBatchInReviewState);
-    });
   });
 
   experiment('postApproveBatch', () => {

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -243,13 +243,12 @@ experiment('modules/billing/services/batch-service', () => {
   });
 
   experiment('.deleteBatch', () => {
-    let batchId;
     let batch;
     let internalCallingUser;
 
     beforeEach(async () => {
       batch = {
-        batchId: batchId = uuid(),
+        id: uuid(),
         region: {
           code: 'A'
         }
@@ -269,31 +268,31 @@ experiment('modules/billing/services/batch-service', () => {
       test('delete the batch at the charge module', async () => {
         const [code, batchId] = chargeModuleBatchConnector.delete.lastCall.args;
         expect(code).to.equal('A');
-        expect(batchId).to.equal(batchId);
+        expect(batchId).to.equal(batch.id);
       });
 
       test('deletes the charge version years', async () => {
-        expect(repos.billingBatchChargeVersionYears.deleteByBatchId.calledWith(batchId)).to.be.true();
+        expect(repos.billingBatchChargeVersionYears.deleteByBatchId.calledWith(batch.id)).to.be.true();
       });
 
       test('deletes the charge versions', async () => {
-        expect(repos.billingBatchChargeVersions.deleteByBatchId.calledWith(batchId)).to.be.true();
+        expect(repos.billingBatchChargeVersions.deleteByBatchId.calledWith(batch.id)).to.be.true();
       });
 
       test('deletes the transactions', async () => {
-        expect(repos.billingTransactions.deleteByBatchId.calledWith(batchId)).to.be.true();
+        expect(repos.billingTransactions.deleteByBatchId.calledWith(batch.id)).to.be.true();
       });
 
       test('deletes the invoice licences', async () => {
-        expect(repos.billingInvoiceLicences.deleteByBatchId.calledWith(batchId)).to.be.true();
+        expect(repos.billingInvoiceLicences.deleteByBatchId.calledWith(batch.id)).to.be.true();
       });
 
       test('deletes the invoices', async () => {
-        expect(repos.billingInvoices.deleteByBatchId.calledWith(batchId)).to.be.true();
+        expect(repos.billingInvoices.deleteByBatchId.calledWith(batch.id)).to.be.true();
       });
 
       test('deletes the batch', async () => {
-        expect(newRepos.billingBatches.delete.calledWith(batchId)).to.be.true();
+        expect(newRepos.billingBatches.delete.calledWith(batch.id)).to.be.true();
       });
 
       test('creates an event showing the calling user successfully deleted the batch', async () => {
@@ -336,7 +335,7 @@ experiment('modules/billing/services/batch-service', () => {
 
       test('sets the status of the batch to error', async () => {
         const [id, changes] = newRepos.billingBatches.update.lastCall.args;
-        expect(id).to.equal(batch.batchId);
+        expect(id).to.equal(batch.id);
         expect(changes).to.equal({
           status: 'error'
         });


### PR DESCRIPTION
WATER-2568

Allows batches to be cancelled when in the ready, review and error
states.

Updates the delete batch service to expect the latest batch model shape.