### PR TITLE
Include invoiceId in invoiceLicence model

### DIFF
--- a/src/lib/models/invoice-licence.js
+++ b/src/lib/models/invoice-licence.js
@@ -11,7 +11,8 @@ const Role = require('./role');
 
 const {
   assertIsArrayOfType,
-  assertIsInstanceOf
+  assertIsInstanceOf,
+  assertId
 } = require('./validators');
 
 const Model = require('./model');
@@ -120,6 +121,19 @@ class InvoiceLicence extends Model {
       get(this, '_address.id'),
       get(this, '_contact.id')
     ].join('.');
+  }
+
+  /**
+   * Parent invoice ID
+   * @param {String} invoiceId - GUID
+   */
+  set invoiceId (invoiceId) {
+    assertId(invoiceId);
+    this._invoiceId = invoiceId;
+  }
+
+  get invoiceId () {
+    return this._invoiceId;
   }
 }
 

--- a/src/modules/billing/mappers/invoice-licence.js
+++ b/src/modules/billing/mappers/invoice-licence.js
@@ -37,6 +37,7 @@ const dbToModel = row => {
     invoiceLicence.transactions = row.billingTransactions.map(transaction.dbToModel);
   }
   invoiceLicence.licence = licence.dbToModel(row.licence);
+  invoiceLicence.invoiceId = row.billingInvoiceId;
   return invoiceLicence;
 };
 

--- a/test/lib/models/invoice-licence.js
+++ b/test/lib/models/invoice-licence.js
@@ -27,6 +27,7 @@ const createData = () => {
 
   return {
     id: 'bc9541fc-bc20-4cf4-a72e-412795748e5d',
+    invoiceId: 'abdc7d1d-3389-48d3-991e-1eeedacc6a59',
     licence,
     company,
     contact,
@@ -197,6 +198,20 @@ experiment('lib/models/invoice-licence', () => {
       expect(json.address.id).to.equal(data.address.id);
       expect(json.transactions[0].id).to.equal(transaction.id);
       expect(json.transactions[0].value).to.equal(transaction.value);
+    });
+  });
+
+  experiment('.invoiceId', () => {
+    test('can be set to a guid string', async () => {
+      invoiceLicence.invoiceId = data.invoiceId;
+      expect(invoiceLicence.invoiceId).to.equal(data.invoiceId);
+    });
+
+    test('throws an error if set to a non-guid string', async () => {
+      const func = () => {
+        invoiceLicence.invoiceId = 'hey';
+      };
+      expect(func).to.throw();
     });
   });
 });

