### PR TITLE
Feat/water 2720 split invoices on fy

### DIFF
--- a/migrations/20200622152008-add-invoice-financial-year.js
+++ b/migrations/20200622152008-add-invoice-financial-year.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200622152008-add-invoice-financial-year-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200622152008-add-invoice-financial-year-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200605100709-licence-versions-unique-constraint-down.sql
+++ b/migrations/sqls/20200605100709-licence-versions-unique-constraint-down.sql
@@ -3,3 +3,6 @@ alter table water.licence_versions
 
 alter table water.licence_version_purposes
   drop constraint uindx_licence_version_purposes_external_id;
+
+alter table water.licence_version_purposes
+  drop column "external_id";

--- a/migrations/sqls/20200622152008-add-invoice-financial-year-down.sql
+++ b/migrations/sqls/20200622152008-add-invoice-financial-year-down.sql
@@ -1,0 +1,8 @@
+/* remove existing unique constraint */
+alter table water.billing_invoices drop constraint unique_batch_year_invoice;
+
+/* drop FY columm */
+alter table water.billing_invoices drop column financial_year_ending;
+
+/* restore original unique index */
+create unique index unique_batch_invoice on water.billing_invoices(billing_batch_id, invoice_account_id);

--- a/migrations/sqls/20200622152008-add-invoice-financial-year-down.sql
+++ b/migrations/sqls/20200622152008-add-invoice-financial-year-down.sql
@@ -5,4 +5,4 @@ alter table water.billing_invoices drop constraint unique_batch_year_invoice;
 alter table water.billing_invoices drop column financial_year_ending;
 
 /* restore original unique index */
-create unique index unique_batch_invoice on water.billing_invoices(billing_batch_id, invoice_account_id);
+alter table water.billing_invoices add constraint unique_batch_invoice unique (billing_batch_id, invoice_account_id);

--- a/migrations/sqls/20200622152008-add-invoice-financial-year-up.sql
+++ b/migrations/sqls/20200622152008-add-invoice-financial-year-up.sql
@@ -1,0 +1,21 @@
+/* remove existing index */
+drop index unique_batch_invoice;
+
+/* create financial year column without not null constraint */
+alter table water.billing_invoices add column financial_year_ending smallint;
+
+/* use max financial year of billing batch to update financial year column */
+update water.billing_invoices i 
+  set financial_year_ending=y.financial_year_ending 
+  from (
+    select y.billing_batch_id, max(y.financial_year_ending) as financial_year_ending 
+      from water.billing_batch_charge_version_years y 
+      group by y.billing_batch_id
+  ) y
+  where i.billing_batch_id=y.billing_batch_id;
+
+/* add not null constraint */
+alter table water.billing_invoices alter column financial_year_ending set not null;
+
+/* create new unique constraint including FY */
+alter table water.billing_invoices add constraint unique_batch_year_invoice unique (billing_batch_id, financial_year_ending, invoice_account_id);

--- a/migrations/sqls/20200622152008-add-invoice-financial-year-up.sql
+++ b/migrations/sqls/20200622152008-add-invoice-financial-year-up.sql
@@ -1,5 +1,5 @@
 /* remove existing index */
-drop index unique_batch_invoice;
+alter table water.billing_invoices drop constraint if exists unique_batch_invoice;
 
 /* create financial year column without not null constraint */
 alter table water.billing_invoices add column financial_year_ending smallint;

