### PR TITLE
Feat: Licence Versions endpoint

### DIFF
--- a/src/lib/connectors/repos/index.js
+++ b/src/lib/connectors/repos/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.applicationState = require('./application-state');
 exports.billingBatches = require('./billing-batches');
 exports.billingBatchChargeVersions = require('./billing-batch-charge-versions');
@@ -9,5 +11,6 @@ exports.changeReasons = require('./change-reasons');
 exports.chargeVersions = require('./charge-versions');
 exports.events = require('./events');
 exports.licenceAgreements = require('./licence-agreements');
+exports.licenceVersions = require('./licence-versions');
 exports.licences = require('./licences');
 exports.regions = require('./regions');

--- a/src/lib/connectors/repos/licence-versions.js
+++ b/src/lib/connectors/repos/licence-versions.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const LicenceVersion = require('../bookshelf/LicenceVersion');
+
+/**
+ * Gets a list of licence versions for the given licence id
+ * @param {String} licenceId - licence id
+ * @return {Promise<Array>}
+ */
+const findByLicenceId = async licenceId => {
+  const licenceVersions = await LicenceVersion
+    .forge()
+    .where('licence_id', licenceId)
+    .fetchAll();
+
+  return licenceVersions.toJSON();
+};
+
+exports.findByLicenceId = findByLicenceId;

--- a/src/lib/mappers/licence-version.js
+++ b/src/lib/mappers/licence-version.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const LicenceVersion = require('../models/licence-version');
+
+const dbToModel = row => {
+  const licenceVersion = new LicenceVersion(row.licenceVersionId);
+
+  return licenceVersion.fromHash({
+    status: row.status,
+    endDate: row.endDate,
+    startDate: row.startDate,
+    externalId: row.externalId,
+    dateUpdated: row.dateUpdated,
+    dateCreated: row.dateCreated,
+    licenceId: row.licenceId,
+    issue: row.issue,
+    increment: row.increment
+  });
+};
+
+exports.dbToModel = dbToModel;

--- a/src/lib/models/licence-version.js
+++ b/src/lib/models/licence-version.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const validators = require('./validators');
+
+const Model = require('./model');
+
+const LICENCE_VERSION_STATUS = {
+  draft: 'draft',
+  current: 'current',
+  superseded: 'superseded'
+};
+
+class LicenceVersion extends Model {
+  get licenceId () { return this._licenceId; }
+  set licenceId (licenceId) {
+    validators.assertId(licenceId);
+    this._licenceId = licenceId;
+  }
+
+  get issue () { return this._issue; }
+  set issue (issue) {
+    validators.assertInteger(issue);
+    this._issue = issue;
+  }
+
+  get increment () { return this._increment; }
+  set increment (increment) {
+    validators.assertInteger(increment);
+    this._increment = increment;
+  }
+
+  get status () { return this._status; }
+  set status (status) {
+    validators.assertEnum(status, Object.values(LICENCE_VERSION_STATUS));
+    this._status = status;
+  }
+
+  get startDate () { return this._startDate; }
+  set startDate (startDate) {
+    this._startDate = this.getDateOrThrow(startDate, 'Start date');
+  }
+
+  get endDate () { return this._endDate; }
+  set endDate (endDate) {
+    const date = this.getDateTimeFromValue(endDate);
+    this._endDate = date;
+  }
+
+  get externalId () { return this._externalId; }
+  set externalId (externalId) {
+    validators.assertString(externalId);
+    this._externalId = externalId;
+  }
+
+  get dateCreated () { return this._dateCreated; }
+  set dateCreated (dateCreated) {
+    this._dateCreated = this.getDateOrThrow(dateCreated, 'Date created');
+  }
+
+  get dateUpdated () { return this._dateUpdated; }
+  set dateUpdated (dateUpdated) {
+    this._dateUpdated = this.getDateOrThrow(dateUpdated, 'Date updated');
+  }
+
+  getDateOrThrow (date, friendlyName) {
+    const momentDate = this.getDateTimeFromValue(date);
+
+    if (momentDate === null) {
+      throw new Error(`${friendlyName} cannot be null`);
+    }
+
+    return momentDate;
+  };
+}
+
+module.exports = LicenceVersion;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -1,5 +1,8 @@
+'use strict';
+
 const repos = require('../connectors/repos');
