### PR TITLE
Send return notifications up to 14 days in advance

### DIFF
--- a/src/modules/batch-notifications/config/returns/lib/return-notification-contacts.js
+++ b/src/modules/batch-notifications/config/returns/lib/return-notification-contacts.js
@@ -2,6 +2,7 @@ const { chunk, groupBy } = require('lodash');
 const returnsConnector = require('../../../../../lib/connectors/returns');
 const documentsConnector = require('../../../../../lib/connectors/crm/documents');
 const { createContacts } = require('../../../../../lib/models/factory/crm-contact-list');
+const moment = require('moment');
 
 const groupReturnsByLicenceNumber = returns => groupBy(returns, ret => ret.licence_ref);
 
@@ -41,8 +42,12 @@ const getCRMContacts = async groupedReturns => {
  *                         licence, and a ContactList instance
  */
 const getReturnContacts = async excludeLicences => {
+  // The reference date is today + 14 days.  This allows returns notifications
+  // to be sent for the following return cycle up to 14 days before the cycle ends
+  const refDate = moment().add(14, 'day');
+
   // Load due returns in current cycle from return service
-  const returns = await returnsConnector.getCurrentDueReturns(excludeLicences);
+  const returns = await returnsConnector.getCurrentDueReturns(excludeLicences, refDate);
 
   // Group returns by licence number
   const groupedReturns = groupReturnsByLicenceNumber(returns);


### PR DESCRIPTION
When sending returns notifications (invite, reminder), supply a reference date that is 14 days in the future, allowing the return reminders to be sent up to 14 days before the end of the cycle.