--- a/src/lib/connectors/bookshelf/BillingInvoice.js
+++ b/src/lib/connectors/bookshelf/BillingInvoice.js
@@ -7,6 +7,8 @@ module.exports = bookshelf.model('BillingInvoice', {
 
   hasTimestamps: ['date_created', 'date_updated'],
 
+  idAttribute: 'billing_invoice_id',
+
   billingBatch () {
     return this.belongsTo('BillingBatch', 'billing_batch_id', 'billing_batch_id');
   },

--- a/src/lib/connectors/charge-module/bill-runs.js
+++ b/src/lib/connectors/charge-module/bill-runs.js
@@ -37,10 +37,11 @@ const send = billRunId =>
  * Removes an individual customer from the bill run
  * @param {String} billRunId - CM bill ID GUID
  * @param {String} customerReference - invoice account number
+ * @param {Number} financialYearEnding
  * @return {Promise<Object>} response payload
  */
-const removeCustomer = (billRunId, customerReference) =>
-  request.delete(`v1/wrls/billruns/${billRunId}/transactions`, { customerReference });
+const removeCustomerInFinancialYear = (billRunId, customerReference, financialYearEnding) =>
+  request.delete(`v1/wrls/billruns/${billRunId}/transactions`, { customerReference, financialYear: financialYearEnding - 1 });
 
 /**
  * Deletes entire bill run
@@ -65,7 +66,7 @@ exports.create = create;
 exports.addTransaction = addTransaction;
 exports.approve = approve;
 exports.send = send;
-exports.removeCustomer = removeCustomer;
+exports.removeCustomerInFinancialYear = removeCustomerInFinancialYear;
 exports.delete = deleteBillRun;
 exports.get = get;
 exports.getCustomer = getCustomer;

--- a/src/lib/connectors/repos/billing-batch-charge-version-years.js
+++ b/src/lib/connectors/repos/billing-batch-charge-version-years.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { BillingBatchChargeVersionYear } = require('../bookshelf');
+const { BillingBatchChargeVersionYear, bookshelf } = require('../bookshelf');
 const raw = require('./lib/raw');
 const queries = require('./queries/billing-batch-charge-version-years');
 
@@ -16,5 +16,15 @@ const update = (id, data) =>
 const findStatusCountsByBatchId = batchId =>
   raw.multiRow(queries.findStatusCountsByBatchId, { batchId });
 
+/**
+ * Deletes all charge version years associated with an invoice ID
+ * @param {String} billingInvoiceId
+ * @return {Promise}
+ */
+const deleteByInvoiceId = billingInvoiceId => bookshelf
+  .knex
+  .raw(queries.deleteByInvoiceId, { billingInvoiceId });
+
 exports.update = update;
 exports.findStatusCountsByBatchId = findStatusCountsByBatchId;
+exports.deleteByInvoiceId = deleteByInvoiceId;

--- a/src/lib/connectors/repos/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/billing-invoice-licences.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const { bookshelf } = require('../bookshelf');
-const billingInvoiceLicence = require('../bookshelf/BillingInvoiceLicence');
+const { bookshelf, BillingInvoiceLicence } = require('../bookshelf');
 const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoice-licences');
 
@@ -12,13 +11,13 @@ const withRelated = [
 ];
 
 /**
- * Gets billingInvoiceLicence and related models by GUID
+ * Gets BillingInvoiceLicence and related models by GUID
  * @param {String} id - guid
  * @return {Promise<Object>}
  */
 const findOne = async id => {
-  const model = await billingInvoiceLicence
-    .forge({ billingInvoiceLicenceId: id })
+  const model = await BillingInvoiceLicence
+    .forge({ BillingInvoiceLicenceId: id })
     .fetch({
       withRelated
     });
@@ -39,17 +38,6 @@ const deleteEmptyByBatchId = batchId =>
   bookshelf.knex.raw(queries.deleteEmptyByBatchId, { batchId });
 
 /**
- * Deletes invoice licences for the invoice account and batch
- * @param {String} batchId
- * @param {String} invoiceAccountId
- */
-const deleteByBatchAndInvoiceAccount = (batchId, invoiceAccountId) =>
-  bookshelf.knex.raw(
-    queries.deleteByBatchAndInvoiceAccount,
-    { batchId, invoiceAccountId }
-  );
-
-/**
  * Finds all the licences in a batch and aggregates the two part tariff
  * error codes for a licence's underlying transactions.
  * @param {String} batchId
@@ -63,8 +51,8 @@ const findLicencesWithTransactionStatusesForBatch = batchId =>
  * @param {String} batchId
  */
 const findOneInvoiceLicenceWithTransactions = async (id) => {
-  const model = await billingInvoiceLicence
-    .forge({ billingInvoiceLicenceId: id })
+  const model = await BillingInvoiceLicence
+    .forge({ BillingInvoiceLicenceId: id })
     .fetch({
       withRelated: [
         'licence',
@@ -82,14 +70,23 @@ const findOneInvoiceLicenceWithTransactions = async (id) => {
  * Delete a single record by ID
  * @param {String} id - one or many IDs
  */
-const deleteRecord = billingInvoiceLicenceId => billingInvoiceLicence
-  .forge({ billingInvoiceLicenceId })
+const deleteRecord = BillingInvoiceLicenceId => BillingInvoiceLicence
+  .forge({ BillingInvoiceLicenceId })
+  .destroy();
+
+/**
+ * Delete multiple by invoice ID
+ * @param {String} id - one or many IDs
+ */
+const deleteByInvoiceId = billingInvoiceId => BillingInvoiceLicence
+  .forge()
+  .where({ billing_invoice_id: billingInvoiceId })
   .destroy();
 
 exports.findOne = findOne;
-exports.deleteByBatchAndInvoiceAccount = deleteByBatchAndInvoiceAccount;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
 exports.findLicencesWithTransactionStatusesForBatch = findLicencesWithTransactionStatusesForBatch;
 exports.findOneInvoiceLicenceWithTransactions = findOneInvoiceLicenceWithTransactions;
 exports.upsert = upsert;
 exports.delete = deleteRecord;
+exports.deleteByInvoiceId = deleteByInvoiceId;

--- a/src/lib/connectors/repos/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/billing-invoice-licences.js
@@ -17,7 +17,7 @@ const withRelated = [
  */
 const findOne = async id => {
   const model = await BillingInvoiceLicence
-    .forge({ BillingInvoiceLicenceId: id })
+    .forge({ billingInvoiceLicenceId: id })
     .fetch({
       withRelated
     });
@@ -52,7 +52,7 @@ const findLicencesWithTransactionStatusesForBatch = batchId =>
  */
 const findOneInvoiceLicenceWithTransactions = async (id) => {
   const model = await BillingInvoiceLicence
-    .forge({ BillingInvoiceLicenceId: id })
+    .forge({ billingInvoiceLicenceId: id })
     .fetch({
       withRelated: [
         'licence',
@@ -70,8 +70,8 @@ const findOneInvoiceLicenceWithTransactions = async (id) => {
  * Delete a single record by ID
  * @param {String} id - one or many IDs
  */
-const deleteRecord = BillingInvoiceLicenceId => BillingInvoiceLicence
-  .forge({ BillingInvoiceLicenceId })
+const deleteRecord = billingInvoiceLicenceId => BillingInvoiceLicence
+  .forge({ billingInvoiceLicenceId })
   .destroy();
 
 /**

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -38,16 +38,15 @@ const findOne = async id => {
   return model.toJSON();
 };
 
-const deleteByBatchAndInvoiceAccountId = (batchId, invoiceAccountId) => {
-  return BillingInvoice
-    .forge()
-    .where({
-      invoice_account_id: invoiceAccountId,
-      billing_batch_id: batchId
-    }).destroy();
-};
+/**
+ * Delete a single record by ID
+ * @param {String} id - one or many IDs
+ */
+const deleteRecord = billingInvoiceId => BillingInvoice
+  .forge({ billingInvoiceId })
+  .destroy();
 
-exports.deleteByBatchAndInvoiceAccountId = deleteByBatchAndInvoiceAccountId;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
 exports.findOne = findOne;
 exports.upsert = upsert;
+exports.delete = deleteRecord;

--- a/src/lib/connectors/repos/billing-transactions.js
+++ b/src/lib/connectors/repos/billing-transactions.js
@@ -101,6 +101,15 @@ const deleteByInvoiceLicenceId = invoiceLicenceId => bookshelf
   .where('billing_invoice_licence_id', invoiceLicenceId)
   .delete();
 
+/**
+ * Deletes all transactions by invoice ID
+ * @param {String} billingInvoiceId
+ * @return {Promise}
+ */
+const deleteByInvoiceId = billingInvoiceId => bookshelf
+  .knex
+  .raw(queries.deleteByInvoiceId, { billingInvoiceId });
+
 exports.findOne = findOne;
 exports.find = find;
 exports.findHistoryByBatchId = findHistoryByBatchId;
@@ -110,3 +119,4 @@ exports.create = create;
 exports.findStatusCountsByBatchId = findStatusCountsByBatchId;
 exports.update = update;
 exports.deleteByInvoiceLicenceId = deleteByInvoiceLicenceId;
+exports.deleteByInvoiceId = deleteByInvoiceId;

--- a/src/lib/connectors/repos/queries/billing-batch-charge-version-years.js
+++ b/src/lib/connectors/repos/queries/billing-batch-charge-version-years.js
@@ -4,3 +4,18 @@ select status, count(*)
   where billing_batch_id = :batchId
   group by status
 `;
+
+exports.deleteByInvoiceId = `
+delete from water.billing_batch_charge_version_years y
+  using 
+    water.billing_invoices i, 
+    water.billing_invoice_licences l,
+    water.billing_transactions t,
+    water.charge_elements e
+  where i.billing_invoice_id=:billingInvoiceId 
+    and i.billing_invoice_id=l.billing_invoice_id 
+    and t.billing_invoice_licence_id=l.billing_invoice_licence_id 
+    and t.charge_element_id=e.charge_element_id 
+    and y.charge_version_id=e.charge_version_id
+    and y.financial_year_ending=i.financial_year_ending
+`;

--- a/src/lib/connectors/repos/queries/billing-invoice-licences.js
+++ b/src/lib/connectors/repos/queries/billing-invoice-licences.js
@@ -26,15 +26,6 @@ delete from water.billing_invoice_licences l
   )
 `;
 
-exports.deleteByBatchAndInvoiceAccount = `
-  delete
-  from water.billing_invoice_licences bil
-  using water.billing_invoices bi
-  where bil.billing_invoice_id = bi.billing_invoice_id
-  and bi.billing_batch_id = :batchId
-  and bi.invoice_account_id = :invoiceAccountId;
-`;
-
 exports.findLicencesWithTransactionStatusesForBatch = `
   select
     bil.billing_invoice_id,

--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -1,9 +1,9 @@
 exports.upsert = `
 insert into water.billing_invoices 
-  (invoice_account_id, address, invoice_account_number, date_created, date_updated, billing_batch_id)
+  (invoice_account_id, address, invoice_account_number, date_created, date_updated, billing_batch_id, financial_year_ending)
 values
-  (:invoiceAccountId, :address, :invoiceAccountNumber, NOW(), NOW(), :billingBatchId)
-on conflict (invoice_account_id, billing_batch_id) do update 
+  (:invoiceAccountId, :address, :invoiceAccountNumber, NOW(), NOW(), :billingBatchId, :financialYearEnding)
+on conflict (invoice_account_id, billing_batch_id, financial_year_ending) do update 
   set date_updated = NOW()
 returning *
 `;

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -38,3 +38,11 @@ select t.status, count(t.status)
   where b.billing_batch_id=:batchId
   group by t.status;
 `;
+
+exports.deleteByInvoiceId = `
+delete from water.billing_transactions t
+  using water.billing_invoice_licences l
+  where 
+    t.billing_invoice_licence_id=l.billing_invoice_licence_id 
+    and l.billing_invoice_id=:billingInvoiceId
+`;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -289,11 +289,11 @@ class Batch extends Model {
   }
 
   /**
-   * Does this batch have a status that means the batch customers
+   * Does this batch have a status that means the batch invoices
    * associated with the batch can be deleted?
    */
-  canDeleteAccounts () {
-    return this.statusIsOneOf(BATCH_STATUS.ready, BATCH_STATUS.review);
+  canDeleteInvoices () {
+    return this.statusIsOneOf(BATCH_STATUS.ready);
   }
 
   /**

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -30,7 +30,8 @@ const BATCH_ERROR_CODE = {
   failedToProcessChargeVersions: 20,
   failedToPrepareTransactions: 30,
   failedToCreateCharge: 40,
-  failedToCreateBillRun: 50
+  failedToCreateBillRun: 50,
+  failedToDeleteInvoice: 60
 };
 
 const Model = require('./model');

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -9,7 +9,7 @@ const InvoiceAccount = require('./invoice-account');
 const InvoiceLicence = require('./invoice-licence');
 const Company = require('./company');
 const Contact = require('./contact-v2');
-
+const FinancialYear = require('./financial-year');
 const Totals = require('./totals');
 
 class Invoice extends Model {
@@ -134,6 +134,19 @@ class Invoice extends Model {
 
   get totals () {
     return this._totals;
+  }
+
+  /**
+   * Sets the financial year
+   * @param {FinancialYear} financialYear
+   */
+  set financialYear (financialYear) {
+    assertIsInstanceOf(financialYear, FinancialYear);
+    this._financialYear = financialYear;
+  }
+
+  get financialYear () {
+    return this._financialYear;
   }
 
   toJSON () {

--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -9,6 +9,11 @@ const batchJob = require('./lib/batch-job');
 const Transaction = require('../../../lib/models/transaction');
 const { get } = require('lodash');
 
+const options = {
+  teamSize: 50,
+  teamConcurrency: 2
+};
+
 /**
  * The current status of the batch - this is either:
  * - processing - there are still candidate transactions to process
@@ -113,3 +118,4 @@ const handleCreateChargeComplete = async (job, messageQueue) => {
 };
 
 module.exports = handleCreateChargeComplete;
+module.exports.options = options;

--- a/src/modules/billing/mappers/api/invoice.js
+++ b/src/modules/billing/mappers/api/invoice.js
@@ -15,6 +15,7 @@ const map = {
   'invoiceAccount.company.name': 'name',
   'totals.netTotal': 'netTotal',
   'invoiceLicences[].licence.licenceNumber': 'licenceNumbers[]',
+  'financialYear.yearEnding': 'financialYearEnding',
   invoiceLicences: {
     key: 'isWaterUndertaker',
     transform: containsWaterUndertaker

--- a/src/modules/billing/mappers/invoice.js
+++ b/src/modules/billing/mappers/invoice.js
@@ -4,6 +4,7 @@ const { omit, pick } = require('lodash');
 
 const Invoice = require('../../../lib/models/invoice');
 const InvoiceAccount = require('../../../lib/models/invoice-account');
+const FinancialYear = require('../../../lib/models/financial-year');
 
 const invoiceAccount = require('./invoice-account');
 const invoiceLicence = require('./invoice-licence');
@@ -22,6 +23,9 @@ const dbToModel = row => {
   if (row.billingInvoiceLicences) {
     invoice.invoiceLicences = row.billingInvoiceLicences.map(invoiceLicence.dbToModel);
   }
+
+  invoice.financialYear = new FinancialYear(row.financialYearEnding);
+
   return invoice;
 };
 
@@ -35,7 +39,8 @@ const modelToDb = (batch, invoice) => ({
   invoiceAccountId: invoice.invoiceAccount.id,
   invoiceAccountNumber: invoice.invoiceAccount.accountNumber,
   address: omit(invoice.address.toObject(), 'id'),
-  billingBatchId: batch.id
+  billingBatchId: batch.id,
+  financialYearEnding: invoice.financialYear.endYear
 });
 
 const crmToModel = row => {

--- a/src/modules/billing/routes.js
+++ b/src/modules/billing/routes.js
@@ -104,15 +104,15 @@ const getBatchInvoiceDetail = {
   }
 };
 
-const deleteAccountFromBatch = {
+const deleteBatchInvoice = {
   method: 'DELETE',
-  path: '/water/1.0/billing/batches/{batchId}/account/{accountId}',
-  handler: controller.deleteAccountFromBatch,
+  path: '/water/1.0/billing/batches/{batchId}/invoices/{invoiceId}',
+  handler: controller.deleteBatchInvoice,
   config: {
     validate: {
       params: {
         batchId: Joi.string().uuid().required(),
-        accountId: Joi.string().uuid().required()
+        invoiceId: Joi.string().uuid().required()
       }
     },
     pre: [
@@ -246,7 +246,7 @@ exports.getBatchInvoiceDetail = getBatchInvoiceDetail;
 exports.getBatchInvoicesDetails = getBatchInvoicesDetails;
 exports.getBatchLicences = getBatchLicences;
 exports.getInvoiceLicence = getInvoiceLicence;
-exports.deleteAccountFromBatch = deleteAccountFromBatch;
+exports.deleteBatchInvoice = deleteBatchInvoice;
 exports.deleteBatch = deleteBatch;
 
 exports.postApproveBatch = postApproveBatch;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -325,7 +325,7 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     await newRepos.billingInvoices.delete(invoiceId);
     return setStatusToEmptyWhenNoTransactions(batch);
   } catch (err) {
-    await setErrorStatus(batch.id);
+    await setErrorStatus(batch.id, Batch.BATCH_ERROR_CODE.failedToDeleteInvoice);
     throw err;
   }
 };

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -319,6 +319,7 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     await chargeModuleBillRunConnector.removeCustomerInFinancialYear(externalId, invoiceAccountNumber, financialYearEnding);
 
     // Delete local data
+    await newRepos.billingBatchChargeVersionYears.deleteByInvoiceId(invoiceId);
     await newRepos.billingTransactions.deleteByInvoiceId(invoiceId);
     await newRepos.billingInvoiceLicences.deleteByInvoiceId(invoiceId);
     await newRepos.billingInvoices.delete(invoiceId);

--- a/src/modules/billing/services/charge-processor-service/index.js
+++ b/src/modules/billing/services/charge-processor-service/index.js
@@ -62,6 +62,7 @@ const processChargeVersionYear = async (batch, financialYear, chargeVersionId) =
 
   // Generate Invoice data structure
   const invoice = mappers.invoice.crmToModel(invoiceAccount);
+  invoice.financialYear = financialYear;
   const invoiceLicence = createInvoiceLicence(company, chargeVersion, licenceHolderRole);
   invoiceLicence.transactions = transactionsProcessor.createTransactions(batch, financialYear, chargeVersion);
   invoice.invoiceLicences = [invoiceLicence];

--- a/test/lib/connectors/charge-module/bill-runs.js
+++ b/test/lib/connectors/charge-module/bill-runs.js
@@ -95,9 +95,9 @@ experiment('lib/connectors/charge-module/bill-runs', () => {
     });
   });
 
-  experiment('.removeCustomer', () => {
+  experiment('.removeCustomerInFinancialYear', () => {
     beforeEach(async () => {
-      await billRunsApiConnector.removeCustomer('test-id', 'customer-id');
+      await billRunsApiConnector.removeCustomerInFinancialYear('test-id', 'customer-id', 2020);
     });
 
     test('the method is DELETE', async () => {
@@ -109,10 +109,11 @@ experiment('lib/connectors/charge-module/bill-runs', () => {
       expect(path).to.equal('v1/wrls/billruns/test-id/transactions');
     });
 
-    test('the correct customer is specified', async () => {
+    test('the correct customer and financial year starting is specified', async () => {
       const [, payload] = request.delete.lastCall.args;
       expect(payload).to.equal({
-        customerReference: 'customer-id'
+        customerReference: 'customer-id',
+        financialYear: 2019
       });
     });
   });

--- a/test/lib/connectors/repos/billing-batch-charge-version-years.js
+++ b/test/lib/connectors/repos/billing-batch-charge-version-years.js
@@ -11,7 +11,7 @@ const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 
 const repos = require('../../../../src/lib/connectors/repos');
-const { BillingBatchChargeVersionYear } = require('../../../../src/lib/connectors/bookshelf');
+const { BillingBatchChargeVersionYear, bookshelf } = require('../../../../src/lib/connectors/bookshelf');
 const queries = require('../../../../src/lib/connectors/repos/queries/billing-batch-charge-version-years');
 const raw = require('../../../../src/lib/connectors/repos/lib/raw');
 
@@ -27,6 +27,7 @@ experiment('lib/connectors/repos/billing-batch-charge-version-year', () => {
     };
     sandbox.stub(BillingBatchChargeVersionYear, 'forge').returns(stub);
     sandbox.stub(raw, 'multiRow');
+    sandbox.stub(bookshelf.knex, 'raw');
   });
 
   afterEach(async () => {
@@ -64,6 +65,20 @@ experiment('lib/connectors/repos/billing-batch-charge-version-year', () => {
       const [query, params] = raw.multiRow.lastCall.args;
       expect(query).to.equal(queries.findStatusCountsByBatchId);
       expect(params).to.equal({ batchId });
+    });
+  });
+
+  experiment('.deleteByInvoiceId', () => {
+    const billingInvoiceId = 'test-invoice-id';
+
+    beforeEach(async () => {
+      await repos.billingBatchChargeVersionYears.deleteByInvoiceId(billingInvoiceId);
+    });
+
+    test('calls knex.raw with correct query and params', async () => {
+      const [query, params] = bookshelf.knex.raw.lastCall.args;
+      expect(query).to.equal(queries.deleteByInvoiceId);
+      expect(params).to.equal({ billingInvoiceId });
     });
   });
 });

--- a/test/lib/connectors/repos/billing-invoice-licences.js
+++ b/test/lib/connectors/repos/billing-invoice-licences.js
@@ -27,6 +27,7 @@ experiment('lib/connectors/repos/billing-invoice-licences', () => {
       toJSON: sandbox.stub()
     };
     bookshelfStub = {
+      where: sandbox.stub().returnsThis(),
       fetch: sandbox.stub().resolves(model),
       destroy: sandbox.stub()
     };
@@ -165,6 +166,28 @@ experiment('lib/connectors/repos/billing-invoice-licences', () => {
     });
 
     test('the model is destroyed', async () => {
+      expect(bookshelfStub.destroy.called).to.be.true();
+    });
+  });
+
+  experiment('.deleteByInvoiceId', async () => {
+    const billingInvoiceId = uuid();
+
+    beforeEach(async () => {
+      await billingInvoiceLicences.deleteByInvoiceId(billingInvoiceId);
+    });
+
+    test('the model is forged', async () => {
+      expect(billingInvoiceLicence.forge.called).to.be.true();
+    });
+
+    test('the correct invoice licences are selected for deletion', async () => {
+      expect(bookshelfStub.where.calledWith({
+        billing_invoice_id: billingInvoiceId
+      })).to.be.true();
+    });
+
+    test('the models are destroyed', async () => {
       expect(bookshelfStub.destroy.called).to.be.true();
     });
   });

--- a/test/lib/connectors/repos/billing-invoice-licences.js
+++ b/test/lib/connectors/repos/billing-invoice-licences.js
@@ -70,23 +70,6 @@ experiment('lib/connectors/repos/billing-invoice-licences', () => {
     });
   });
 
-  experiment('.deleteByBatchAndInvoiceAccount', () => {
-    let batchId;
-    let invoiceAccountId;
-
-    beforeEach(async () => {
-      batchId = uuid();
-      invoiceAccountId = uuid();
-      await billingInvoiceLicences.deleteByBatchAndInvoiceAccount(batchId, invoiceAccountId);
-    });
-
-    test('calls bookshelf.knex.raw with correct params', async () => {
-      const { args } = bookshelf.knex.raw.lastCall;
-      expect(args[0]).to.equal(queries.deleteByBatchAndInvoiceAccount);
-      expect(args[1]).to.equal({ batchId, invoiceAccountId });
-    });
-  });
-
   experiment('.findLicencesWithTransactionStatusesForBatch', () => {
     let batchId;
 

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -83,27 +83,6 @@ experiment('lib/connectors/repos/billing-invoices', () => {
     });
   });
 
-  experiment('.deleteByBatchAndInvoiceAccountId', () => {
-    beforeEach(async () => {
-      await billingInvoices.deleteByBatchAndInvoiceAccountId(
-        'test-batch-id',
-        'test-invoice-account-id'
-      );
-    });
-
-    test('filters using the expected where clause', async () => {
-      const [clause] = stub.where.lastCall.args;
-      expect(clause).to.equal({
-        invoice_account_id: 'test-invoice-account-id',
-        billing_batch_id: 'test-batch-id'
-      });
-    });
-
-    test('deletes the found data via destroy', async () => {
-      expect(stub.destroy.called).to.equal(true);
-    });
-  });
-
   experiment('.findOne', () => {
     let result;
 

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -7,6 +7,7 @@ const {
 const { expect } = require('@hapi/code');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
+const uuid = require('uuid/v4');
 
 const { bookshelf, BillingInvoice } = require('../../../../src/lib/connectors/bookshelf');
 const queries = require('../../../../src/lib/connectors/repos/queries/billing-invoices');
@@ -115,6 +116,24 @@ experiment('lib/connectors/repos/billing-invoices', () => {
 
     test('returns the result of the toJSON() call', async () => {
       expect(result).to.equal({ foo: 'bar' });
+    });
+  });
+
+  experiment('.delete', async () => {
+    const billingInvoiceId = uuid();
+
+    beforeEach(async () => {
+      await billingInvoices.delete(billingInvoiceId);
+    });
+
+    test('the model is forged with correct params', async () => {
+      expect(BillingInvoice.forge.calledWith({
+        billingInvoiceId
+      })).to.be.true();
+    });
+
+    test('the model is destroyed', async () => {
+      expect(stub.destroy.called).to.be.true();
     });
   });
 });

--- a/test/lib/connectors/repos/billing-transactions.js
+++ b/test/lib/connectors/repos/billing-transactions.js
@@ -23,8 +23,6 @@ experiment('lib/connectors/repos/billing-transactions', () => {
       delete: sandbox.stub()
     };
 
-    sandbox.stub(bookshelf, 'knex').returns(knexStub);
-
     model = {
       toJSON: sandbox.stub().returns({ foo: 'bar' }),
       pagination: {
@@ -151,6 +149,7 @@ experiment('lib/connectors/repos/billing-transactions', () => {
 
   experiment('.deleteRecords', () => {
     beforeEach(async () => {
+      sandbox.stub(bookshelf, 'knex').returns(knexStub);
       await billingTransactions.delete('transaction-id');
     });
 
@@ -235,6 +234,7 @@ experiment('lib/connectors/repos/billing-transactions', () => {
 
   experiment('.deleteByInvoiceLicenceId', () => {
     beforeEach(async () => {
+      sandbox.stub(bookshelf, 'knex').returns(knexStub);
       await billingTransactions.deleteByInvoiceLicenceId('test-invoice-licence-id');
     });
 
@@ -252,6 +252,21 @@ experiment('lib/connectors/repos/billing-transactions', () => {
 
     test('calls .delete() on query builder', async () => {
       expect(knexStub.delete.called).to.be.true();
+    });
+  });
+
+  experiment('.deleteByInvoiceId', () => {
+    beforeEach(async () => {
+      sandbox.stub(bookshelf.knex, 'raw');
+      await billingTransactions.deleteByInvoiceId('test-invoice-id');
+    });
+
+    test('calls knex.raw with the correct query and params', async () => {
+      const [query, params] = bookshelf.knex.raw.lastCall.args;
+      expect(query).to.equal(queries.deleteByInvoiceId);
+      expect(params).to.equal({
+        billingInvoiceId: 'test-invoice-id'
+      });
     });
   });
 });

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -565,46 +565,46 @@ experiment('lib/models/batch', () => {
     });
   });
 
-  experiment('.canDeleteAccounts', () => {
+  experiment('.canDeleteInvoices', () => {
     test('returns false if the batch has no status', async () => {
       const batch = new Batch();
-      expect(batch.canDeleteAccounts()).to.equal(false);
+      expect(batch.canDeleteInvoices()).to.equal(false);
     });
 
     test('returns false if the batch status is error', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.error;
-      expect(batch.canDeleteAccounts()).to.equal(false);
+      expect(batch.canDeleteInvoices()).to.equal(false);
     });
 
     test('returns false if the batch status is processing', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.processing;
-      expect(batch.canDeleteAccounts()).to.equal(false);
+      expect(batch.canDeleteInvoices()).to.equal(false);
     });
 
     test('returns false if the batch status is empty', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.empty;
-      expect(batch.canDeleteAccounts()).to.equal(false);
+      expect(batch.canDeleteInvoices()).to.equal(false);
     });
 
     test('returns false if the batch status is sent', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.sent;
-      expect(batch.canDeleteAccounts()).to.equal(false);
+      expect(batch.canDeleteInvoices()).to.equal(false);
     });
 
     test('returns true if the batch status is ready', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.ready;
-      expect(batch.canDeleteAccounts()).to.equal(true);
+      expect(batch.canDeleteInvoices()).to.equal(true);
     });
 
-    test('returns true if the batch status is review', async () => {
+    test('returns false if the batch status is review', async () => {
       const batch = new Batch();
       batch.status = Batch.BATCH_STATUS.review;
-      expect(batch.canDeleteAccounts()).to.equal(true);
+      expect(batch.canDeleteInvoices()).to.equal(false);
     });
   });
 });

--- a/test/lib/models/invoice-account.js
+++ b/test/lib/models/invoice-account.js
@@ -6,7 +6,6 @@ const { expect } = require('@hapi/code');
 const InvoiceAccount = require('../../../src/lib/models/invoice-account');
 const Company = require('../../../src/lib/models/company');
 const Address = require('../../../src/lib/models/address');
-const InvoiceAccountAddress = require('../../../src/lib/models/invoice-account-address');
 
 const TEST_GUID = 'add1cf3b-7296-4817-b013-fea75a928580';
 const TEST_ACCOUNT_NUMBER = 'S12345678A';

--- a/test/lib/models/invoice-account.js
+++ b/test/lib/models/invoice-account.js
@@ -4,6 +4,7 @@ const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').scri
 const { expect } = require('@hapi/code');
 
 const InvoiceAccount = require('../../../src/lib/models/invoice-account');
+const InvoiceAccountAddress = require('../../../src/lib/models/invoice-account-address');
 const Company = require('../../../src/lib/models/company');
 const Address = require('../../../src/lib/models/address');
 

--- a/test/modules/billing/mappers/invoice.js
+++ b/test/modules/billing/mappers/invoice.js
@@ -14,6 +14,7 @@ const Company = require('../../../../src/lib/models/company');
 const Contact = require('../../../../src/lib/models/contact-v2');
 const Invoice = require('../../../../src/lib/models/invoice');
 const Address = require('../../../../src/lib/models/address');
+const FinancialYear = require('../../../../src/lib/models/financial-year');
 const InvoiceAccount = require('../../../../src/lib/models/invoice-account');
 
 const invoiceMapper = require('../../../../src/modules/billing/mappers/invoice');
@@ -22,7 +23,8 @@ const invoiceRow = {
   billingInvoiceId: '5a1577d7-8dc9-4d67-aadc-37d7ea85abca',
   invoiceAccountId: 'aea355f7-b931-4824-8465-575f5b95657f',
   invoiceAccountNumber: 'A12345678A',
-  dateCreated: '2020-03-05T10:57:23.911Z'
+  dateCreated: '2020-03-05T10:57:23.911Z',
+  financialYearEnding: 2019
 };
 
 experiment('modules/billing/mappers/invoice', () => {
@@ -48,6 +50,11 @@ experiment('modules/billing/mappers/invoice', () => {
     test('maps the date created value', async () => {
       expect(result.dateCreated).to.equal(invoiceRow.dateCreated);
     });
+
+    test('has a financial year instance', async () => {
+      expect(result.financialYear instanceof FinancialYear).to.be.true();
+      expect(result.financialYear.yearEnding).to.equal(invoiceRow.financialYearEnding);
+    });
   });
 
   experiment('.modelToDB', () => {
@@ -68,6 +75,7 @@ experiment('modules/billing/mappers/invoice', () => {
       postcode: 'TT1 1TT',
       country: 'UK'
     });
+    invoice.financialYear = new FinancialYear(2020);
 
     beforeEach(async () => {
       result = invoiceMapper.modelToDb(batch, invoice);
@@ -78,6 +86,7 @@ experiment('modules/billing/mappers/invoice', () => {
       expect(result.invoiceAccountNumber).to.equal(invoice.invoiceAccount.accountNumber);
       expect(result.address).to.equal(invoice.address.toJSON());
       expect(result.billingBatchId).to.equal(batch.id);
+      expect(result.financialYearEnding).to.equal(invoice.financialYear.yearEnding);
     });
   });
 

--- a/test/modules/billing/routes.js
+++ b/test/modules/billing/routes.js
@@ -280,20 +280,20 @@ experiment('modules/billing/routes', () => {
     });
   });
 
-  experiment('deleteAccountFromBatch', () => {
+  experiment('deleteBatchInvoice', () => {
     let request;
     let server;
     let validBatchId;
-    let validAccountId;
+    let validInvoiceId;
 
     beforeEach(async () => {
-      server = getServer(routes.deleteAccountFromBatch);
+      server = getServer(routes.deleteBatchInvoice);
       validBatchId = uuid();
-      validAccountId = uuid();
+      validInvoiceId = uuid();
 
       request = {
         method: 'DELETE',
-        url: `/water/1.0/billing/batches/${validBatchId}/account/${validAccountId}`
+        url: `/water/1.0/billing/batches/${validBatchId}/invoices/${validInvoiceId}`
       };
     });
 
@@ -308,14 +308,14 @@ experiment('modules/billing/routes', () => {
       expect(response.statusCode).to.equal(400);
     });
 
-    test('returns a 400 if the account id is not a uuid', async () => {
-      request.url = request.url.replace(validAccountId, '123');
+    test('returns a 400 if the invoice id is not a uuid', async () => {
+      request.url = request.url.replace(validInvoiceId, '123');
       const response = await server.inject(request);
       expect(response.statusCode).to.equal(400);
     });
 
     test('contains a pre handler to load the batch', async () => {
-      const { pre } = routes.deleteAccountFromBatch.config;
+      const { pre } = routes.deleteBatchInvoice.config;
       expect(pre).to.have.length(1);
       expect(pre[0].method).to.equal(preHandlers.loadBatch);
       expect(pre[0].assign).to.equal('batch');
@@ -370,7 +370,7 @@ experiment('modules/billing/routes', () => {
     });
 
     test('contains a pre handler to load the batch', async () => {
-      const { pre } = routes.deleteAccountFromBatch.config;
+      const { pre } = routes.deleteBatch.config;
       expect(pre).to.have.length(1);
       expect(pre[0].method).to.equal(preHandlers.loadBatch);
       expect(pre[0].assign).to.equal('batch');

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -21,6 +21,7 @@ const Licence = require('../../../../src/lib/models/licence');
 const Totals = require('../../../../src/lib/models/totals');
 const Transaction = require('../../../../src/lib/models/transaction');
 const { BatchStatusError, TransactionStatusError } = require('../../../../src/modules/billing/lib/errors');
+const { NotFoundError } = require('../../../../src/lib/errors');
 
 const eventService = require('../../../../src/lib/services/events');
 const { logger } = require('../../../../src/logger');
@@ -104,8 +105,15 @@ experiment('modules/billing/services/batch-service', () => {
     sandbox.stub(chargeModuleBillRunConnector, 'delete').resolves();
     sandbox.stub(chargeModuleBillRunConnector, 'approve').resolves();
     sandbox.stub(chargeModuleBillRunConnector, 'send').resolves();
+    sandbox.stub(chargeModuleBillRunConnector, 'removeCustomerInFinancialYear').resolves();
 
     sandbox.stub(eventService, 'create').resolves();
+
+    sandbox.stub(newRepos.billingInvoices, 'findOne');
+    sandbox.stub(newRepos.billingBatchChargeVersionYears, 'deleteByInvoiceId');
+    sandbox.stub(newRepos.billingTransactions, 'deleteByInvoiceId');
+    sandbox.stub(newRepos.billingInvoiceLicences, 'deleteByInvoiceId');
+    sandbox.stub(newRepos.billingInvoices, 'delete');
   });
 
   afterEach(async () => {
@@ -985,6 +993,114 @@ experiment('modules/billing/services/batch-service', () => {
           expect(err).to.be.an.instanceOf(TransactionStatusError);
           expect(err.message).to.equal('Cannot approve review. There are outstanding two part tariff errors to resolve');
         }
+      });
+    });
+  });
+
+  experiment('.deleteBatchinvoice', () => {
+    let batch, invoiceId;
+
+    experiment('when the batch is not in "ready" status', () => {
+      beforeEach(async () => {
+        batch = new Batch();
+        batch.status = Batch.BATCH_STATUS.review;
+      });
+
+      test('throws a BatchStatusError', async () => {
+        const func = () => batchService.deleteBatchInvoice(batch, invoiceId);
+        const err = await expect(func()).to.reject();
+        expect(err instanceof BatchStatusError).to.be.true();
+      });
+    });
+
+    experiment('when the batch is in "ready" status', () => {
+      beforeEach(async () => {
+        batch = new Batch(uuid());
+        batch.fromHash({
+          status: Batch.BATCH_STATUS.ready,
+          externalId: uuid()
+        });
+      });
+
+      test('throws a NotFoundError if the invoice is not found', async () => {
+        newRepos.billingInvoices.findOne.resolves(null);
+        const func = () => batchService.deleteBatchInvoice(batch, invoiceId);
+        const err = await expect(func()).to.reject();
+        expect(err instanceof NotFoundError).to.be.true();
+      });
+
+      experiment('when the invoice is found and there are no errors', () => {
+        beforeEach(async () => {
+          newRepos.billingInvoices.findOne.resolves({
+            invoiceAccountNumber: 'A12345678A',
+            financialYearEnding: 2020,
+            billingBatch: {
+              externalId: batch.externalId
+            }
+          });
+          newRepos.billingTransactions.findByBatchId.resolves([]);
+          await batchService.deleteBatchInvoice(batch, invoiceId);
+        });
+
+        test('loads the invoice with the supplied ID', async () => {
+          expect(newRepos.billingInvoices.findOne.calledWith(invoiceId)).to.be.true();
+        });
+
+        test('deletes the charge module transactions in the bill run with matching customer number and financial year', async () => {
+          expect(chargeModuleBillRunConnector.removeCustomerInFinancialYear.calledWith(
+            batch.externalId, 'A12345678A', 2020
+          )).to.be.true();
+        });
+
+        test('deletes associated charge version years from batch', async () => {
+          expect(newRepos.billingBatchChargeVersionYears.deleteByInvoiceId.calledWith(invoiceId)).to.be.true();
+        });
+
+        test('deletes associated transactions from batch', async () => {
+          expect(newRepos.billingTransactions.deleteByInvoiceId.calledWith(invoiceId)).to.be.true();
+        });
+
+        test('deletes associated invoice licences from batch', async () => {
+          expect(newRepos.billingInvoiceLicences.deleteByInvoiceId.calledWith(invoiceId)).to.be.true();
+        });
+
+        test('deletes invoice from batch', async () => {
+          expect(newRepos.billingInvoices.delete.calledWith(invoiceId)).to.be.true();
+        });
+
+        test('sets status of batch to empty when there are no transactions', () => {
+          expect(newRepos.billingBatches.update.calledWith(
+            batch.id, { status: 'empty' }
+          )).to.be.true();
+        });
+      });
+
+      experiment('when the invoice is found and there is an error errors', () => {
+        beforeEach(async () => {
+          newRepos.billingInvoices.findOne.resolves({
+            invoiceAccountNumber: 'A12345678A',
+            financialYearEnding: 2020,
+            billingBatch: {
+              externalId: batch.externalId
+            }
+          });
+          newRepos.billingTransactions.findByBatchId.resolves([]);
+          chargeModuleBillRunConnector.removeCustomerInFinancialYear.rejects(new Error('oh no!'));
+        });
+
+        test('the batch is set to error status with the correct code', async () => {
+          const func = () => batchService.deleteBatchInvoice(batch, invoiceId);
+          await expect(func()).to.reject();
+          expect(newRepos.billingBatches.update.calledWith(
+            batch.id, { status: Batch.BATCH_STATUS.error, errorCode: Batch.BATCH_ERROR_CODE.failedToDeleteInvoice }
+          )).to.be.true();
+        });
+
+        test('the error is rethrown', async () => {
+          const func = () => batchService.deleteBatchInvoice(batch, invoiceId);
+          const err = await expect(func()).to.reject();
+          expect(err.message).to.equal('oh no!');
+        });
       });
     });
   });


### PR DESCRIPTION
Makes invoices specific to a financial year.
Replaces the 'delete customer' API endpoint with a 'delete invoice' endpoint.