### PR TITLE
Feat: Adds batch licences api

### DIFF
--- a/src/lib/connectors/repos/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/billing-invoice-licences.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { bookshelf } = require('../bookshelf');
 const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoice-licences');
@@ -26,6 +28,15 @@ const deleteByBatchAndInvoiceAccount = (batchId, invoiceAccountId) =>
     { batchId, invoiceAccountId }
   );
 
-exports.upsert = upsert;
-exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
+/**
+ * Finds all the licences in a batch and aggregates the two part tariff
+ * error codes for a licence's underlying transactions.
+ * @param {String} batchId
+ */
+const findLicencesWithTransactionStatusesForBatch = batchId =>
+  raw.multiRow(queries.findLicencesWithTransactionStatusesForBatch, { batchId });
+
 exports.deleteByBatchAndInvoiceAccount = deleteByBatchAndInvoiceAccount;
+exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
+exports.findLicencesWithTransactionStatusesForBatch = findLicencesWithTransactionStatusesForBatch;
+exports.upsert = upsert;

--- a/src/lib/connectors/repos/queries/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/queries/billing-invoice-licences.js
@@ -34,3 +34,24 @@ exports.deleteByBatchAndInvoiceAccount = `
   and bi.billing_batch_id = :batchId
   and bi.invoice_account_id = :invoiceAccountId;
 `;
+
+exports.findLicencesWithTransactionStatusesForBatch = `
+  select
+    bil.billing_invoice_id,
+    bil.billing_invoice_licence_id,
+    bil.licence_id,
+    bil.licence_ref,
+    bil.licence_holder_name,
+    array_agg(bt.two_part_tariff_status) as "two_part_tariff_statuses"
+  from water.billing_invoices bi
+    join water.billing_invoice_licences bil
+      on bi.billing_invoice_id = bil.billing_invoice_id
+    join water.billing_transactions bt
+      on bt.billing_invoice_licence_id = bil.billing_invoice_licence_id
+  where bi.billing_batch_id = :batchId
+  group by
+    bil.billing_invoice_id,
+    bil.billing_invoice_licence_id,
+    bil.licence_ref,
+    bil.licence_holder_name;
+`;

--- a/src/modules/billing/routes.js
+++ b/src/modules/billing/routes.js
@@ -151,11 +151,28 @@ const postApproveBatch = {
   }
 };
 
+const getBatchLicences = {
+  method: 'GET',
+  path: '/water/1.0/billing/batches/{batchId}/licences',
+  handler: controller.getBatchLicences,
+  config: {
+    validate: {
+      params: {
+        batchId: Joi.string().uuid().required()
+      }
+    },
+    pre: [
+      { method: preHandlers.loadBatch, assign: 'batch' }
+    ]
+  }
+};
+
 exports.getBatch = getBatch;
 exports.getBatches = getBatches;
 exports.getBatchInvoices = getBatchInvoices;
 exports.getBatchInvoiceDetail = getBatchInvoiceDetail;
 exports.getBatchInvoicesDetails = getBatchInvoicesDetails;
+exports.getBatchLicences = getBatchLicences;
 
 exports.deleteAccountFromBatch = deleteAccountFromBatch;
 exports.deleteBatch = deleteBatch;

--- a/src/modules/billing/services/invoice-licences-service.js
+++ b/src/modules/billing/services/invoice-licences-service.js
@@ -15,4 +15,35 @@ const saveInvoiceLicenceToDB = (invoice, invoiceLicence) => {
   return newRepos.billingInvoiceLicences.upsert(data);
 };
 
+/**
+   * Gets a shape of data not defined by the service layer models that
+   * represents the billing invoice licence records that exist in a
+   * batch, including the aggregated two part tariff status codes for the
+   * underlying transactions.
+   *
+   * This shifts from the pattern of passing models around due to
+   * the volume of data that would have to be serialized for annual batches.
+   *
+   * @param {String} batchId
+   */
+const getLicencesWithTransactionStatusesForBatch = async batchId => {
+  const data = await newRepos.billingInvoiceLicences.findLicencesWithTransactionStatusesForBatch(batchId);
+
+  return data.map(item => {
+    return {
+      billingInvoiceId: item.billingInvoiceId,
+      billingInvoiceLicenceId: item.billingInvoiceLicenceId,
+      licenceRef: item.licenceRef,
+      licenceId: item.licenceId,
+      licenceHolder: item.licenceHolderName,
+      twoPartTariffStatuses: Array.from(
+        item.twoPartTariffStatuses.reduce((statuses, status) => {
+          return (status === null) ? statuses : statuses.add(status);
+        }, new Set())
+      )
+    };
+  });
+};
+
+exports.getLicencesWithTransactionStatusesForBatch = getLicencesWithTransactionStatusesForBatch;
 exports.saveInvoiceLicenceToDB = saveInvoiceLicenceToDB;

--- a/test/lib/connectors/repos/billing-invoice-licences.js
+++ b/test/lib/connectors/repos/billing-invoice-licences.js
@@ -18,6 +18,7 @@ experiment('lib/connectors/repos/billing-invoice-licences', () => {
   beforeEach(async () => {
     sandbox.stub(bookshelf.knex, 'raw');
     sandbox.stub(raw, 'singleRow');
+    sandbox.stub(raw, 'multiRow');
   });
 
   afterEach(async () => {
@@ -71,6 +72,21 @@ experiment('lib/connectors/repos/billing-invoice-licences', () => {
       const { args } = bookshelf.knex.raw.lastCall;
       expect(args[0]).to.equal(queries.deleteByBatchAndInvoiceAccount);
       expect(args[1]).to.equal({ batchId, invoiceAccountId });
+    });
+  });
+
+  experiment('.findLicencesWithTransactionStatusesForBatch', () => {
+    let batchId;
+
+    beforeEach(async () => {
+      batchId = uuid();
+      await billingInvoiceLicences.findLicencesWithTransactionStatusesForBatch(batchId);
+    });
+
+    test('calls raw.multiRow with correct argumements', async () => {
+      const { args } = raw.multiRow.lastCall;
+      expect(args[0]).to.equal(queries.findLicencesWithTransactionStatusesForBatch);
+      expect(args[1]).to.equal({ batchId });
     });
   });
 });

