### PR TITLE
Refresh net total / bill counts when customer is deleted from bill run

### DIFF
--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -30,7 +30,7 @@ const handleCreateChargeComplete = async (job, messageQueue) => {
 
     // If there are no remaining candidate transactions, publish job to
     // read batch totals in the CM
-    await messageQueue.publish(refreshTotalsJob.createMessage(eventId, batch));
+    await messageQueue.publish(refreshTotalsJob.createMessage(batchId));
 
     await jobService.setReadyJob(eventId, batchId);
   } catch (err) {

--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -13,19 +13,23 @@ const JOB_NAME = 'billing.refreshTotals.*';
  * @param {String} eventId The UUID of the event
  * @param {Object} batch The object from the batch database table
  */
-const createMessage = (eventId, batch) => {
-  return batchJob.createMessage(JOB_NAME, batch, { eventId }, {
-    singletonKey: batch.billing_batch_id,
+const createMessage = batchId => ({
+  name: JOB_NAME.replace('*', batchId),
+  data: {
+    batchId
+  },
+  options: {
+    singletonKey: batchId,
     retryLimit: 5,
     retryDelay: 120,
     retryBackoff: true
-  });
-};
+  }
+});
 
 const handleRefreshTotals = async job => {
   batchJob.logHandling(job);
 
-  const batchId = get(job, 'data.batch.billing_batch_id');
+  const batchId = get(job, 'data.batchId');
 
   try {
     const batch = await batchService.getBatchById(batchId);

--- a/test/modules/billing/jobs/create-charge-complete.js
+++ b/test/modules/billing/jobs/create-charge-complete.js
@@ -103,8 +103,7 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
 
     test('a job is published to get Charge Module totals', async () => {
       const { data } = messageQueue.publish.lastCall.args[0];
-      expect(data.eventId).to.equal(EVENT_ID);
-      expect(data.batch).to.equal(job.data.response.batch);
+      expect(data.batchId).to.equal(BATCH_ID);
     });
 
     test('the job is marked as ready', async () => {

--- a/test/modules/billing/jobs/refresh-totals.js
+++ b/test/modules/billing/jobs/refresh-totals.js
@@ -17,15 +17,11 @@ const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
 const Batch = require('../../../../src/lib/models/batch');
 
 const BATCH_ID = uuid();
-const EVENT_ID = uuid();
 
 experiment('modules/billing/jobs/refresh-totals', () => {
-  let batch, dbBatchRow;
+  let batch;
 
   beforeEach(async () => {
-    dbBatchRow = {
-      billing_batch_id: BATCH_ID
-    };
     batch = new Batch();
     sandbox.stub(batchService, 'getBatchById');
     sandbox.stub(batchJob, 'logHandling');
@@ -46,7 +42,7 @@ experiment('modules/billing/jobs/refresh-totals', () => {
   experiment('.createMessage', () => {
     let message;
     beforeEach(async () => {
-      message = refreshTotals.createMessage(EVENT_ID, dbBatchRow);
+      message = refreshTotals.createMessage(BATCH_ID);
     });
 
     test('message has the expected name', async () => {
@@ -54,7 +50,7 @@ experiment('modules/billing/jobs/refresh-totals', () => {
     });
 
     test('message has the expected data', async () => {
-      expect(message.data).to.equal({ eventId: EVENT_ID, batch: dbBatchRow });
+      expect(message.data).to.equal({ batchId: BATCH_ID });
     });
 
     test('message has the expected options', async () => {
@@ -72,9 +68,7 @@ experiment('modules/billing/jobs/refresh-totals', () => {
     beforeEach(async () => {
       job = {
         data: {
-          batch: {
-            billing_batch_id: BATCH_ID
-          }
+          batchId: BATCH_ID
         }
       };
     });


### PR DESCRIPTION
When a customer is removed from a bill run, a job is published to refresh the net total / bill counts.