### PR TITLE
Fix: Prevents attempting to deal null batch ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5319,7 +5319,7 @@
         },
         "jsonwebtoken": {
           "version": "8.2.1",
-          "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
           "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
           "requires": {
             "jws": "^3.1.4",

--- a/src/modules/acceptance-tests/lib/batches.js
+++ b/src/modules/acceptance-tests/lib/batches.js
@@ -64,7 +64,9 @@ const deleteBatches = async () => {
     getAnglianAndMidlandsBatchIds()
   ]);
 
-  await deleteUniqueBatches(acceptanceTestBatchIds.concat(areaBatchIds));
+  const toDelete = [...acceptanceTestBatchIds, ...areaBatchIds].filter(id => id !== null);
+
+  await deleteUniqueBatches(toDelete);
 };
 
 exports.delete = deleteBatches;

--- a/test/modules/acceptance-tests/lib/batches.js
+++ b/test/modules/acceptance-tests/lib/batches.js
@@ -34,6 +34,7 @@ experiment('modules/acceptance-tests/batches', () => {
     beforeEach(async () => {
       pool.query.onFirstCall().resolves({
         rows: [
+          { billing_batch_id: null },
           { billing_batch_id: '00000000-0000-0000-0000-000000000000' }
         ]
       });


### PR DESCRIPTION
During acceptance test teardown null batch ids are filtered to prevent
bookshelf throwing an error