### PR TITLE
Feat: Add connector code from CRM test data endpoints

### DIFF
--- a/src/lib/connectors/crm-v2/addresses.js
+++ b/src/lib/connectors/crm-v2/addresses.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const urlJoin = require('url-join');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+const config = require('../../../../config');
+
+const getUri = (...tail) => urlJoin(config.services.crm_v2, 'addresses', ...tail);
+
+/**
+ * Get a single address
+ * @param {String} addressId The uuid of the address to retrieve
+ */
+const getAddress = addressId => serviceRequest.get(getUri(addressId));
+
+/**
+ * Creates an address entity in the CRM
+ *
+ * @param {Object} address The address data to save in the CRM
+ */
+const createAddress = async address => {
+  const uri = getUri();
+  return serviceRequest.post(uri, { body: address });
+};
+
+exports.getAddress = getAddress;
+exports.createAddress = createAddress;

--- a/src/lib/connectors/crm-v2/companies.js
+++ b/src/lib/connectors/crm-v2/companies.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const urlJoin = require('url-join');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+const config = require('../../../../config');
+
+const getUri = (...tail) => urlJoin(config.services.crm_v2, 'companies', ...tail);
+
+/**
+ * Get a single company
+ * @param {String} companyId The uuid of the company to retrieve
+ */
+const getCompany = companyId => serviceRequest.get(getUri(companyId));
+
+/**
+ * Creates a company entity in the CRM
+ *
+ * @param {Object} company The company data to save in the CRM
+ */
+const createCompany = async company => {
+  const uri = getUri();
+  return serviceRequest.post(uri, { body: company });
+};
+
+/**
+ * Creates a company addresses entity in the CRM
+ *
+ * @param {String} companyId The company that will have the address added to
+ * @param {Object} companyAddress The company address data
+ */
+const createCompanyAddress = async (companyId, companyAddress) => {
+  const uri = getUri(companyId, 'addresses');
+  return serviceRequest.post(uri, { body: companyAddress });
+};
+
+/**
+ * Creates a company contacts entity in the CRM
+ *
+ * @param {String} companyId The company that will have the contact added to
+ * @param {Object} companyContact The company contact data
+ */
+const createCompanyContact = async (companyId, companyContact) => {
+  const uri = getUri(companyId, 'contacts');
+  return serviceRequest.post(uri, { body: companyContact });
+};
+
+exports.getCompany = getCompany;
+exports.createCompany = createCompany;
+exports.createCompanyAddress = createCompanyAddress;
+exports.createCompanyContact = createCompanyContact;

--- a/src/lib/connectors/crm-v2/contacts.js
+++ b/src/lib/connectors/crm-v2/contacts.js
@@ -26,5 +26,18 @@ const getContacts = contactIds => {
   });
 };
 
+/**
+ * Creates a contact entity in the CRM
+ *
+ * @param {Object} contact The contact data
+ */
+const createContact = async contact => {
+  return serviceRequest.post(
+    getUri(),
+    { body: contact }
+  );
+};
+
+exports.createContact = createContact;
 exports.getContact = getContact;
 exports.getContacts = getContacts;

--- a/src/lib/connectors/crm-v2/documents.js
+++ b/src/lib/connectors/crm-v2/documents.js
@@ -9,6 +9,14 @@ const config = require('../../../../config');
 const VALID_LICENCE_NUMBER = Joi.string().required().example('01/123/R01');
 const VALID_GUID = Joi.string().guid().required();
 
