### PR TITLE
Fix issue with empty lines in CSV for returns upload

### DIFF
--- a/src/modules/returns/lib/csv-adapter/csv-parser.js
+++ b/src/modules/returns/lib/csv-adapter/csv-parser.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const util = require('util');
+const parseCsv = util.promisify(require('csv-parse'));
+
+const parseOptions = {
+  skip_lines_with_empty_values: true,
+  skip_empty_lines: true,
+  trim: true
+};
+
+exports.parseCsv = str => parseCsv(str, parseOptions);

--- a/src/modules/returns/lib/csv-adapter/mapper.js
+++ b/src/modules/returns/lib/csv-adapter/mapper.js
@@ -1,10 +1,10 @@
 const { unzip } = require('lodash');
 const common = require('../common-mapping');
-const util = require('util');
-const parseCsv = util.promisify(require('csv-parse'));
+
 const moment = require('moment');
 const DATE_FORMAT = 'YYYY-MM-DD';
 
+const csvParser = require('./csv-parser');
 const dateParser = require('./date-parser');
 
 const ROW_INDEX = {
@@ -174,7 +174,7 @@ const isEmptyReturn = column => {
  * @return {Promise<Array>} resolves with array of return objects
  */
 const mapCsv = async (csvStr, user, today) => {
-  const data = await parseCsv(csvStr);
+  const data = await csvParser.parseCsv(csvStr);
 
   const [headers, ...returns] = unzip(data);
 

--- a/src/modules/returns/lib/csv-adapter/validator.js
+++ b/src/modules/returns/lib/csv-adapter/validator.js
@@ -1,19 +1,14 @@
-const parse = require('csv-parse');
-const util = require('util');
-const parseCsv = util.promisify(parse);
+'use strict';
+
 const { isEmpty, flatten, compact, isString, times } = require('lodash');
 
 const { returnIDRegex, parseReturnId } = require('../../../../lib/returns');
+
 const dateParser = require('./date-parser');
+const csvParser = require('./csv-parser');
 
 const lineErrorRegex = /line (\d*)$/;
 const validAbstractionVolumeRegex = /(^Do not edit$)|(^-?\d[\d.,]*$)|(^\s*$)/;
-
-const parseOptions = {
-  skip_lines_with_empty_values: true,
-  skip_empty_lines: true,
-  trim: true
-};
 
 const errorMessages = {
   licenceNumber: 'Licence number is missing',
@@ -244,7 +239,7 @@ const validateLicences = licences => {
 
 const validate = async csv => {
   try {
-    const records = await parseCsv(csv, parseOptions);
+    const records = await csvParser.parseCsv(csv);
 
     // validate the headings
     const headerErrors = validateHeadings(records);


### PR DESCRIPTION
Fixes an issue where empty lines at the bottom of an uploaded CSV caused the mapping stage to fail.

This is fixed by using the same CSV parsing options that were already used for the validation stage.