-const mappers = require('../mappers');
+const licenceMapper = require('../mappers/licence');
+const licenceVersionMapper = require('../mappers/licence-version');
 
 /**
  * Gets a licence model by ID
@@ -8,7 +11,13 @@ const mappers = require('../mappers');
  */
 const getLicenceById = async licenceId => {
   const data = await repos.licences.findOne(licenceId);
-  return data && mappers.licence.dbToModel(data);
+  return data && licenceMapper.dbToModel(data);
+};
+
+const getLicenceVersions = async licenceId => {
+  const versions = await repos.licenceVersions.findByLicenceId(licenceId);
+  return versions.map(licenceVersionMapper.dbToModel);
 };
 
 exports.getLicenceById = getLicenceById;
+exports.getLicenceVersions = getLicenceVersions;

--- a/src/modules/licences/controllers/licences.js
+++ b/src/modules/licences/controllers/licences.js
@@ -1,10 +1,18 @@
+'use strict';
+
 const Boom = require('@hapi/boom');
+
 const licencesService = require('../../../lib/services/licences');
 
-const getLicence = async (request, h) => {
+const getLicence = async request => {
   const { licenceId } = request.params;
   const licence = await licencesService.getLicenceById(licenceId);
   return licence || Boom.notFound(`Licence ${licenceId} not found`, { licenceId });
 };
 
+const getLicenceVersions = async request => {
+  return licencesService.getLicenceVersions(request.params.licenceId);
+};
+
 exports.getLicence = getLicence;
+exports.getLicenceVersions = getLicenceVersions;

--- a/src/modules/licences/routes/licences.js
+++ b/src/modules/licences/routes/licences.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Joi = require('@hapi/joi');
 
 const { version } = require('../../../../config');
@@ -15,6 +17,20 @@ module.exports = {
       validate: {
         params: {
           licenceId: Joi.string().guid().required()
+        }
+      }
+    }
+  },
+
+  getLicenceVersions: {
+    method: 'GET',
+    path: `${pathPrefix}{licenceId}/versions`,
+    handler: controller.getLicenceVersions,
+    config: {
+      description: 'Gets the licence versions by licence ID',
+      validate: {
+        params: {
+          licenceId: Joi.string().uuid().required()
         }
       }
     }

--- a/test/lib/connectors/repos/licence-versions.js
+++ b/test/lib/connectors/repos/licence-versions.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const sandbox = require('sinon').createSandbox();
+
+const licenceVersionsRepo = require('../../../../src/lib/connectors/repos/licence-versions');
+const LicenceVersion = require('../../../../src/lib/connectors/bookshelf/LicenceVersion');
+
+experiment('lib/connectors/repos/licence-versions', () => {
+  let stub;
+  let result;
+
+  beforeEach(async () => {
+    stub = {
+      fetchAll: sandbox.stub().resolves({
+        toJSON: () => ([
+          { licenceVersionId: 'ver-1' },
+          { licenceVersionId: 'ver-2' }
+        ])
+      }),
+      where: sandbox.stub().returnsThis()
+    };
+    sandbox.stub(LicenceVersion, 'forge').returns(stub);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.findByLicenceId', () => {
+    beforeEach(async () => {
+      result = await licenceVersionsRepo.findByLicenceId('test-licence-id');
+    });
+
+    test('queries by licence id', async () => {
+      const [field, id] = stub.where.lastCall.args;
+      expect(field).to.equal('licence_id');
+      expect(id).to.equal('test-licence-id');
+    });
+
+    test('calls .fetchAll() to retrieve all matching records', async () => {
+      expect(stub.fetchAll.called).to.be.true();
+    });
+
+    test('resolves with the results', async () => {
+      expect(result).to.equal([
+        { licenceVersionId: 'ver-1' },
+        { licenceVersionId: 'ver-2' }
+      ]);
+    });
+  });
+});

--- a/test/lib/mappers/licence-version.js
+++ b/test/lib/mappers/licence-version.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const moment = require('moment');
+
+const LicenceVersion = require('../../../src/lib/models/licence-version');
+
+const licenceVersionMapper = require('../../../src/lib/mappers/licence-version');
+
+const dbRow = {
+  status: 'superseded',
+  endDate: '2000-01-01',
+  startDate: '1990-01-01',
+  externalId: '1:11:100:0',
+  dateUpdated: '2020-06-02 11:10:00.000000',
+  dateCreated: '2020-06-01 11:10:00.000000',
+  licenceId: '55cdc419-04f8-4844-ad09-94fe92b33453',
+  licenceVersionId: '17c45db7-aeaa-4c2e-bd58-584696b56681',
+  issue: 100,
+  increment: 0
+};
+
+experiment('modules/billing/mappers/licence-version', () => {
+  experiment('.dbToModel', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = licenceVersionMapper.dbToModel(dbRow);
+    });
+
+    test('returns a LicenceVersion instance with correct ID', async () => {
+      expect(result instanceof LicenceVersion).to.be.true();
+      expect(result.id).to.equal(dbRow.licenceVersionId);
+    });
+
+    test('has a status property', async () => {
+      expect(result.status).to.equal(dbRow.status);
+    });
+
+    test('has an endDate property', async () => {
+      expect(result.endDate).to.equal(moment(dbRow.endDate));
+    });
+
+    test('has a startDate property', async () => {
+      expect(result.startDate).to.equal(moment(dbRow.startDate));
+    });
+
+    test('has an externalId property', async () => {
+      expect(result.externalId).to.equal(dbRow.externalId);
+    });
+
+    test('has a dateUpdated property', async () => {
+      expect(result.dateUpdated).to.equal(moment(dbRow.dateUpdated));
+    });
+
+    test('has a dateCreated property', async () => {
+      expect(result.dateCreated).to.equal(moment(dbRow.dateCreated));
+    });
+
+    test('has an issue property', async () => {
+      expect(result.issue).to.equal(dbRow.issue);
+    });
+
+    test('has an increment property', async () => {
+      expect(result.increment).to.equal(dbRow.increment);
+    });
+  });
+});

