### PR TITLE
Feat: Adds new empty status for a batch

### DIFF
--- a/migrations/20200306164300-empty-batch-status.js
+++ b/migrations/20200306164300-empty-batch-status.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200306164300-empty-batch-status-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200306164300-empty-batch-status-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200306164300-empty-batch-status-down.sql
+++ b/migrations/sqls/20200306164300-empty-batch-status-down.sql
@@ -1,0 +1,30 @@
+/*
+  Update any empty batches to error. This is a crude
+  approach but this will allow a user to delete the batch.
+*/
+update water.billing_batches
+set status = 'error'
+where status = 'empty';
+
+update water.billing_batch_charge_version_years
+set status = 'error'
+where status = 'empty';
+
+alter type water.batch_status
+  rename to batch_status_old;
+
+create type water.batch_status as enum (
+  'processing',
+  'review',
+  'ready',
+  'error',
+  'sent'
+);
+
+alter table water.billing_batches
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+alter table water.billing_batch_charge_version_years
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+drop type water.batch_status_old;

--- a/migrations/sqls/20200306164300-empty-batch-status-up.sql
+++ b/migrations/sqls/20200306164300-empty-batch-status-up.sql
@@ -1,0 +1,19 @@
+alter type water.batch_status
+  rename to batch_status_old;
+
+create type water.batch_status as enum (
+  'processing',
+  'review',
+  'ready',
+  'error',
+  'sent',
+  'empty'
+);
+
+alter table water.billing_batches
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+alter table water.billing_batch_charge_version_years
+  alter column status type water.batch_status using status::text::water.batch_status;
+
+drop type water.batch_status_old;

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -4,7 +4,7 @@ join water.billing_invoice_licences il on t.billing_invoice_licence_id=il.billin
 join water.billing_invoices i on il.billing_invoice_id=i.billing_invoice_id
 join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
 join (
-  select il.licence_id,  
+  select il.licence_id,
     make_date(b.from_financial_year_ending-1, 4, 1) AS min_date,
     make_date(b.to_financial_year_ending, 3, 31) AS max_date
   from water.billing_batches b
@@ -12,10 +12,10 @@ join (
   join water.billing_invoice_licences il on i.billing_invoice_id=il.billing_invoice_id
   where b.billing_batch_id=:batchId
 ) il_2 on il.licence_id=il_2.licence_id
-where 
-  b.status='sent' 
+where
+  b.status='sent'
   and b.billing_batch_id<>:batchId
-  and b.batch_type<>'two_part_tariff' 
+  and b.batch_type<>'two_part_tariff'
   and t.start_date>=il_2.min_date
   and t.end_date<=il_2.max_date
 order by t.date_created ASC
@@ -23,20 +23,18 @@ order by t.date_created ASC
 
 exports.findByBatchId = `
 select t.* from water.billing_transactions t
-join water.billing_invoice_licences il on t.billing_invoice_licence_id=il.billing_invoice_licence_id 
-join water.billing_invoices i on il.billing_invoice_id=i.billing_invoice_id 
+join water.billing_invoice_licences il on t.billing_invoice_licence_id=il.billing_invoice_licence_id
+join water.billing_invoices i on il.billing_invoice_id=i.billing_invoice_id
 join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
-where b.billing_batch_id=:batchId
-`
-;
+where b.billing_batch_id=:batchId;
+`;
 
 exports.findStatusCountsByBatchId = `
 select t.status, count(t.status)
-  from water.billing_batches b 
+  from water.billing_batches b
   join water.billing_invoices i on b.billing_batch_id=i.billing_batch_id
   join water.billing_invoice_licences il on i.billing_invoice_id=il.billing_invoice_id
   join water.billing_transactions t on t.billing_invoice_licence_id=il.billing_invoice_licence_id
   where b.billing_batch_id=:batchId
-  group by t.status
-`
-;
+  group by t.status;
+`;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -20,7 +20,10 @@ const BATCH_STATUS = {
   review: 'review', // two-part tariff only - reviewing results of returns matching
   ready: 'ready', // processing completed - awaiting approval
   sent: 'sent', // approved & sent to Charge Module
-  error: 'error'
+  error: 'error',
+  // if there are no charge versions, or all billing has already happened
+  // in earlier run, or all customers have been removed from the batch
+  empty: 'empty'
 };
 
 const BATCH_ERROR_CODE = {
@@ -268,6 +271,7 @@ class Batch extends Model {
    */
   canBeDeleted () {
     return this.statusIsOneOf(
+      BATCH_STATUS.empty,
       BATCH_STATUS.error,
       BATCH_STATUS.ready,
       BATCH_STATUS.review

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -125,8 +125,8 @@ const deleteAccountFromBatch = async (request, h) => {
     return Boom.notFound(`No invoices for account (${accountId}) in batch (${batch.id})`);
   }
 
-  await batchService.deleteAccountFromBatch(batch, accountId);
-  return h.response().code(204);
+  const updatedBatch = await batchService.deleteAccountFromBatch(batch, accountId);
+  return updatedBatch;
 };
 
 const deleteBatch = async (request, h) => {

--- a/src/modules/billing/jobs/populate-batch-charge-versions-complete.js
+++ b/src/modules/billing/jobs/populate-batch-charge-versions-complete.js
@@ -90,7 +90,7 @@ const handlePopulateBatchChargeVersionsComplete = async (job, messageQueue) => {
   const { eventId } = job.data.request.data;
 
   if (billingBatchChargeVersions.length === 0) {
-    return jobService.setReadyJob(eventId, batch.billing_batch_id);
+    return jobService.setEmptyBatch(eventId, batch.billing_batch_id);
   }
 
   try {

--- a/src/modules/billing/jobs/prepare-transactions-complete.js
+++ b/src/modules/billing/jobs/prepare-transactions-complete.js
@@ -22,7 +22,7 @@ const handlePrepareTransactionsComplete = async (job, messageQueue) => {
     // no transactions created for this batch, update the
     // batch status to complete
     logger.info(`No transactions produced for batch ${batchId}, finalising batch run`);
-    return jobService.setReadyJob(eventId, batchId);
+    return jobService.setEmptyBatch(eventId, batchId);
   }
 
   logger.info(`${transactions.length} transactions produced for batch ${batchId}, creating charges...`);

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -186,6 +186,24 @@ const deleteAccountFromBatch = async (batch, accountId) => {
   await repos.billingTransactions.deleteByInvoiceAccount(batch.id, accountId);
   await newRepos.billingInvoiceLicences.deleteByBatchAndInvoiceAccount(batch.id, accountId);
   await newRepos.billingInvoices.deleteByBatchAndInvoiceAccountId(batch.id, accountId);
+
+  return setStatusToEmptyWhenNoTransactions(batch);
+};
+
+/**
+ * If the batch has no more transactions then the batch is set
+ * to empty, otherwise it stays the same
+ *
+ * @param {Batch} batch
+ * @returns {Batch} The updated batch if no transactions
+ */
+const setStatusToEmptyWhenNoTransactions = async batch => {
+  const remainingTransactions = await newRepos.billingTransactions.findByBatchId(batch.id);
+
+  if (remainingTransactions.length === 0) {
+    return setStatus(batch.id, BATCH_STATUS.empty);
+  }
+  return batch;
 };
 
 exports.approveBatch = approveBatch;
@@ -202,3 +220,4 @@ exports.refreshTotals = refreshTotals;
 exports.saveInvoicesToDB = saveInvoicesToDB;
 exports.setErrorStatus = setErrorStatus;
 exports.setStatus = setStatus;
+exports.setStatusToEmptyWhenNoTransactions = setStatusToEmptyWhenNoTransactions;

--- a/src/modules/billing/services/job-service.js
+++ b/src/modules/billing/services/job-service.js
@@ -13,11 +13,30 @@ const setStatuses = (eventId, eventStatus, batchId, batchStatus) => {
   ]);
 };
 
+/**
+ * Sets the event/job to complete, and the batch to ready
+ * @param {String} eventId
+ * @param {String} batchId
+ */
 const setReadyJob = (eventId, batchId) =>
   setStatuses(eventId, jobStatus.complete, batchId, BATCH_STATUS.ready);
 
+/**
+ * Sets the event/job to complete, and the batch to empty
+ * @param {String} eventId
+ * @param {String} batchId
+ */
+const setEmptyBatch = (eventId, batchId) =>
+  setStatuses(eventId, jobStatus.complete, batchId, BATCH_STATUS.empty);
+
+/**
+ * Sets the event/job to error, and the batch to error
+ * @param {String} eventId
+ * @param {String} batchId
+ */
 const setFailedJob = (eventId, batchId) =>
   setStatuses(eventId, jobStatus.error, batchId, BATCH_STATUS.error);
 
-exports.setReadyJob = setReadyJob;
+exports.setEmptyBatch = setEmptyBatch;
 exports.setFailedJob = setFailedJob;
+exports.setReadyJob = setReadyJob;

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -134,6 +134,11 @@ experiment('lib/models/batch', () => {
       expect(batch.status).to.equal('error');
     });
 
+    test('can be set to "empty"', async () => {
+      batch.status = 'empty';
+      expect(batch.status).to.equal('empty');
+    });
+
     test('cannot be set to an invalid status', async () => {
       const func = () => {
         batch.status = 'pondering';
@@ -540,6 +545,12 @@ experiment('lib/models/batch', () => {
       batch.status = Batch.BATCH_STATUS.review;
       expect(batch.canBeDeleted()).to.equal(true);
     });
+
+    test('returns true if the batch status is empty', async () => {
+      const batch = new Batch();
+      batch.status = Batch.BATCH_STATUS.empty;
+      expect(batch.canBeDeleted()).to.equal(true);
+    });
   });
 
   experiment('.canDeleteAccounts', () => {
@@ -557,6 +568,12 @@ experiment('lib/models/batch', () => {
     test('returns false if the batch status is processing', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.processing;
+      expect(batch.canDeleteAccounts()).to.equal(false);
+    });
+
+    test('returns false if the batch status is empty', async () => {
+      const batch = new Batch();
+      batch.status = Batch.BATCH_STATUS.empty;
       expect(batch.canDeleteAccounts()).to.equal(false);
     });
 

--- a/test/modules/billing/controller.js
+++ b/test/modules/billing/controller.js
@@ -409,6 +409,7 @@ experiment('modules/billing/controller', () => {
 
     beforeEach(async () => {
       batch = new Batch(uuid());
+      batch.status = Batch.BATCH_STATUS.ready;
       request = {
         params: { batchId: batch.id, accountId: 'test-account-id' },
         pre: { batch }
@@ -425,6 +426,7 @@ experiment('modules/billing/controller', () => {
       }];
 
       invoiceService.getInvoicesForBatch.resolves(invoices);
+      batchService.deleteAccountFromBatch.resolves(batch);
     });
 
     experiment('when accounts cannot be deleted from the batch', () => {
@@ -476,6 +478,12 @@ experiment('modules/billing/controller', () => {
       expect(invoiceService.getInvoicesForBatch.calledWith(batch.id)).to.be.true();
       expect(response.output.payload.statusCode).to.equal(404);
       expect(response.output.payload.message).to.equal(`No invoices for account (test-account-id) in batch (${batch.id})`);
+    });
+
+    test('returns the batch', async () => {
+      invoices[0].invoiceAccount.id = 'test-account-id';
+      const response = await controller.deleteAccountFromBatch(request);
+      expect(response.id).to.equal(batch.id);
     });
   });
 

--- a/test/modules/billing/jobs/populate-batch-charge-versions-complete.js
+++ b/test/modules/billing/jobs/populate-batch-charge-versions-complete.js
@@ -26,7 +26,7 @@ experiment('modules/billing/jobs/populate-batch-charge-versions-complete', () =>
     sandbox.stub(batchJob, 'logOnCompleteError');
     sandbox.stub(batchJob, 'failBatch');
 
-    sandbox.stub(jobService, 'setReadyJob');
+    sandbox.stub(jobService, 'setEmptyBatch');
 
     sandbox.stub(repos.chargeVersions, 'findOneById');
     sandbox.stub(repos.billingBatchChargeVersionYears, 'create');
@@ -89,7 +89,7 @@ experiment('modules/billing/jobs/populate-batch-charge-versions-complete', () =>
     });
 
     test('the batch is set to complete', async () => {
-      const [eventId, batchId] = jobService.setReadyJob.lastCall.args;
+      const [eventId, batchId] = jobService.setEmptyBatch.lastCall.args;
       expect(eventId).to.equal('test-event-id');
       expect(batchId).to.equal('test-batch-id');
     });

--- a/test/modules/billing/jobs/prepare-transactions-complete.js
+++ b/test/modules/billing/jobs/prepare-transactions-complete.js
@@ -25,6 +25,7 @@ experiment('modules/billing/jobs/prepare-transactions-complete', () => {
     sandbox.stub(batchJob, 'logOnComplete');
     sandbox.stub(batchJob, 'failBatch');
     sandbox.stub(jobService, 'setReadyJob');
+    sandbox.stub(jobService, 'setEmptyBatch');
 
     messageQueue = {
       publish: sandbox.spy()
@@ -71,10 +72,12 @@ experiment('modules/billing/jobs/prepare-transactions-complete', () => {
       }, messageQueue);
     });
 
-    test('the batch is completed', async () => {
-      const [eventId, batchId] = jobService.setReadyJob.lastCall.args;
+    test('the batch is set as empty', async () => {
+      const [eventId, batchId] = jobService.setEmptyBatch.lastCall.args;
       expect(eventId).to.equal('test-event-id');
       expect(batchId).to.equal('test-batch-id');
+
+      expect(jobService.setReadyJob.called).to.equal(false);
     });
 
     test('no further jobs are published', async () => {

--- a/test/modules/billing/services/job-service.js
+++ b/test/modules/billing/services/job-service.js
@@ -8,8 +8,7 @@ const {
 } = exports.lab = require('@hapi/lab').script();
 
 const { expect } = require('@hapi/code');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sandbox = require('sinon').createSandbox();
 
 const { BATCH_STATUS } = require('../../../../src/lib/models/batch');
 const { jobStatus } = require('../../../../src/modules/billing/lib/batch');
@@ -42,6 +41,24 @@ experiment('modules/billing/services/jobService', () => {
       const [batchId, status] = batchService.setStatus.lastCall.args;
       expect(batchId).to.equal('test-batch-id');
       expect(status).to.equal(BATCH_STATUS.ready);
+    });
+  });
+
+  experiment('.setEmptyBatch', () => {
+    beforeEach(async () => {
+      await jobService.setEmptyBatch('test-event-id', 'test-batch-id');
+    });
+
+    test('updates the event status', async () => {
+      const [eventId, status] = eventService.updateStatus.lastCall.args;
+      expect(eventId).to.equal('test-event-id');
+      expect(status).to.equal(jobStatus.complete);
+    });
+
+    test('updates the batch status', async () => {
+      const [batchId, status] = batchService.setStatus.lastCall.args;
+      expect(batchId).to.equal('test-batch-id');
+      expect(status).to.equal(BATCH_STATUS.empty);
     });
   });
 


### PR DESCRIPTION
WATER-2561

 - Database migrations for new empty batch status
 - Updates the batch status enum
 - Updates the job service to update a batch to empty status
 - Updates the complete handler for charge versions to mark an empty batch
 - Updates the prepare transactions complete handler to mark a batch as empty if there are no transactions
 - Sets a batch to empty if no remaining transactions when deleting an account