### PR TITLE
Feat: Handles seasons with two part tariff

### DIFF
--- a/migrations/20200410160941-update-batches-season-to-is-summer-flag.js
+++ b/migrations/20200410160941-update-batches-season-to-is-summer-flag.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200410160941-update-batches-season-to-is-summer-flag-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200410160941-update-batches-season-to-is-summer-flag-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200402122015-charge-module-bill-run-id-up.sql
+++ b/migrations/sqls/20200402122015-charge-module-bill-run-id-up.sql
@@ -1,6 +1,6 @@
-ALTER TABLE water.billing_batches 
+ALTER TABLE water.billing_batches
 RENAME COLUMN external_id TO bill_run_id;
 
-ALTER TABLE water.billing_batches 
+ALTER TABLE water.billing_batches
 ADD COLUMN external_id uuid;
 

--- a/migrations/sqls/20200410160941-update-batches-season-to-is-summer-flag-down.sql
+++ b/migrations/sqls/20200410160941-update-batches-season-to-is-summer-flag-down.sql
@@ -1,0 +1,16 @@
+alter table water.billing_batches
+   add column season water.charge_element_season;
+
+update water.billing_batches
+set season = 'all year';
+
+update water.billing_batches
+set season = 'summer'
+where batch_type = 'two_part_tariff'
+and is_summer is true;
+
+alter table water.billing_batches
+   alter column season set not null;
+
+alter table water.billing_batches
+  drop column is_summer;

--- a/migrations/sqls/20200410160941-update-batches-season-to-is-summer-flag-up.sql
+++ b/migrations/sqls/20200410160941-update-batches-season-to-is-summer-flag-up.sql
@@ -1,0 +1,10 @@
+alter table water.billing_batches
+   add column is_summer boolean not null default false;
+
+update water.billing_batches
+set is_summer = true
+where batch_type = 'two_part_tariff'
+and season = 'summer';
+
+alter table water.billing_batches
+  drop column season;

--- a/src/lib/connectors/repos/billing-batch-charge-versions.js
+++ b/src/lib/connectors/repos/billing-batch-charge-versions.js
@@ -35,7 +35,7 @@ const createAnnual = params =>
   * @param {String} regionId - GUID from water.regions.region_id
   * @param {String} billingBatchId - GUID from water.billing_batches.billing_batch_id
   * @param {Number} toFinancialYearEnding - the year in which the financial year being processed ends
-  * @param {String} season - summer|winter - the season of the two-part billing batch
+  * @param {Boolean} isSummer - is it the summer season for a two-part billing batch
   * @return {Promise<Array>} charge versions, properties are camel-cased
   */
 const createTwoPartTariff = params =>

--- a/src/lib/connectors/repos/queries/billing-batch-charge-versions.js
+++ b/src/lib/connectors/repos/queries/billing-batch-charge-versions.js
@@ -26,13 +26,13 @@ exports.createAnnual = `
       and cv.status='current'
       and cv.charge_version_id not in (
         select distinct cv.charge_version_id
-        from water.billing_batches b 
+        from water.billing_batches b
         join water.billing_batch_charge_versions cv on b.billing_batch_id=cv.billing_batch_id
-        join water.billing_batch_charge_version_years y on 
-          b.billing_batch_id=y.billing_batch_id 
+        join water.billing_batch_charge_version_years y on
+          b.billing_batch_id=y.billing_batch_id
           and cv.charge_version_id=y.charge_version_id
         where b.batch_type in ('annual', 'supplementary')
-          and y.financial_year_ending=:toFinancialYearEnding  
+          and y.financial_year_ending=:toFinancialYearEnding
       )
     returning *;`;
 
@@ -52,19 +52,19 @@ exports.createTwoPartTariff = `
         and (l.revoked_date is null or l.revoked_date > :fromDate)
         and (cv.end_date is null or cv.end_date > :fromDate)
         and (la.end_date is null or la.end_date > :fromDate)
-        and case  
-          when :season='summer' then ce.season in ('summer')
-          when :season='all year' then ce.season in ('winter', 'all year')
+        and case
+          when :isSummer is true then ce.season in ('summer')
+          when :isSummer is false then ce.season in ('winter', 'all year')
         end
         and cv.charge_version_id not in (
           select distinct cv.charge_version_id
-          from water.billing_batches b 
+          from water.billing_batches b
           join water.billing_batch_charge_versions cv on b.billing_batch_id=cv.billing_batch_id
-          join water.billing_batch_charge_version_years y on 
-            b.billing_batch_id=y.billing_batch_id 
+          join water.billing_batch_charge_version_years y on
+            b.billing_batch_id=y.billing_batch_id
             and cv.charge_version_id=y.charge_version_id
           where b.batch_type='two_part_tariff'
-            and b.season=:season 
-            and y.financial_year_ending=:toFinancialYearEnding  
+            and b.isSummer=:isSummer
+            and y.financial_year_ending=:toFinancialYearEnding
         )
       returning *;`;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -6,7 +6,6 @@ const Region = require('./region');
 const Totals = require('./totals');
 const { assert } = require('@hapi/hoek');
 const { isArray } = require('lodash');