+const getDocumentsUrl = (...tail) => {
+  return urlJoin(config.services.crm_v2, 'documents', ...tail);
+};
+
+const getDocumentRolesUrl = (...tail) => {
+  return urlJoin(config.services.crm_v2, 'document-roles', ...tail);
+};
+
 /**
  * Get a list of documents for the given licence number
  * @param {String} licenceNumber
@@ -16,8 +24,7 @@ const VALID_GUID = Joi.string().guid().required();
  */
 const getDocuments = licenceNumber => {
   Joi.assert(licenceNumber, VALID_LICENCE_NUMBER);
-  const uri = urlJoin(config.services.crm_v2, '/documents');
-  return serviceRequest.get(uri, {
+  return serviceRequest.get(getDocumentsUrl(), {
     qs: {
       documentRef: licenceNumber,
       regime: 'water',
@@ -33,9 +40,24 @@ const getDocuments = licenceNumber => {
  */
 const getDocument = documentId => {
   Joi.assert(documentId, VALID_GUID);
-  const uri = urlJoin(config.services.crm_v2, '/documents/', documentId);
-  return serviceRequest.get(uri);
+  return serviceRequest.get(getDocumentsUrl(documentId));
 };
 
-exports.getDocuments = getDocuments;
+const createDocumentRole = async (documentId, documentRole) => {
+  const url = getDocumentsUrl(documentId, 'roles');
+  return serviceRequest.post(url, { body: documentRole });
+};
+
+/**
+ * Get a single document role for the requested ID
+ * @param {String} licenceNumber
+ * @return {Promise<Array>}
+ */
+const getDocumentRole = documentRoleId => {
+  return serviceRequest.get(getDocumentRolesUrl(documentRoleId));
+};
+
+exports.createDocumentRole = createDocumentRole;
 exports.getDocument = getDocument;
+exports.getDocumentRole = getDocumentRole;
+exports.getDocuments = getDocuments;

--- a/src/lib/connectors/crm-v2/invoice-accounts.js
+++ b/src/lib/connectors/crm-v2/invoice-accounts.js
@@ -32,5 +32,28 @@ const getInvoiceAccountsByIds = async ids => {
  */
 const getInvoiceAccountById = id => serviceRequest.get(getUri(id));
 
+/**
+ * Creates an invoice account entity in the CRM
+ *
+ * @param {Object} invoiceAccount The invoice account to persist
+ */
+const createInvoiceAccount = invoiceAccount => {
+  return serviceRequest.post(getUri(), { body: invoiceAccount });
+};
+
+/**
+ * Creates an invoice account address association to the invoice
+ * account with the given invoice account id
+ *
+ * @param {String} invoiceAccountId The invoice account to associate the address with
+ * @param {Object} invoiceAccountAddress The invoice account address to persist
+ */
+const createInvoiceAccountAddress = (invoiceAccountId, invoiceAccountAddress) => {
+  const url = getUri(invoiceAccountId, 'addresses');
+  return serviceRequest.post(url, { body: invoiceAccountAddress });
+};
+
+exports.createInvoiceAccount = createInvoiceAccount;
+exports.createInvoiceAccountAddress = createInvoiceAccountAddress;
 exports.getInvoiceAccountById = getInvoiceAccountById;
 exports.getInvoiceAccountsByIds = getInvoiceAccountsByIds;

--- a/src/lib/connectors/crm-v2/test-data.js
+++ b/src/lib/connectors/crm-v2/test-data.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const urlJoin = require('url-join');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+const config = require('../../../../config');
+
+/**
+ * Deletes all the test data from the CRM
+ *
+ */
+const deleteTestData = () => {
+  const url = urlJoin(config.services.crm_v2, 'test-data');
+  return serviceRequest.delete(url);
+};
+
+exports.deleteTestData = deleteTestData;

--- a/test/lib/connectors/crm-v2/addresses.js
+++ b/test/lib/connectors/crm-v2/addresses.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const uuid = require('uuid/v4');
+
+const addressConnector = require('../../../../src/lib/connectors/crm-v2/addresses');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+const config = require('../../../../config');
+
+experiment('lib/connectors/crm-v2/addresses', () => {
+  beforeEach(async () => {
+    sandbox.stub(config.services, 'crm_v2').value('http://test.defra');
+    sandbox.stub(serviceRequest, 'get');
+    sandbox.stub(serviceRequest, 'post');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getAddress', () => {
+    let response;
+
+    beforeEach(async () => {
+      serviceRequest.get.resolves({
+        addressId: 'test-address-id'
+      });
+
+      response = await addressConnector.getAddress('test-address-id');
+    });
+
+    test('makes a request to the expected URL', async () => {
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal('http://test.defra/addresses/test-address-id');
+    });
+
+    test('returns the result from the crm', async () => {
+      expect(response).to.equal({
+        addressId: 'test-address-id'
+      });
+    });
+  });
+
+  experiment('.createAddress', () => {
+    let address;
+    let addressId;
+    let result;
+
+    beforeEach(async () => {
+      addressId = uuid();
+      address = { addressId };
+
+      serviceRequest.post.resolves(address);
+      result = await addressConnector.createAddress(address);
+    });
+
+    test('makes a post to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal('http://test.defra/addresses');
+    });
+
+    test('passes the address to the post', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options).to.equal({ body: address });
+    });
+
+    test('returns the entity from the CRM', async () => {
+      expect(result).to.equal(address);
+    });
+  });
+});

--- a/test/lib/connectors/crm-v2/companies.js
+++ b/test/lib/connectors/crm-v2/companies.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const uuid = require('uuid/v4');
+
+const comapnyConnector = require('../../../../src/lib/connectors/crm-v2/companies');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+const config = require('../../../../config');
+
+experiment('lib/connectors/crm-v2/companies', () => {
+  beforeEach(async () => {
+    sandbox.stub(config.services, 'crm_v2').value('http://test.defra');
+    sandbox.stub(serviceRequest, 'get');
+    sandbox.stub(serviceRequest, 'post');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getCompany', () => {
+    let response;
+
+    beforeEach(async () => {
+      serviceRequest.get.resolves({
+        companyId: 'test-company-id'
+      });
+
+      response = await comapnyConnector.getCompany('test-company-id');
+    });
+
+    test('makes a request to the expected URL', async () => {
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal('http://test.defra/companies/test-company-id');
+    });
+
+    test('returns the result from the crm', async () => {
+      expect(response).to.equal({
+        companyId: 'test-company-id'
+      });
+    });
+  });
+
+  experiment('.createCompany', () => {
+    let company;
+    let companyId;
+    let result;
+
+    beforeEach(async () => {
+      companyId = uuid();
+      company = { companyId };
+
+      serviceRequest.post.resolves(company);
+      result = await comapnyConnector.createCompany(company);
+    });
+
+    test('makes a post to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal('http://test.defra/companies');
+    });
+
+    test('passes the company to the post', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options).to.equal({ body: company });
+    });
+
+    test('returns the entity from the CRM', async () => {
+      expect(result).to.equal(company);
+    });
+  });
+
+  experiment('.createCompanyAddress', () => {
+    let companyAddress;
+    let companyAddressId;
+    let addressId;
+    let companyId;
+    let result;
+
+    beforeEach(async () => {
+      addressId = uuid();
+      companyId = uuid();
+      companyAddressId = uuid();
+      companyAddress = { addressId };
+
+      serviceRequest.post.resolves({ companyAddressId, ...companyAddress });
+      result = await comapnyConnector.createCompanyAddress(companyId, companyAddress);
+    });
+
+    test('makes a post to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal(`http://test.defra/companies/${companyId}/addresses`);
+    });
+
+    test('passes the company address data to the post', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options).to.equal({ body: companyAddress });
+    });
+
+    test('returns the entity from the CRM', async () => {
+      expect(result).to.equal({
+        companyAddressId,
+        ...companyAddress
+      });
+    });
+  });
+
+  experiment('.createCompanyContact', () => {
+    let companyContact;
+    let companyContactId;
+    let contactId;
+    let companyId;
+    let result;
+
+    beforeEach(async () => {
+      contactId = uuid();
+      companyId = uuid();
+      companyContactId = uuid();
+      companyContact = { contactId };
+
+      serviceRequest.post.resolves({ companyContactId, ...companyContact });
+      result = await comapnyConnector.createCompanyContact(companyId, companyContact);
+    });
+
+    test('makes a post to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal(`http://test.defra/companies/${companyId}/contacts`);
+    });
+
+    test('passes the company address data to the post', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options).to.equal({ body: companyContact });
+    });
+
+    test('returns the entity from the CRM', async () => {
+      expect(result).to.equal({
+        companyContactId,
+        ...companyContact
+      });
+    });
+  });
+});

