### PR TITLE
Feat/water 2609 prevent multiple onComplete handlers

### DIFF
--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -65,10 +65,11 @@ const doNothing = () => {};
  * @param {Object} job
  * @return {Promise}
  */
-const finaliseEmptyBatch = async (job) => {
+const finaliseEmptyBatch = async (job, messageQueue) => {
   const { eventId, batchId } = parseJob(job);
   await batchService.cleanup(batchId);
   await jobService.setEmptyBatch(eventId, batchId);
+  await batchJob.deleteOnCompleteQueue(job, messageQueue);
 };
 
 /**
@@ -83,6 +84,7 @@ const finaliseReadyBatch = async (job, messageQueue) => {
   await batchService.cleanup(batchId);
   await messageQueue.publish(refreshTotalsJob.createMessage(batchId));
   await jobService.setReadyJob(eventId, batchId);
+  await batchJob.deleteOnCompleteQueue(job, messageQueue);
 };
 
 const actions = {

--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -9,7 +9,8 @@ const batchJob = require('./lib/batch-job');
 const JOB_NAME = 'billing.create-charge.*';
 
 const options = {
-  teamSize: 10
+  teamSize: 50,
+  teamConcurrency: 2
 };
 
 /**

--- a/src/modules/billing/jobs/lib/batch-job.js
+++ b/src/modules/billing/jobs/lib/batch-job.js
@@ -73,6 +73,17 @@ const createMessage = (nameTemplate, batch, data, options) => {
  */
 const hasJobFailed = job => job.data.failed === true;
 
+/**
+ * Deletes all onComplete jobs in queue for the supplied job
+ * @param {Object} job
+ * @param {Object<PgBoss>} messageQueue The PgBoss message queue
+ */
+const deleteOnCompleteQueue = (job, messageQueue) => {
+  const name = `__state__completed__${getRequestName(job)}`;
+  logger.info(`Deleting queue ${name}`);
+  return messageQueue.deleteQueue(name);
+};
+
 exports.createMessage = createMessage;
 exports.failBatch = failBatch;
 exports.hasJobFailed = hasJobFailed;
@@ -80,3 +91,4 @@ exports.logHandling = logHandling;
 exports.logHandlingError = logHandlingError;
 exports.logOnComplete = logOnComplete;
 exports.logOnCompleteError = logOnCompleteError;
+exports.deleteOnCompleteQueue = deleteOnCompleteQueue;

--- a/src/modules/billing/jobs/process-charge-version-complete.js
+++ b/src/modules/billing/jobs/process-charge-version-complete.js
@@ -20,7 +20,9 @@ const handleProcessChargeVersionComplete = async (job, messageQueue) => {
 
   if (processing === 0) {
     logger.info(`No more charge version year entries to process for batch: ${batchId}`);
+
     const message = prepareTransactionsJob.createMessage(eventId, batch);
+    await batchJob.deleteOnCompleteQueue(job, messageQueue);
     return messageQueue.publish(message);
   }
 

--- a/src/modules/billing/jobs/process-charge-version.js
+++ b/src/modules/billing/jobs/process-charge-version.js
@@ -6,7 +6,10 @@ const batchJob = require('./lib/batch-job');
 
 const JOB_NAME = 'billing.process-charge-version.*';
 
-const options = { teamSize: 10 };
+const options = {
+  teamSize: 50,
+  teamConcurrency: 2
+};
 
 /**
  * Creates the request object for publishing a new job for processing a

--- a/test/modules/billing/jobs/create-charge-complete.js
+++ b/test/modules/billing/jobs/create-charge-complete.js
@@ -53,6 +53,7 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
     sandbox.stub(batchJob, 'failBatch').resolves();
     sandbox.stub(batchJob, 'logOnComplete').resolves();
     sandbox.stub(batchJob, 'logOnCompleteError').resolves();
+    sandbox.stub(batchJob, 'deleteOnCompleteQueue').resolves();
 
     messageQueue = {
       publish: sandbox.stub().resolves()
@@ -99,6 +100,10 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
     test('the batch cleanup is not called', async () => {
       expect(batchService.cleanup.called).to.be.false();
     });
+
+    test('remaining onComplete jobs are not deleted', async () => {
+      expect(batchJob.deleteOnCompleteQueue.called).to.be.false();
+    });
   });
 
   experiment('when a non-empty batch is processed', () => {
@@ -124,6 +129,12 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
         EVENT_ID, BATCH_ID
       )).to.be.true();
     });
+
+    test('remaining onComplete jobs are deleted', async () => {
+      expect(batchJob.deleteOnCompleteQueue.calledWith(
+        job, messageQueue
+      )).to.be.true();
+    });
   });
 
   experiment('when an empty batch is processed', () => {
@@ -146,6 +157,12 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
     test('the job is marked as empty', async () => {
       expect(jobService.setEmptyBatch.calledWith(
         EVENT_ID, BATCH_ID
+      )).to.be.true();
+    });
+
+    test('remaining onComplete jobs are deleted', async () => {
+      expect(batchJob.deleteOnCompleteQueue.calledWith(
+        job, messageQueue
       )).to.be.true();
     });
   });

--- a/test/modules/billing/jobs/lib/batch-job.js
+++ b/test/modules/billing/jobs/lib/batch-job.js
@@ -290,4 +290,24 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
       expect(batchJob.hasJobFailed(job)).to.equal(false);
     });
   });
+
+  experiment('.deleteOnCompleteQueue', () => {
+    let job;
+
+    beforeEach(async () => {
+      job = {
+        data: {
+          request: {
+            name: 'test-name'
+          }
+        }
+      };
+      await batchJob.deleteOnCompleteQueue(job, messageQueue);
+    });
+
+    test('deletes onComplete queue related to current job', async () => {
+      const [name] = messageQueue.deleteQueue.lastCall.args;
+      expect(name).to.equal('__state__completed__test-name');
+    });
+  });
 });


### PR DESCRIPTION
Because the onComplete handlers in the billing run more slowly than the jobs themselves, they continue being called after that phase of processing is complete.

This fix:

- Empties onComplete queues when a phase of the billing processing is complete