### PR TITLE
Fix: Transaction don't have value if there is no charge

### DIFF
--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -127,7 +127,9 @@ const decorateInvoiceTransactionValues = (invoice, chargeModuleBillRun) => {
   const map = indexChargeModuleTransactions(chargeModuleBillRun, accountNumber);
 
   getInvoiceTransactions(invoice).forEach(transaction => {
-    transaction.value = map.get(transaction.externalId);
+    // a transaction is not created in the CM if its value evaluates to 0,
+    // therefore, it does not have an externalId
+    transaction.value = map.get(transaction.externalId) || 0;
   });
 };
 


### PR DESCRIPTION
WATER-2550

If transaction externalId is null, value is set to 0.