### PR TITLE
Fixes issue with CRM v2 invoice accounts connector

### DIFF
--- a/src/lib/connectors/crm-v2/invoice-accounts.js
+++ b/src/lib/connectors/crm-v2/invoice-accounts.js
@@ -1,21 +1,29 @@
 'use strict';
 
+const { chunk, flatMap } = require('lodash');
 const urlJoin = require('url-join');
 const { serviceRequest } = require('@envage/water-abstraction-helpers');
 const config = require('../../../../config');
 
 const getUri = (...tail) => urlJoin(config.services.crm_v2, 'invoice-accounts', ...tail);
 
+const getBatch = ids =>
+  serviceRequest.get(getUri(), {
+    qs: { id: ids },
+    qsStringifyOptions: { arrayFormat: 'repeat' }
+  });
+
 /**
  * Gets the invoice accounts including company data
  * for the given for the given invoice account ids
  * @param {Array<String>} invoiceAccountids The array of invoice account ids to fetch
  */
-const getInvoiceAccountsByIds = ids => {
-  return serviceRequest.get(getUri(), {
-    qs: { id: ids },
-    qsStringifyOptions: { arrayFormat: 'repeat' }
-  });
+const getInvoiceAccountsByIds = async ids => {
+  // Split array into chunks to avoid exceeding max query limit of 1024
+  const idBatches = chunk(ids, 24);
+  // Get batches
+  const results = await Promise.all(idBatches.map(getBatch));
+  return flatMap(results);
 };
 
 /**


### PR DESCRIPTION
An issue was found where for large bill runs, the number of invoice accounts requested from the CRM caused the max advisable query length of 1024 to be exceeded.
This fix resolves this by chunking the queries.