### PR TITLE
Fixes bulk returns upload issue with large volume of returns in CSV

### DIFF
--- a/test/lib/connectors/returns.js
+++ b/test/lib/connectors/returns.js
@@ -49,6 +49,20 @@ experiment('connectors/returns', () => {
 
       expect(columns).to.include(['return_id', 'status', 'due_date']);
     });
+
+    test('when there are a large number of returns, return IDs are sent in batches of 20', async () => {
+      const returnIds = [...Array(40).keys()];
+      await returns.getActiveReturns(returnIds);
+      expect(returns.returns.findAll.callCount).to.equal(2);
+
+      const [firstBatchFilter] = returns.returns.findAll.firstCall.args;
+      expect(firstBatchFilter.return_id.$in).to.be.an.array().length(20);
+      expect(firstBatchFilter.return_id.$in[0]).to.equal(0);
+
+      const [secondBatchFilter] = returns.returns.findAll.secondCall.args;
+      expect(secondBatchFilter.return_id.$in).to.be.an.array().length(20);
+      expect(secondBatchFilter.return_id.$in[0]).to.equal(20);
+    });
   });
 
   experiment('.getCurrentDueReturns', () => {


### PR DESCRIPTION
Fixes an issue where very large volumes could not be submitted via CSV.

At one stage in the process, active returns are fetched from the returns module, and a very long query string was generated.

This fix requests active returns in batches to avoid the query string exceeding around 2048 chars.