--- a/test/modules/billing/mappers/invoice-licence.js
+++ b/test/modules/billing/mappers/invoice-licence.js
@@ -49,7 +49,8 @@ experiment('modules/billing/mappers/invoice-licence', () => {
         billingInvoiceLicenceId: '4e44ea0b-62fc-4a3d-82ed-6ff563f1e39b',
         companyId: '40283a80-766f-481f-ba54-484ac0b7ea6d',
         addressId: '399282c3-f9b4-4a4b-af1b-0019e040ad61',
-        licence: createLicence()
+        licence: createLicence(),
+        billingInvoiceId: 'cf796261-fc3a-4203-86fd-a4b39e9f3f88'
       };
 
       beforeEach(async () => {
@@ -78,15 +79,20 @@ experiment('modules/billing/mappers/invoice-licence', () => {
       test('the invoiceLicence has a Licence', async () => {
         expect(result.licence instanceof Licence).to.be.true();
       });
+
+      test('the invoiceId is set', async () => {
+        expect(result.invoiceId).to.equal(dbRow.billingInvoiceId);
+      });
     });
 
-    experiment('when there contact ID is set', () => {
+    experiment('when the contact ID is set', () => {
       const dbRow = {
         billingInvoiceLicenceId: '4e44ea0b-62fc-4a3d-82ed-6ff563f1e39b',
         companyId: '40283a80-766f-481f-ba54-484ac0b7ea6d',
         addressId: '399282c3-f9b4-4a4b-af1b-0019e040ad61',
         contactId: 'b21a7769-942e-4166-a787-a16701f25e4e',
-        licence: createLicence()
+        licence: createLicence(),
+        billingInvoiceId: 'cf796261-fc3a-4203-86fd-a4b39e9f3f88'
       };
 
       beforeEach(async () => {
@@ -113,7 +119,8 @@ experiment('modules/billing/mappers/invoice-licence', () => {
             billingTransactionId: uuid()
           }, {
             billingTransactionId: uuid()
-          }]
+          }],
+          billingInvoiceId: 'cf796261-fc3a-4203-86fd-a4b39e9f3f88'
         };
         result = invoiceLicenceMapper.dbToModel(dbRow);
       });

--- a/test/modules/billing/services/invoice-service.js
+++ b/test/modules/billing/services/invoice-service.js
@@ -59,6 +59,7 @@ const createBatchData = () => ({
     invoiceAccountId: INVOICE_1_ACCOUNT_ID,
     invoiceAccountNumber: INVOICE_1_ACCOUNT_NUMBER,
     billingInvoiceLicences: [{
+      billingInvoiceId: uuid(),
       licence: {
         licenceId: LICENCE_ID,
         licenceRef: '01/123/ABC',
@@ -71,6 +72,7 @@ const createBatchData = () => ({
         }
       }
     }, {
+      billingInvoiceId: uuid(),
       licence: {
         licenceId: LICENCE_ID,
         licenceRef: '02/345',
@@ -87,6 +89,7 @@ const createBatchData = () => ({
     invoiceAccountId: INVOICE_2_ACCOUNT_ID,
     invoiceAccountNumber: INVOICE_2_ACCOUNT_NUMBER,
     billingInvoiceLicences: [{
+      billingInvoiceId: uuid(),
       licence: {
         licenceId: LICENCE_ID,
         licenceRef: '04/563',
@@ -169,6 +172,7 @@ const createInvoiceData = () => ({
   invoiceAccountId: INVOICE_1_ACCOUNT_ID,
   invoiceAccountNumber: INVOICE_1_ACCOUNT_NUMBER,
   billingInvoiceLicences: [{
+    billingInvoiceId: uuid(),
     licence: {
       licenceId: LICENCE_ID,
       licenceRef: '01/123/ABC',
@@ -203,6 +207,7 @@ const createOneWithInvoicesWithTransactions = () => ({
     invoiceAccountId: INVOICE_1_ACCOUNT_ID,
     invoiceAccountNumber: INVOICE_1_ACCOUNT_NUMBER,
     billingInvoiceLicences: [{
+      billingInvoiceId: uuid(),
       licence: {
         licenceId: LICENCE_ID,
         licenceRef: '01/123/ABC',
@@ -231,6 +236,7 @@ const createOneWithInvoicesWithTransactions = () => ({
     invoiceAccountId: INVOICE_2_ACCOUNT_ID,
     invoiceAccountNumber: INVOICE_2_ACCOUNT_NUMBER,
     billingInvoiceLicences: [{
+      billingInvoiceId: uuid(),
       licence: {
         licenceId: LICENCE_ID,
         licenceRef: '01/123/ABC',
@@ -243,6 +249,7 @@ const createOneWithInvoicesWithTransactions = () => ({
         }
       }
     }, {
+      billingInvoiceId: uuid(),
       licence: {
         licenceId: LICENCE_ID,
         licenceRef: '02/345',

--- a/test/modules/billing/services/supplementary-billing-service.js
+++ b/test/modules/billing/services/supplementary-billing-service.js
@@ -38,6 +38,7 @@ const createFullTransaction = (...args) => ({
     loss: 'high'
   },
   billingInvoiceLicence: {
+    billingInvoiceId: '6046df4e-c5fa-462c-8afb-dee31c88d62d',
     billingInvoice: {
       invoiceAccountId
     },


### PR DESCRIPTION
Adds the invoiceId to the invoiceLicence model.
This is so the UI can request the parent invoice when it only has an invoiceLicence model