--- a/test/lib/models/licence-version.js
+++ b/test/lib/models/licence-version.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
+const moment = require('moment');
+
+const LicenceVersion = require('../../../src/lib/models/licence-version');
+
+experiment('lib/models/licence-agreement', () => {
+  let licenceVersion;
+
+  beforeEach(async () => {
+    licenceVersion = new LicenceVersion();
+  });
+
+  experiment('.id', () => {
+    test('can be set to a uuid', async () => {
+      const id = uuid();
+      licenceVersion.id = id;
+      expect(licenceVersion.id).to.equal(id);
+    });
+
+    test('cannot be set to a number', async () => {
+      expect(() => { licenceVersion.id = 123; }).to.throw();
+    });
+  });
+
+  experiment('.issue', () => {
+    test('can be set to an integer', async () => {
+      const issue = 123;
+      licenceVersion.issue = issue;
+      expect(licenceVersion.issue).to.equal(issue);
+    });
+
+    test('cannot be set to a floating point number', async () => {
+      expect(() => { licenceVersion.issue = 1.23; }).to.throw();
+    });
+  });
+
+  experiment('.increment', () => {
+    test('can be set to an integer', async () => {
+      const increment = 1;
+      licenceVersion.increment = increment;
+      expect(licenceVersion.increment).to.equal(increment);
+    });
+
+    test('cannot be set to a floating point number', async () => {
+      expect(() => { licenceVersion.increment = 1.23; }).to.throw();
+    });
+  });
+
+  experiment('.status', () => {
+    test('can be set to draft', async () => {
+      const status = 'draft';
+      licenceVersion.status = status;
+      expect(licenceVersion.status).to.equal(status);
+    });
+
+    test('can be set to superseded', async () => {
+      const status = 'superseded';
+      licenceVersion.status = status;
+      expect(licenceVersion.status).to.equal(status);
+    });
+
+    test('can be set to current', async () => {
+      const status = 'current';
+      licenceVersion.status = status;
+      expect(licenceVersion.status).to.equal(status);
+    });
+
+    test('cannot be set to a different value', async () => {
+      expect(() => { licenceVersion.status = 'finished'; }).to.throw();
+    });
+  });
+
+  experiment('.startDate', () => {
+    test('converts an ISO date string to a moment internally', async () => {
+      const dateString = '2020-01-20T14:51:42.024Z';
+      licenceVersion.startDate = dateString;
+
+      expect(licenceVersion.startDate).to.equal(moment(dateString));
+    });
+
+    test('converts a JS Date to a moment internally', async () => {
+      const date = new Date();
+      licenceVersion.startDate = date;
+
+      expect(licenceVersion.startDate).to.equal(moment(date));
+    });
+
+    test('can be set using a moment', async () => {
+      const now = moment();
+      licenceVersion.startDate = now;
+
+      expect(licenceVersion.startDate).to.equal(now);
+    });
+
+    test('throws for an invalid string', async () => {
+      const dateString = 'not a date';
+      expect(() => { licenceVersion.startDate = dateString; }).to.throw();
+    });
+
+    test('throws for a boolean value', async () => {
+      expect(() => { licenceVersion.startDate = true; }).to.throw();
+    });
+
+    test('throws for null', async () => {
+      expect(() => { licenceVersion.startDate = null; }).to.throw();
+    });
+  });
+
+  experiment('.endDate', () => {
+    test('converts an ISO date string to a moment internally', async () => {
+      const dateString = '2020-01-20T14:51:42.024Z';
+      licenceVersion.endDate = dateString;
+
+      expect(licenceVersion.endDate).to.equal(moment(dateString));
+    });
+
+    test('converts a JS Date to a moment internally', async () => {
+      const date = new Date();
+      licenceVersion.endDate = date;
+
+      expect(licenceVersion.endDate).to.equal(moment(date));
+    });
+
+    test('can be set using a moment', async () => {
+      const now = moment();
+      licenceVersion.endDate = now;
+
+      expect(licenceVersion.endDate).to.equal(now);
+    });
+
+    test('throws for an invalid string', async () => {
+      const dateString = 'not a date';
+      expect(() => { licenceVersion.endDate = dateString; }).to.throw();
+    });
+
+    test('throws for a boolean value', async () => {
+      expect(() => { licenceVersion.endDate = true; }).to.throw();
+    });
+
+    test('allows null', async () => {
+      licenceVersion.endDate = null;
+      expect(licenceVersion.endDate).to.be.null();
+    });
+  });
+
+  experiment('.dateCreated', () => {
+    test('converts an ISO date string to a moment internally', async () => {
+      const dateString = '2020-01-20T14:51:42.024Z';
+      licenceVersion.dateCreated = dateString;
+
+      expect(licenceVersion.dateCreated).to.equal(moment(dateString));
+    });
+
+    test('converts a JS Date to a moment internally', async () => {
+      const date = new Date();
+      licenceVersion.dateCreated = date;
+
+      expect(licenceVersion.dateCreated).to.equal(moment(date));
+    });
+
+    test('can be set using a moment', async () => {
+      const now = moment();
+      licenceVersion.dateCreated = now;
+
+      expect(licenceVersion.dateCreated).to.equal(now);
+    });
+
+    test('throws for an invalid string', async () => {
+      const dateString = 'not a date';
+      expect(() => { licenceVersion.dateCreated = dateString; }).to.throw();
+    });
+
+    test('throws for a boolean value', async () => {
+      expect(() => { licenceVersion.dateCreated = true; }).to.throw();
+    });
+
+    test('throws for null', async () => {
+      expect(() => { licenceVersion.dateCreated = null; }).to.throw();
+    });
+  });
+
+  experiment('.dateUpdated', () => {
+    test('converts an ISO date string to a moment internally', async () => {
+      const dateString = '2020-01-20T14:51:42.024Z';
+      licenceVersion.dateUpdated = dateString;
+
+      expect(licenceVersion.dateUpdated).to.equal(moment(dateString));
+    });
+
+    test('converts a JS Date to a moment internally', async () => {
+      const date = new Date();
+      licenceVersion.dateUpdated = date;
+
+      expect(licenceVersion.dateUpdated).to.equal(moment(date));
+    });
+
+    test('can be set using a moment', async () => {
+      const now = moment();
+      licenceVersion.dateUpdated = now;
+
+      expect(licenceVersion.dateUpdated).to.equal(now);
+    });
+
+    test('throws for an invalid string', async () => {
+      const dateString = 'not a date';
+      expect(() => { licenceVersion.dateUpdated = dateString; }).to.throw();
+    });
+
+    test('throws for a boolean value', async () => {
+      expect(() => { licenceVersion.dateUpdated = true; }).to.throw();
+    });
+
+    test('throws for null', async () => {
+      expect(() => { licenceVersion.dateUpdated = null; }).to.throw();
+    });
+  });
+
+  experiment('.externalId', () => {
+    test('accepts a string', async () => {
+      const externalId = '1:2';
+      licenceVersion.externalId = externalId;
+      expect(licenceVersion.externalId).to.equal(externalId);
+    });
+
+    test('throws for an number', async () => {
+      expect(() => { licenceVersion.externalId = 123; }).to.throw();
+    });
+
+    test('throws for a boolean value', async () => {
+      expect(() => { licenceVersion.externalId = true; }).to.throw();
+    });
+
+    test('throws for null', async () => {
+      expect(() => { licenceVersion.externalId = null; }).to.throw();
+    });
+  });
+});