--- a/test/lib/connectors/crm-v2/contacts.js
+++ b/test/lib/connectors/crm-v2/contacts.js
@@ -9,8 +9,9 @@ const {
 const { expect } = require('@hapi/code');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
+const uuid = require('uuid/v4');
 
-const contacts = require('../../../../src/lib/connectors/crm-v2/contacts');
+const contactsConnector = require('../../../../src/lib/connectors/crm-v2/contacts');
 const { serviceRequest } = require('@envage/water-abstraction-helpers');
 const config = require('../../../../config');
 
@@ -18,6 +19,7 @@ experiment('lib/connectors/crm-v2/contacts', () => {
   beforeEach(async () => {
     sandbox.stub(config.services, 'crm_v2').value('http://test.defra');
     sandbox.stub(serviceRequest, 'get').resolves();
+    sandbox.stub(serviceRequest, 'post');
   });
 
   afterEach(async () => {
@@ -32,7 +34,7 @@ experiment('lib/connectors/crm-v2/contacts', () => {
         contactId: 'test-contact-id'
       });
 
-      response = await contacts.getContact('test-contact-id');
+      response = await contactsConnector.getContact('test-contact-id');
     });
 
     test('makes a request to the expected URL', async () => {
@@ -56,7 +58,7 @@ experiment('lib/connectors/crm-v2/contacts', () => {
         { contactId: 'test-contact-id-2' }
       ]);
 
-      response = await contacts.getContacts([
+      response = await contactsConnector.getContacts([
         'test-contact-id-1',
         'test-contact-id-2'
       ]);
@@ -85,6 +87,35 @@ experiment('lib/connectors/crm-v2/contacts', () => {
         { contactId: 'test-contact-id-1' },
         { contactId: 'test-contact-id-2' }
       ]);
+    });
+  });
+
+  experiment('.createContact', () => {
+    let contact;
+    let contactId;
+    let result;
+
+    beforeEach(async () => {
+      contactId = uuid();
+      contact = { firstName: 'Test' };
+
+      serviceRequest.post.resolves({ contactId, ...contact });
+      result = await contactsConnector.createContact(contact);
+    });
+
+    test('makes a post to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal('http://test.defra/contacts');
+    });
+
+    test('passes the contact to the post', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options).to.equal({ body: contact });
+    });
+
+    test('returns the entity from the CRM', async () => {
+      expect(result.contactId).to.equal(contactId);
+      expect(result.firstName).to.equal('Test');
     });
   });
 });

