### PR TITLE
Fix: Fix final return line in leap year

### DIFF
--- a/src/modules/returns/lib/api-connector.js
+++ b/src/modules/returns/lib/api-connector.js
@@ -120,7 +120,7 @@ const fetchLines = async (returnId, versionId) => {
     version_id: versionId
   };
   const pagination = {
-    perPage: 365
+    perPage: 366
   };
   const { data, error } = await lines.findMany(filter, sort, pagination);
   if (error) {


### PR DESCRIPTION
WATER-2667

Fixes an issue with the pagination of returns results. It was set to
365 for a max of one years return lines, but this does not work for leap
years. Therefore incremented to 366.