--- a/test/modules/billing/routes.js
+++ b/test/modules/billing/routes.js
@@ -429,4 +429,38 @@ experiment('modules/billing/routes', () => {
       expect(pre[0].assign).to.equal('batch');
     });
   });
+
+  experiment('getBatchLicences', () => {
+    let request;
+    let server;
+    let validBatchId;
+
+    beforeEach(async () => {
+      server = getServer(routes.getBatchLicences);
+      validBatchId = uuid();
+
+      request = {
+        method: 'GET',
+        url: `/water/1.0/billing/batches/${validBatchId}/licences`
+      };
+    });
+
+    test('returns the 200 for a valid payload', async () => {
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('returns a 400 if the batch id is not a uuid', async () => {
+      request.url = request.url.replace(validBatchId, '123');
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('contains a pre handler to load the batch', async () => {
+      const { pre } = routes.postApproveBatch.config;
+      expect(pre).to.have.length(1);
+      expect(pre[0].method).to.equal(preHandlers.loadBatch);
+      expect(pre[0].assign).to.equal('batch');
+    });
+  });
 });

--- a/test/modules/billing/services/invoice-licences-service.js
+++ b/test/modules/billing/services/invoice-licences-service.js
@@ -18,6 +18,7 @@ const mappers = require('../../../../src/modules/billing/mappers');
 
 experiment('modules/billing/services/invoice-licences-service', () => {
   beforeEach(async () => {
+    sandbox.stub(newRepos.billingInvoiceLicences, 'findLicencesWithTransactionStatusesForBatch');
     sandbox.stub(newRepos.billingInvoiceLicences, 'upsert');
     sandbox.stub(mappers.invoiceLicence, 'modelToDB').returns({
       licenceRef: '01/123'
@@ -45,6 +46,95 @@ experiment('modules/billing/services/invoice-licences-service', () => {
       const [data] = newRepos.billingInvoiceLicences.upsert.lastCall.args;
       expect(data).to.equal({
         licenceRef: '01/123'
+      });
+    });
+  });
+
+  experiment('.getLicencesWithTransactionStatusesForBatch', () => {
+    experiment('when there is data returned it contains', () => {
+      let result;
+
+      beforeEach(async () => {
+        newRepos.billingInvoiceLicences.findLicencesWithTransactionStatusesForBatch.resolves([
+          {
+            billingInvoiceId: 'billing-invoice-id-1',
+            billingInvoiceLicenceId: 'billing-invoice-licence-id-1',
+            licenceRef: 'licence-1',
+            licenceId: 'licence-id-1',
+            licenceHolderName: {
+              id: 'licence-holder-1',
+              name: 'licence-holder-1-name'
+            },
+            twoPartTariffStatuses: [
+              null,
+              null
+            ]
+          },
+          {
+            billingInvoiceId: 'billing-invoice-id-2',
+            billingInvoiceLicenceId: 'billing-invoice-licence-id-2',
+            licenceRef: 'licence-2',
+            licenceId: 'licence-id-2',
+            licenceHolderName: {
+              id: 'licence-holder-2',
+              initials: 'A B',
+              lastName: 'Last',
+              firstName: 'First',
+              salutation: null
+            },
+            twoPartTariffStatuses: [
+              100,
+              null,
+              200,
+              200
+            ]
+          }
+        ]);
+
+        result = await invoiceLicencesService.getLicencesWithTransactionStatusesForBatch('batch-id');
+      });
+
+      test('the billing invoice id', async () => {
+        expect(result[0].billingInvoiceId).to.equal('billing-invoice-id-1');
+        expect(result[1].billingInvoiceId).to.equal('billing-invoice-id-2');
+      });
+
+      test('the billing invoice licence id', async () => {
+        expect(result[0].billingInvoiceLicenceId).to.equal('billing-invoice-licence-id-1');
+        expect(result[1].billingInvoiceLicenceId).to.equal('billing-invoice-licence-id-2');
+      });
+
+      test('the licence ref', async () => {
+        expect(result[0].licenceRef).to.equal('licence-1');
+        expect(result[1].licenceRef).to.equal('licence-2');
+      });
+
+      test('the licence id', async () => {
+        expect(result[0].licenceId).to.equal('licence-id-1');
+        expect(result[1].licenceId).to.equal('licence-id-2');
+      });
+
+      test('the licence holder object', async () => {
+        expect(result[0].licenceHolder).to.equal({
+          id: 'licence-holder-1',
+          name: 'licence-holder-1-name'
+        });
+
+        expect(result[1].licenceHolder).to.equal({
+          id: 'licence-holder-2',
+          initials: 'A B',
+          lastName: 'Last',
+          firstName: 'First',
+          salutation: null
+        });
+      });
+
+      test('an empty array status codes when the values are all null', async () => {
+        expect(result[0].twoPartTariffStatuses).to.equal([]);
+      });
+
+      test('an array of unique status codes when the values are not all null', async () => {
+        expect(result[1].twoPartTariffStatuses).to.equal([100, 200]);
       });
     });
   });


### PR DESCRIPTION
WATER-2519

Adds a resource that get the licences in a batch including an aggregate
of the two part tariff error codes