-const { CHARGE_SEASON } = require('./constants');
 
 const validators = require('./validators');
 
@@ -82,20 +81,20 @@ class Batch extends Model {
   }
 
   /**
-   * Sets the season for this batch
-   * @param {String} season
+   * Sets if this batch is for a summer season two part tariff run
+   * @param {Boolean} isSummer
    */
-  set season (season) {
-    validators.assertEnum(season, Object.values(CHARGE_SEASON));
-    this._season = season;
+  set isSummer (isSummer) {
+    validators.assertIsBoolean(isSummer);
+    this._isSummer = isSummer;
   }
 
   /**
-   * Gets the season for this batch
-   * @return {String}
+   * Is this batch a summer season two part tariff run
+   * @return {Boolean}
    */
-  get season () {
-    return this._season;
+  get isSummer () {
+    return this._isSummer;
   }
 
   /**
@@ -287,10 +286,6 @@ class Batch extends Model {
    */
   canDeleteAccounts () {
     return this.statusIsOneOf(BATCH_STATUS.ready, BATCH_STATUS.review);
-  }
-
-  isSummer () {
-    return this.season === CHARGE_SEASON.summer;
   }
 
   /**

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -40,11 +40,11 @@ const createBatchEvent = (userEmail, batch) => {
  * @param {Object} h HAPI response toolkit
  */
 const postCreateBatch = async (request, h) => {
-  const { userEmail, regionId, batchType, financialYearEnding, season } = request.payload;
+  const { userEmail, regionId, batchType, financialYearEnding, isSummer } = request.payload;
 
   try {
     // create a new entry in the batch table
-    const batch = await batchService.create(regionId, batchType, financialYearEnding, season);
+    const batch = await batchService.create(regionId, batchType, financialYearEnding, isSummer);
 
     // add these details to the event log
     const batchEvent = await createBatchEvent(userEmail, batch);

--- a/src/modules/billing/mappers/batch.js
+++ b/src/modules/billing/mappers/batch.js
@@ -17,7 +17,7 @@ const dbToModel = row => {
   batch.fromHash({
     id: row.billingBatchId,
     type: row.batchType,
-    ...pick(row, ['season', 'status', 'dateCreated', 'dateUpdated', 'errorCode']),
+    ...pick(row, ['isSummer', 'status', 'dateCreated', 'dateUpdated', 'errorCode']),
     startYear: new FinancialYear(row.fromFinancialYearEnding),
     endYear: new FinancialYear(row.toFinancialYearEnding),
     ...pickBy({

--- a/src/modules/billing/routes.js
+++ b/src/modules/billing/routes.js
@@ -4,7 +4,6 @@ const Joi = require('@hapi/joi');
 
 const preHandlers = require('./pre-handlers');
 const controller = require('./controller');
-const { CHARGE_SEASON } = require('../../lib/models/constants');
 
 const getBatches = {
   method: 'GET',
@@ -31,7 +30,7 @@ const postCreateBatch = {
         regionId: Joi.string().uuid().required(),
         batchType: Joi.string().valid('annual', 'supplementary', 'two_part_tariff').required(),
         financialYearEnding: Joi.number().required(),
-        season: Joi.string().valid(Object.values(CHARGE_SEASON)).required()
+        isSummer: Joi.boolean().default(false)
       }
     }
   }

--- a/src/modules/billing/service/charge-version-year.js
+++ b/src/modules/billing/service/charge-version-year.js
@@ -30,7 +30,7 @@ const createBatchFromChargeVersionYear = async chargeVersionYear => {
     financialYearEnding,
     chargeVersionId,
     batch.isTwoPartTariff(),
-    batch.isSummer()
+    batch.isSummer
   );
 
   if (error) {

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -224,10 +224,10 @@ const cleanup = async batchId => {
  * @param {String} regionId - guid from water.regions.region_id
  * @param {String} batchType - annual|supplementary|two_part_tariff
  * @param {Number} toFinancialYearEnding
- * @param {String} season - summer|winter|all_year
+ * @param {Boolean} isSummer - Is this a summer season two part tariff run
  * @return {Promise<Batch>} resolves with Batch service model
  */
-const create = async (regionId, batchType, toFinancialYearEnding, season) => {
+const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
   const existingBatch = await getMostRecentLiveBatchByRegion(regionId);
 
   if (existingBatch) {
@@ -246,7 +246,7 @@ const create = async (regionId, batchType, toFinancialYearEnding, season) => {
     batchType,
     fromFinancialYearEnding,
     toFinancialYearEnding,
-    season
+    isSummer
   });
 
   return getBatchById(billingBatchId);

--- a/src/modules/billing/services/charge-version-service.js
+++ b/src/modules/billing/services/charge-version-service.js
@@ -17,7 +17,7 @@ const createForBatch = batch => {
     regionId: batch.region.id,
     fromFinancialYearEnding: batch.startYear.endYear,
     toFinancialYearEnding: batch.endYear.endYear,
-    season: batch.season
+    isSummer: batch.isSummer
   };
   return actions[batch.type](params);
 };

--- a/src/modules/billing/services/two-part-tariff-service/returns-helpers.js
+++ b/src/modules/billing/services/two-part-tariff-service/returns-helpers.js
@@ -11,8 +11,8 @@ const camelCaseKeys = require('../../../../lib/camel-case-keys');
  */
 const getReturnCycleFromBatch = batch => {
   const { endYear: { yearEnding } } = batch;
-  const returnCycleStartMonth = batch.isSummer() ? 11 : 4;
-  const yearStarting = batch.isSummer() ? yearEnding - 1 : yearEnding;
+  const returnCycleStartMonth = batch.isSummer ? 11 : 4;
+  const yearStarting = batch.isSummer ? yearEnding - 1 : yearEnding;
 
   return {
     startDate: getFinancialYearDate(1, returnCycleStartMonth, yearStarting),

--- a/test/lib/connectors/repos/billing-batch-charge-versions.js
+++ b/test/lib/connectors/repos/billing-batch-charge-versions.js
@@ -21,7 +21,7 @@ const getParams = (fromFinancialYearEnding = 2020) => ({
   billingBatchId: uuid(),
   regionId: uuid(),
   toFinancialYearEnding: 2020,
-  season: 'summer'
+  isSummer: true
 });
 
 const response = [{
@@ -57,7 +57,7 @@ experiment('lib/connectors/repos/billing-batch-charge-versions', () => {
       expect(queryParams.regionId).to.equal(params.regionId);
       expect(queryParams.fromFinancialYearEnding).to.equal(params.fromFinancialYearEnding);
       expect(queryParams.toFinancialYearEnding).to.equal(params.toFinancialYearEnding);
-      expect(queryParams.season).to.equal(params.season);
+      expect(queryParams.isSummer).to.equal(params.isSummer);
       expect(queryParams.fromDate).to.equal('2013-04-01');
     });
 
@@ -83,7 +83,7 @@ experiment('lib/connectors/repos/billing-batch-charge-versions', () => {
       expect(queryParams.regionId).to.equal(params.regionId);
       expect(queryParams.fromFinancialYearEnding).to.equal(params.fromFinancialYearEnding);
       expect(queryParams.toFinancialYearEnding).to.equal(params.toFinancialYearEnding);
-      expect(queryParams.season).to.equal(params.season);
+      expect(queryParams.isSummer).to.equal(params.isSummer);
       expect(queryParams.fromDate).to.equal('2019-04-01');
     });
 
@@ -109,7 +109,7 @@ experiment('lib/connectors/repos/billing-batch-charge-versions', () => {
       expect(queryParams.regionId).to.equal(params.regionId);
       expect(queryParams.fromFinancialYearEnding).to.equal(params.fromFinancialYearEnding);
       expect(queryParams.toFinancialYearEnding).to.equal(params.toFinancialYearEnding);
-      expect(queryParams.season).to.equal(params.season);
+      expect(queryParams.isSummer).to.equal(params.isSummer);
       expect(queryParams.fromDate).to.equal('2019-04-01');
     });
 

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -8,8 +8,6 @@ const { expect } = require('@hapi/code');
 const { Batch, FinancialYear, Invoice, InvoiceAccount, Region, Totals } =
   require('../../../src/lib/models');
 
-const { CHARGE_SEASON } = require('../../../src/lib/models/constants');
-
 const TEST_GUID = 'add1cf3b-7296-4817-b013-fea75a928580';
 const TEST_FINANCIAL_YEAR = new FinancialYear(2020);
 
@@ -70,25 +68,20 @@ experiment('lib/models/batch', () => {
     });
   });
 
-  experiment('.season', () => {
-    test('can be set to "summer"', async () => {
-      batch.season = CHARGE_SEASON.summer;
-      expect(batch.season).to.equal(CHARGE_SEASON.summer);
+  experiment('.isSummer', () => {
+    test('can be set to true', async () => {
+      batch.isSummer = true;
+      expect(batch.isSummer).to.equal(true);
     });
 
-    test('can be set to "winter"', async () => {
-      batch.season = CHARGE_SEASON.winter;
-      expect(batch.season).to.equal(CHARGE_SEASON.winter);
+    test('can be set to false', async () => {
+      batch.isSummer = false;
+      expect(batch.isSummer).to.equal(false);
     });
 
-    test('can be set to "all year"', async () => {
-      batch.season = CHARGE_SEASON.allYear;
-      expect(batch.season).to.equal(CHARGE_SEASON.allYear);
-    });
-
-    test('cannot be set to an invalid season', async () => {
+    test('cannot be set to an invalid value', async () => {
       const func = () => {
-        batch.season = 'autumn';
+        batch.isSummer = 123;
       };
       expect(func).to.throw();
     });
@@ -612,25 +605,6 @@ experiment('lib/models/batch', () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.review;
       expect(batch.canDeleteAccounts()).to.equal(true);
-    });
-  });
-
-  experiment('.isSummer()', () => {
-    const notSummer = [CHARGE_SEASON.allYear, CHARGE_SEASON.winter];
-    notSummer.forEach(season => {
-      test(`when the season is ${season} batch.isSummer() is false`, async () => {
-        const batch = new Batch();
-        batch.season = season;
-
-        expect(batch.isSummer()).to.equal(false);
-      });
-    });
-
-    test('when the season is summer batch.isSummer() is true', async () => {
-      const batch = new Batch();
-      batch.season = CHARGE_SEASON.summer;
-
-      expect(batch.isSummer()).to.equal(true);
     });
   });
 });

--- a/test/modules/billing/controller.js
+++ b/test/modules/billing/controller.js
@@ -16,8 +16,6 @@ const Invoice = require('../../../src/lib/models/invoice');
 const Batch = require('../../../src/lib/models/batch');
 const BATCH_STATUS = Batch.BATCH_STATUS;
 
-const { CHARGE_SEASON } = require('../../../src/lib/models/constants');
-
 const newRepos = require('../../../src/lib/connectors/repos');
 const eventService = require('../../../src/lib/services/events');
 const invoiceService = require('../../../src/modules/billing/services/invoice-service');
@@ -83,7 +81,7 @@ experiment('modules/billing/controller', () => {
           regionId: '22222222-2222-2222-2222-222222222222',
           batchType: 'annual',
           financialYearEnding: 2019,
-          season: CHARGE_SEASON.summer
+          isSummer: true
         },
         messageQueue: {
           publish: sandbox.stub().resolves()
@@ -104,7 +102,7 @@ experiment('modules/billing/controller', () => {
           request.payload.regionId,
           request.payload.batchType,
           request.payload.financialYearEnding,
-          request.payload.season
+          request.payload.isSummer
         )).to.be.true();
       });
 
@@ -153,7 +151,7 @@ experiment('modules/billing/controller', () => {
           request.payload.regionId,
           request.payload.batchType,
           request.payload.financialYearEnding,
-          request.payload.season
+          request.payload.isSummer
         )).to.be.true();
       });
 
@@ -202,7 +200,7 @@ experiment('modules/billing/controller', () => {
           regionId: '22222222-2222-2222-2222-222222222222',
           batchType: 'supplementary',
           financialYearEnding: 2019,
-          season: CHARGE_SEASON.summer
+          isSummer: true
         },
         messageQueue: {
           publish: sandbox.stub().resolves()
@@ -217,7 +215,7 @@ experiment('modules/billing/controller', () => {
         request.payload.regionId,
         request.payload.batchType,
         request.payload.financialYearEnding,
-        request.payload.season
+        request.payload.isSummer
       )).to.be.true();
     });
   });

--- a/test/modules/billing/mappers/batch.js
+++ b/test/modules/billing/mappers/batch.js
@@ -13,13 +13,12 @@ const Batch = require('../../../../src/lib/models/batch');
 const FinancialYear = require('../../../../src/lib/models/financial-year');
 const Region = require('../../../../src/lib/models/region');
 const Totals = require('../../../../src/lib/models/totals');
-const { CHARGE_SEASON } = require('../../../../src/lib/models/constants');
 
 const data = {
   batch: {
     billingBatchId: uuid(),
     batchType: 'supplementary',
-    season: CHARGE_SEASON.summer,
+    isSummer: true,
     status: 'processing',
     dateCreated: '2020-02-18T13:54:25+00:00',
     dateUpdated: '2020-02-18T13:54:25+00:00',
@@ -54,7 +53,7 @@ experiment('modules/billing/mappers/batch', () => {
       test('scalar properties are mapped correctly', async () => {
         expect(batch.id).to.equal(data.batch.billingBatchId);
         expect(batch.type).to.equal(data.batch.batchType);
-        expect(batch.season).to.equal(data.batch.season);
+        expect(batch.isSummer).to.equal(data.batch.isSummer);
         expect(batch.status).to.equal(data.batch.status);
         expect(batch.dateCreated.format()).to.equal(data.batch.dateCreated);
         expect(batch.dateUpdated.format()).to.equal(data.batch.dateUpdated);

--- a/test/modules/billing/routes.js
+++ b/test/modules/billing/routes.js
@@ -9,7 +9,6 @@ const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').scri
 
 const routes = require('../../../src/modules/billing/routes');
 const preHandlers = require('../../../src/modules/billing/pre-handlers');
-const { CHARGE_SEASON } = require('../../../src/lib/models/constants');
 
 /**
  * Creates a test Hapi server that has no other plugins loaded,
@@ -46,7 +45,7 @@ experiment('modules/billing/routes', () => {
           regionId: '054517f2-be00-4505-a3cc-df65a89cd8e1',
           batchType: 'annual',
           financialYearEnding: 2019,
-          season: CHARGE_SEASON.summer
+          isSummer: true
         }
       };
     });
@@ -104,16 +103,19 @@ experiment('modules/billing/routes', () => {
       expect(response.statusCode).to.equal(400);
     });
 
-    test('returns a 400 if the season is an unexpected value', async () => {
-      request.payload.season = 'spring';
+    test('returns a 400 if the isSummer is an unexpected value', async () => {
+      request.payload.isSummer = 'nope';
       const response = await server.inject(request);
       expect(response.statusCode).to.equal(400);
     });
 
-    test('returns a 400 if the season is omitted', async () => {
-      delete request.payload.season;
+    test('returns a 200 if the isSummer is omitted (defaults to false)', async () => {
+      delete request.payload.isSummer;
+
       const response = await server.inject(request);
-      expect(response.statusCode).to.equal(400);
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.request.payload.isSummer).to.equal(false);
     });
   });
 

--- a/test/modules/billing/service/charge-version-year.js
+++ b/test/modules/billing/service/charge-version-year.js
@@ -11,7 +11,6 @@ const { expect } = require('@hapi/code');
 
 const sandbox = require('sinon').createSandbox();
 const { Batch } = require('../../../../src/lib/models');
-const { CHARGE_SEASON } = require('../../../../src/lib/models/constants');
 
 const chargeVersionYear = require('../../../../src/modules/billing/service/charge-version-year');
 const chargeProcessor = require('../../../../src/modules/billing/service/charge-processor');
@@ -198,7 +197,7 @@ experiment('modules/billing/service/charge-version-year.js', () => {
     experiment('if the batch is for the summer season', () => {
       test('the charge processor is setup with the summer flag', async () => {
         const batch = createBatch();
-        batch.season = CHARGE_SEASON.summer;
+        batch.isSummer = true;
 
         batchService.getBatchById.resolves(batch);
 
@@ -215,25 +214,21 @@ experiment('modules/billing/service/charge-version-year.js', () => {
     });
 
     experiment('if the batch is not for the summer season', () => {
-      const notSummer = [CHARGE_SEASON.winter, CHARGE_SEASON.allYear];
+      test('the charge processor is setup with the summer flag', async () => {
+        const batch = createBatch();
+        batch.isSummer = false;
 
-      notSummer.forEach(season => {
-        test('the charge processor is not setup with the summer flag', async () => {
-          const batch = createBatch();
-          batch.season = season;
+        batchService.getBatchById.resolves(batch);
 
-          batchService.getBatchById.resolves(batch);
-
-          chargeProcessor.processCharges.resolves({
-            error: null,
-            data: data.charges
-          });
-
-          await chargeVersionYear.createBatchFromChargeVersionYear(data.chargeVersionYear);
-
-          const [, , , isSummer] = chargeProcessor.processCharges.lastCall.args;
-          expect(isSummer).to.equal(false);
+        chargeProcessor.processCharges.resolves({
+          error: null,
+          data: data.charges
         });
+
+        await chargeVersionYear.createBatchFromChargeVersionYear(data.chargeVersionYear);
+
+        const [, , , isSummer] = chargeProcessor.processCharges.lastCall.args;
+        expect(isSummer).to.equal(false);
       });
     });
   });

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -20,7 +20,6 @@ const InvoiceLicence = require('../../../../src/lib/models/invoice-licence');
 const Licence = require('../../../../src/lib/models/licence');
 const Totals = require('../../../../src/lib/models/totals');
 const Transaction = require('../../../../src/lib/models/transaction');
-const { CHARGE_SEASON } = require('../../../../src/lib/models/constants');
 
 const eventService = require('../../../../src/lib/services/events');
 const { logger } = require('../../../../src/logger');
@@ -51,7 +50,7 @@ const region = {
 const batch = {
   billingBatchId: BATCH_ID,
   batchType: 'supplementary',
-  season: CHARGE_SEASON.summer,
+  isSummer: true,
   regionId: region.regionId,
   fromFinancialYearEnding: 2014,
   toFinancialYearEnding: 2019,
@@ -138,8 +137,8 @@ experiment('modules/billing/services/batch-service', () => {
         expect(result.type).to.equal(data.batch.batchType);
       });
 
-      test('with correct season', async () => {
-        expect(result.season).to.equal(data.batch.season);
+      test('with correct isSummer flag', async () => {
+        expect(result.isSummer).to.equal(data.batch.isSummer);
       });
 
       experiment('with start year', () => {
@@ -188,7 +187,7 @@ experiment('modules/billing/services/batch-service', () => {
             billingBatchId: 'a9e9334e-4709-4b86-9b75-19e58f3f0d8c',
             region,
             batchType: 'supplementary',
-            season: CHARGE_SEASON.allYear,
+            isSummer: false,
             dateCreated: '2020-01-09T16:23:24.753Z',
             dateUpdated: '2020-01-09T16:23:32.631Z',
             status: 'ready',
@@ -199,7 +198,7 @@ experiment('modules/billing/services/batch-service', () => {
             billingBatchId: 'b08b07e0-8467-4e43-888f-a23d08c98a28',
             region,
             batchType: 'supplementary',
-            season: CHARGE_SEASON.allYear,
+            isSummer: false,
             dateCreated: '2020-01-09T16:11:09.981Z',
             dateUpdated: '2020-01-09T16:11:17.077Z',
             status: 'review',
@@ -245,7 +244,7 @@ experiment('modules/billing/services/batch-service', () => {
       expect(batches[0]).to.be.instanceOf(Batch);
       expect(batches[0].id).to.equal(response.data[0].billingBatchId);
       expect(batches[0].type).to.equal(response.data[0].batchType);
-      expect(batches[0].season).to.equal(response.data[0].season);
+      expect(batches[0].isSummer).to.equal(response.data[0].isSummer);
       expect(batches[0].startYear.yearEnding).to.equal(response.data[0].fromFinancialYearEnding);
       expect(batches[0].endYear.yearEnding).to.equal(response.data[0].toFinancialYearEnding);
       expect(batches[0].status).to.equal(response.data[0].status);
@@ -255,7 +254,7 @@ experiment('modules/billing/services/batch-service', () => {
       expect(batches[1]).to.be.instanceOf(Batch);
       expect(batches[1].id).to.equal(response.data[1].billingBatchId);
       expect(batches[1].type).to.equal(response.data[1].batchType);
-      expect(batches[1].season).to.equal(response.data[1].season);
+      expect(batches[1].isSummer).to.equal(response.data[1].isSummer);
       expect(batches[1].startYear.yearEnding).to.equal(response.data[1].fromFinancialYearEnding);
       expect(batches[1].endYear.yearEnding).to.equal(response.data[1].toFinancialYearEnding);
       expect(batches[1].status).to.equal(response.data[1].status);
@@ -561,7 +560,7 @@ experiment('modules/billing/services/batch-service', () => {
           billingBatchId: '11111111-0000-0000-0000-000000000000',
           regionId: '22222222-0000-0000-0000-000000000000',
           batchType: 'supplementary',
-          season: CHARGE_SEASON.allYear,
+          isSummer: false,
           status: 'processing',
           region: {
             regionId: '22222222-0000-0000-0000-000000000000',
@@ -575,7 +574,7 @@ experiment('modules/billing/services/batch-service', () => {
           billingBatchId: '33333333-0000-0000-0000-000000000000',
           regionId,
           batchType: 'supplementary',
-          season: CHARGE_SEASON.allYear,
+          isSummer: false,
           status: 'processing',
           region: {
             regionId,
@@ -840,7 +839,7 @@ experiment('modules/billing/services/batch-service', () => {
         newRepos.billingBatches.findByStatuses.resolves([{
           billingBatchId: existingBatchId,
           batchType: 'supplementary',
-          season: CHARGE_SEASON.allYear,
+          isSummer: false,
           status: 'processing',
           regionId,
           region: {
@@ -893,7 +892,7 @@ experiment('modules/billing/services/batch-service', () => {
             batchType: 'annual',
             fromFinancialYearEnding: 2019,
             toFinancialYearEnding: 2019,
-            season: 'all-year'
+            isSummer: false
           }));
         });
 
@@ -914,7 +913,7 @@ experiment('modules/billing/services/batch-service', () => {
             batchType: 'supplementary',
             fromFinancialYearEnding: 2013,
             toFinancialYearEnding: 2019,
-            season: 'all-year'
+            isSummer: false
           }));
         });
 
@@ -935,7 +934,7 @@ experiment('modules/billing/services/batch-service', () => {
             batchType: 'two_part_tariff',
             fromFinancialYearEnding: 2019,
             toFinancialYearEnding: 2019,
-            season: 'summer'
+            isSummer: true
           }));
         });
 

--- a/test/modules/billing/services/charge-version-service.js
+++ b/test/modules/billing/services/charge-version-service.js
@@ -23,7 +23,7 @@ const createBatch = (type = 'annual') => {
     region: new Region(uuid()),
     startYear: new FinancialYear(2016),
     endYear: new FinancialYear(2020),
-    season: 'summer',
+    isSummer: true,
     type
   });
 };
@@ -58,7 +58,7 @@ experiment('modules/billing/services/charge-version-service', () => {
         expect(params.regionId).to.equal(batch.region.id);
         expect(params.fromFinancialYearEnding).to.equal(2016);
         expect(params.toFinancialYearEnding).to.equal(2020);
-        expect(params.season).to.equal('summer');
+        expect(params.isSummer).to.equal(true);
       });
     });
 

--- a/test/modules/billing/services/two-part-tariff-service/returns-helpers.js
+++ b/test/modules/billing/services/two-part-tariff-service/returns-helpers.js
@@ -52,7 +52,7 @@ experiment('modules/billing/services/two-part-tariff-service/returns-helpers .ge
   });
 
   test('gets correct return cycle dates for winter batch', async () => {
-    batch.season = 'winter';
+    batch.isSummer = false;
     result = await returnsHelpers.getReturnsForMatching(licence, batch);
 
     const [, startDate, endDate] = returns.getReturnsForLicence.lastCall.args;

--- a/test/modules/billing/services/two-part-tariff-service/test-batch.js
+++ b/test/modules/billing/services/two-part-tariff-service/test-batch.js
@@ -60,7 +60,7 @@ invoice.fromHash({
 const batch = new Batch();
 batch.fromHash({
   type: Batch.BATCH_TYPE.twoPartTariff,
-  season: 'summer',
+  isSummer: true,
   status: Batch.BATCH_STATUS.processing,
   startYear: new FinancialYear(2019),
   endYear: new FinancialYear(2019)


### PR DESCRIPTION
WATER-2611

Changes batches to have the concept of is_summer rather than season.
This defaults to false and would be true only for some two part tariff
bill runs.

Changes batches table to have is_summer flag