--- a/test/lib/connectors/crm-v2/invoice-accounts.js
+++ b/test/lib/connectors/crm-v2/invoice-accounts.js
@@ -9,6 +9,7 @@ const {
 const { expect } = require('@hapi/code');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
+const uuid = require('uuid/v4');
 
 const invoiceAccountConnector = require('../../../../src/lib/connectors/crm-v2/invoice-accounts');
 const { serviceRequest } = require('@envage/water-abstraction-helpers');
@@ -18,6 +19,7 @@ experiment('lib/connectors/crm-v2/invoice-accounts', () => {
   beforeEach(async () => {
     sandbox.stub(config.services, 'crm_v2').value('http://test.defra');
     sandbox.stub(serviceRequest, 'get').resolves();
+    sandbox.stub(serviceRequest, 'post');
   });
 
   afterEach(async () => {
@@ -80,6 +82,74 @@ experiment('lib/connectors/crm-v2/invoice-accounts', () => {
 
     test('returns the result from the crm', async () => {
       expect(response).to.equal({ invoiceAccountId: 'test-id-1' });
+    });
+  });
+
+  experiment('.createInvoiceAccount', () => {
+    let invoiceAccount;
+    let invoiceAccountId;
+    let createdInvoiceAccount;
+    let result;
+
+    beforeEach(async () => {
+      invoiceAccountId = uuid();
+      invoiceAccount = {
+        invoiceAccountNumber: '1234abcd'
+      };
+      createdInvoiceAccount = { invoiceAccountId, ...invoiceAccount };
+      serviceRequest.post.resolves(createdInvoiceAccount);
+      result = await invoiceAccountConnector.createInvoiceAccount(invoiceAccount);
+    });
+
+    test('makes a post request to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal('http://test.defra/invoice-accounts');
+    });
+
+    test('passes the invoice account in the body', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options.body).to.equal(invoiceAccount);
+    });
+
+    test('returns the created entity', async () => {
+      expect(result).to.equal(createdInvoiceAccount);
+    });
+  });
+
+  experiment('.createInvoiceAccountAddress', () => {
+    let invoiceAccountId;
+    let invoiceAccountAddress;
+    let invoiceAccountAddressId;
+    let createdInvoiceAccountAddress;
+    let result;
+
+    beforeEach(async () => {
+      invoiceAccountId = uuid();
+      invoiceAccountAddressId = uuid();
+      invoiceAccountAddress = {
+        addressId: uuid()
+      };
+      createdInvoiceAccountAddress = {
+        invoiceAccountAddressId,
+        ...invoiceAccountAddress
+      };
+
+      serviceRequest.post.resolves(createdInvoiceAccountAddress);
+      result = await invoiceAccountConnector.createInvoiceAccountAddress(invoiceAccountId, invoiceAccountAddress);
+    });
+
+    test('makes a post request to the expected URL', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal(`http://test.defra/invoice-accounts/${invoiceAccountId}/addresses`);
+    });
+
+    test('passes the invoice account address in the body', async () => {
+      const [, options] = serviceRequest.post.lastCall.args;
+      expect(options.body).to.equal(invoiceAccountAddress);
+    });
+
+    test('returns the created entity', async () => {
+      expect(result).to.equal(createdInvoiceAccountAddress);
     });
   });
 });

--- a/test/lib/connectors/crm-v2/test-data.js
+++ b/test/lib/connectors/crm-v2/test-data.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const testDataConnector = require('../../../../src/lib/connectors/crm-v2/test-data');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+const config = require('../../../../config');
+
+experiment('lib/connectors/crm-v2/test-data', () => {
+  beforeEach(async () => {
+    sandbox.stub(config.services, 'crm_v2').value('http://test.defra');
+    sandbox.stub(serviceRequest, 'delete');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.deleteTestData', () => {
+    beforeEach(async () => {
+      await testDataConnector.deleteTestData();
+
+      test('makes a delete request to the expected URL', async () => {
+        const [url] = serviceRequest.delete.lastCall.args;
+        expect(url).to.equal('http://test.defra/test-data');
+      });
+    });
+  });
+});


### PR DESCRIPTION
WATER-2642

Adds the connector code for

 - addresses
 - companies
 - contacts
 - documents
 - invoice-accounts
 - test data