--- a/test/modules/licences/controllers/licences.js
+++ b/test/modules/licences/controllers/licences.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { expect } = require('@hapi/code');
 const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi/lab').script();
 
@@ -5,12 +7,12 @@ const controller = require('../../../../src/modules/licences/controllers/licence
 const licencesService = require('../../../../src/lib/services/licences');
 const Licence = require('../../../../src/lib/models/licence');
 
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const sandbox = require('sinon').createSandbox();
 
 experiment('modules/licences/controllers/licences.js', () => {
   beforeEach(async () => {
     sandbox.stub(licencesService, 'getLicenceById');
+    sandbox.stub(licencesService, 'getLicenceVersions');
   });
 
   afterEach(async () => {
@@ -53,6 +55,38 @@ experiment('modules/licences/controllers/licences.js', () => {
         expect(result.isBoom).to.be.true();
         expect(result.output.statusCode).to.equal(404);
       });
+    });
+  });
+
+  experiment('.getLicenceVersions', () => {
+    let result;
+    let request;
+    let licenceVersions;
+
+    beforeEach(async () => {
+      licenceVersions = [
+        { licenceVersionId: '1' },
+        { licenceVersionId: '2' }
+      ];
+
+      licencesService.getLicenceVersions.resolves(licenceVersions);
+
+      request = {
+        params: {
+          licenceId: 'test-licence-id'
+        }
+      };
+
+      result = await controller.getLicenceVersions(request);
+    });
+
+    test('passes the licence id to the service layer', async () => {
+      const [id] = licencesService.getLicenceVersions.lastCall.args;
+      expect(id).to.equal(request.params.licenceId);
+    });
+
+    test('returns the licence versions', async () => {
+      expect(result).to.equal(licenceVersions);
     });
   });
 });

