### PR TITLE
Fix issue setting transaction volume to billable volume

### DIFF
--- a/src/lib/models/charge-element.js
+++ b/src/lib/models/charge-element.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isNull } = require('lodash');
+const { isNull, max } = require('lodash');
 const Model = require('./model');
 const AbstractionPeriod = require('./abstraction-period');
 const PurposeUse = require('./purpose-use');
@@ -102,6 +102,14 @@ class ChargeElement extends Model {
   set billableAnnualQuantity (quantity) {
     validators.assertNullableQuantity(quantity);
     this._billableAnnualQuantity = isNull(quantity) ? null : parseFloat(quantity);
+  }
+
+  /**
+   * Gets the maximum allowable annual quantity
+   * @return {Number}
+   */
+  get maxAnnualQuantity () {
+    return max([this.billableAnnualQuantity, this.authorisedAnnualQuantity]);
   }
 
   /**

--- a/src/lib/models/transaction.js
+++ b/src/lib/models/transaction.js
@@ -194,7 +194,7 @@ class Transaction extends Model {
   }
 
   set volume (volume) {
-    validators.assertNullableQuantityWithMaximum(volume, this.chargeElement.authorisedAnnualQuantity);
+    validators.assertNullableQuantityWithMaximum(volume, this.chargeElement.maxAnnualQuantity);
     this._volume = volume;
   }
 

--- a/test/lib/models/charge-element.js
+++ b/test/lib/models/charge-element.js
@@ -148,6 +148,24 @@ experiment('lib/models/charge-element', () => {
     });
   });
 
+  experiment('.maxAnnualQuantity', () => {
+    test('returns billableAnnualQuantity when this is set', async () => {
+      chargeElement.billableAnnualQuantity = 9.3;
+      expect(chargeElement.maxAnnualQuantity).to.equal(9.3);
+    });
+
+    test('returns authorisedAnnualQuantity when this is set', async () => {
+      chargeElement.authorisedAnnualQuantity = 10.2;
+      expect(chargeElement.maxAnnualQuantity).to.equal(10.2);
+    });
+
+    test('returns maximum of authorisedAnnualQuantity and billableAnnualQuantity when both are set', async () => {
+      chargeElement.billableAnnualQuantity = 9.3;
+      chargeElement.authorisedAnnualQuantity = 10.2;
+      expect(chargeElement.maxAnnualQuantity).to.equal(10.2);
+    });
+  });
+
   experiment('.volume', () => {
     test('is the billableAnnualQuantity if set', async () => {
       chargeElement.authorisedAnnualQuantity = 10.7;

--- a/test/lib/models/transaction.js
+++ b/test/lib/models/transaction.js
@@ -351,7 +351,7 @@ experiment('lib/models/transaction', () => {
       expect(func).to.throw();
     });
 
-    test('throws an error if volume is greater than authorised quantity', async () => {
+    test('throws an error if volume is greater than charge element max quantity', async () => {
       const func = () => {
         transaction.volume = 20;
       };


### PR DESCRIPTION
Permits transaction volume to go to max of charge element auth and billable volume.

This is because in many cases the billable volume is higher.