--- a/test/modules/licences/routes.js
+++ b/test/modules/licences/routes.js
@@ -1,6 +1,6 @@
-const Hapi = require('@hapi/hapi');
+'use strict';
+
 const { expect } = require('@hapi/code');
-const { cloneDeep } = require('lodash');
 
 const {
   beforeEach,
@@ -8,188 +8,205 @@ const {
   test
 } = exports.lab = require('@hapi/lab').script();
 
+const testHelpers = require('../../test-helpers');
 const routes = require('../../../src/modules/licences/routes');
 const id = '00000000-0000-0000-0000-000000000000';
 
-experiment('/documents/{documentId}/licence', () => {
-  let server;
+experiment('modules/licences/routes', () => {
+  experiment('/documents/{documentId}/licence', () => {
+    let server;
 
-  beforeEach(async () => {
-    const getLicenceByDocumentId = cloneDeep(routes.getLicenceByDocumentId);
-    getLicenceByDocumentId.handler = () => 'ok';
-    server = Hapi.server();
-    server.route(getLicenceByDocumentId);
-  });
-
-  test('validates the documentId must be a GUID', async () => {
-    const url = '/water/1.0/documents/not-a-guid/licence';
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(400);
-  });
-
-  test('allows a valid guid for documentId', async () => {
-    const url = '/water/1.0/documents/00000000-0000-0000-0000-000000000000/licence';
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(200);
-  });
-});
-
-experiment('/documents/{documentId}/licence/conditions', () => {
-  let server;
-
-  beforeEach(async () => {
-    const getLicenceConditionsByDocumentId = cloneDeep(routes.getLicenceConditionsByDocumentId);
-    getLicenceConditionsByDocumentId.handler = () => 'ok';
-    server = Hapi.server();
-    server.route(getLicenceConditionsByDocumentId);
-  });
-
-  test('validates the documentId must be a GUID', async () => {
-    const url = '/water/1.0/documents/not-a-guid/licence/conditions';
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(400);
-  });
-
-  test('allows a valid guid for documentId', async () => {
-    const url = `/water/1.0/documents/${id}/licence/conditions`;
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(200);
-  });
-});
-
-experiment('/documents/{documentId}/licence/points', () => {
-  let server;
-
-  beforeEach(async () => {
-    const getLicencePointsByDocumentId = cloneDeep(routes.getLicencePointsByDocumentId);
-    getLicencePointsByDocumentId.handler = () => 'ok';
-    server = Hapi.server();
-    server.route(getLicencePointsByDocumentId);
-  });
-
-  test('validates the documentId must be a GUID', async () => {
-    const url = '/water/1.0/documents/not-a-guid/licence/points';
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(400);
-  });
-
-  test('allows a valid guid for documentId', async () => {
-    const url = `/water/1.0/documents/${id}/licence/points`;
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(200);
-  });
-});
-
-experiment('/documents/{documentId}/licence/users', () => {
-  let server;
-
-  beforeEach(async () => {
-    const getLicenceUsersByDocumentId = cloneDeep(routes.getLicenceUsersByDocumentId);
-    getLicenceUsersByDocumentId.handler = () => 'ok';
-    server = Hapi.server();
-    server.route(getLicenceUsersByDocumentId);
-  });
-
-  test('validates the documentId must be a GUID', async () => {
-    const url = '/water/1.0/documents/not-a-guid/licence/users';
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(400);
-  });
-
-  test('allows a valid guid for documentId', async () => {
-    const url = `/water/1.0/documents/${id}/licence/users`;
-    const output = await server.inject(url);
-    expect(output.statusCode).to.equal(200);
-  });
-});
-
-experiment('/documents/{documentId}/rename', () => {
-  let server;
-
-  beforeEach(async () => {
-    const postLicenceName = cloneDeep(routes.postLicenceName);
-    postLicenceName.handler = () => 'ok';
-    server = Hapi.server();
-    server.route(postLicenceName);
-  });
-
-  test('validates the documentId must be a GUID', async () => {
-    const url = '/water/1.0/documents/not-a-guid/rename';
-    const output = await server.inject({
-      method: 'POST',
-      url,
-      payload: {
-        userName: 'test@example.com',
-        rename: false,
-        documentName: 'test-doc-name'
-      }
+    beforeEach(async () => {
+      server = testHelpers.createServerForRoute(routes.getLicenceByDocumentId);
     });
-    expect(output.statusCode).to.equal(400);
+
+    test('validates the documentId must be a GUID', async () => {
+      const url = '/water/1.0/documents/not-a-guid/licence';
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('allows a valid guid for documentId', async () => {
+      const url = '/water/1.0/documents/00000000-0000-0000-0000-000000000000/licence';
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(200);
+    });
   });
 
-  test('allows a valid guid for documentId', async () => {
-    const url = `/water/1.0/documents/${id}/rename`;
-    const output = await server.inject({
-      method: 'POST',
-      url,
-      payload: {
-        userName: 'test@example.com',
-        documentName: 'test-doc-name'
-      }
+  experiment('/documents/{documentId}/licence/conditions', () => {
+    let server;
+
+    beforeEach(async () => {
+      server = testHelpers.createServerForRoute(routes.getLicenceConditionsByDocumentId);
     });
-    expect(output.statusCode).to.equal(200);
+
+    test('validates the documentId must be a GUID', async () => {
+      const url = '/water/1.0/documents/not-a-guid/licence/conditions';
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('allows a valid guid for documentId', async () => {
+      const url = `/water/1.0/documents/${id}/licence/conditions`;
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(200);
+    });
   });
 
-  test('validates the userName as an email address', async () => {
-    const url = `/water/1.0/documents/${id}/rename`;
-    const output = await server.inject({
-      method: 'POST',
-      url,
-      payload: {
-        userName: 'not.an.email.address',
-        documentName: 'test-doc-name'
-      }
+  experiment('/documents/{documentId}/licence/points', () => {
+    let server;
+
+    beforeEach(async () => {
+      server = testHelpers.createServerForRoute(routes.getLicencePointsByDocumentId);
     });
-    expect(output.statusCode).to.equal(400);
+
+    test('validates the documentId must be a GUID', async () => {
+      const url = '/water/1.0/documents/not-a-guid/licence/points';
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('allows a valid guid for documentId', async () => {
+      const url = `/water/1.0/documents/${id}/licence/points`;
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(200);
+    });
   });
 
-  test('validates the userName as required', async () => {
-    const url = `/water/1.0/documents/${id}/rename`;
-    const output = await server.inject({
-      method: 'POST',
-      url,
-      payload: {
-        rename: false,
-        documentName: 'test-doc-name'
-      }
+  experiment('/documents/{documentId}/licence/users', () => {
+    let server;
+
+    beforeEach(async () => {
+      server = testHelpers.createServerForRoute(routes.getLicenceUsersByDocumentId);
     });
-    expect(output.statusCode).to.equal(400);
+
+    test('validates the documentId must be a GUID', async () => {
+      const url = '/water/1.0/documents/not-a-guid/licence/users';
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('allows a valid guid for documentId', async () => {
+      const url = `/water/1.0/documents/${id}/licence/users`;
+      const output = await server.inject(url);
+      expect(output.statusCode).to.equal(200);
+    });
   });
 
-  test('validates the rename as boolean', async () => {
-    const url = `/water/1.0/documents/${id}/rename`;
-    const output = await server.inject({
-      method: 'POST',
-      url,
-      payload: {
-        userName: 'test@email.com',
-        rename: 'something',
-        documentName: 'test-doc-name'
-      }
+  experiment('/documents/{documentId}/rename', () => {
+    let server;
+
+    beforeEach(async () => {
+      server = testHelpers.createServerForRoute(routes.postLicenceName);
     });
-    expect(output.statusCode).to.equal(400);
+
+    test('validates the documentId must be a GUID', async () => {
+      const url = '/water/1.0/documents/not-a-guid/rename';
+      const output = await server.inject({
+        method: 'POST',
+        url,
+        payload: {
+          userName: 'test@example.com',
+          rename: false,
+          documentName: 'test-doc-name'
+        }
+      });
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('allows a valid guid for documentId', async () => {
+      const url = `/water/1.0/documents/${id}/rename`;
+      const output = await server.inject({
+        method: 'POST',
+        url,
+        payload: {
+          userName: 'test@example.com',
+          documentName: 'test-doc-name'
+        }
+      });
+      expect(output.statusCode).to.equal(200);
+    });
+
+    test('validates the userName as an email address', async () => {
+      const url = `/water/1.0/documents/${id}/rename`;
+      const output = await server.inject({
+        method: 'POST',
+        url,
+        payload: {
+          userName: 'not.an.email.address',
+          documentName: 'test-doc-name'
+        }
+      });
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('validates the userName as required', async () => {
+      const url = `/water/1.0/documents/${id}/rename`;
+      const output = await server.inject({
+        method: 'POST',
+        url,
+        payload: {
+          rename: false,
+          documentName: 'test-doc-name'
+        }
+      });
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('validates the rename as boolean', async () => {
+      const url = `/water/1.0/documents/${id}/rename`;
+      const output = await server.inject({
+        method: 'POST',
+        url,
+        payload: {
+          userName: 'test@email.com',
+          rename: 'something',
+          documentName: 'test-doc-name'
+        }
+      });
+      expect(output.statusCode).to.equal(400);
+    });
+
+    test('validates the documentName as required', async () => {
+      const url = `/water/1.0/documents/${id}/rename`;
+      const output = await server.inject({
+        method: 'POST',
+        url,
+        payload: {
+          userName: 'test@email.com',
+          rename: false
+        }
+      });
+      expect(output.statusCode).to.equal(400);
+    });
   });
 
-  test('validates the documentName as required', async () => {
-    const url = `/water/1.0/documents/${id}/rename`;
-    const output = await server.inject({
-      method: 'POST',
-      url,
-      payload: {
-        userName: 'test@email.com',
-        rename: false
-      }
+  experiment('/licences{licenceId}/versions', () => {
+    let server;
+    beforeEach(async () => {
+      server = testHelpers.createServerForRoute(routes.getLicenceVersions);
     });
-    expect(output.statusCode).to.equal(400);
+
+    test('returns a 400 if the licence id is not a uuid', async () => {
+      const request = {
+        method: 'GET',
+        url: '/water/1.0/licences/1234/versions'
+      };
+
+      const response = await server.inject(request);
+
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('uses the controller handler if the request is valid', async () => {
+      const request = {
+        method: 'GET',
+        url: `/water/1.0/licences/${id}/versions`
+      };
+
+      const response = await server.inject(request);
+
+      expect(response.statusCode).to.equal(200);
+    });
   });
 });

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { cloneDeep } = require('lodash');
+const Hapi = require('@hapi/hapi');
+
+/**
+ * Creates a HAPI server to allow a single route to be
+ * tested. The route handler is replaced with
+ * a simple ok 200 response to allow the route definition to
+ * be tested.
+ *
+ * @param {Object} route The HAPI route definition
+ */
+const createServerForRoute = route => {
+  const server = Hapi.server();
+  const testRoute = cloneDeep(route);
+  testRoute.handler = async () => 'ok';
+
+  server.route(testRoute);
+
+  return server;
+};
+
+exports.createServerForRoute = createServerForRoute;


### PR DESCRIPTION
WATER-2705

Adds the resource endpoint at /water/1.0/licences/{id}/versions to get
all the licence versions for the given licence

Includes new models and mappers