### PR TITLE
Initial work to create service models for returns, lines and versions

### DIFF
--- a/src/lib/connectors/repos/index.js
+++ b/src/lib/connectors/repos/index.js
@@ -15,3 +15,4 @@ exports.licenceAgreements = require('./licence-agreements');
 exports.licenceVersions = require('./licence-versions');
 exports.licences = require('./licences');
 exports.regions = require('./regions');
+exports.purposeUses = require('./purpose-uses');

--- a/src/lib/connectors/repos/purpose-uses.js
+++ b/src/lib/connectors/repos/purpose-uses.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { PurposeUse } = require('../bookshelf');
+
+/**
+ * Gets a list of purpose uses by the supplied legacy NALD use codes
+ * @param {Array<String>} codes
+ * @return {Promise<Array>}
+ */
+const findByCodes = async codes => {
+  const collection = await PurposeUse
+    .where('legacy_id', 'in', codes)
+    .fetchAll();
+  return collection ? collection.toJSON() : null;
+};
+
+exports.findByCodes = findByCodes;

--- a/src/lib/mappers/return-line.js
+++ b/src/lib/mappers/return-line.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const DateRange = require('../models/date-range');
+const ReturnLine = require('../models/return-line');
+
+/**
+ * Maps a return line from the returns service to a water service model
+ * @param {Object} row - from returns service
+ * @return {ReturnLine} service model
+ */
+const returnsServiceToModel = (row) => {
+  const line = new ReturnLine();
+  return line.fromHash({
+    id: row.line_id,
+    dateRange: new DateRange(row.start_date, row.end_date),
+    volume: row.quantity,
+    timePeriod: row.time_period
+  });
+};
+
+exports.returnsServiceToModel = returnsServiceToModel;

--- a/src/lib/mappers/return-version.js
+++ b/src/lib/mappers/return-version.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const ReturnVersion = require('../models/return-version');
+const returnLineMapper = require('./return-line');
+
+/**
+ * Maps a return version from the returns service to a water service model
+ * @param {Object} row - from returns service
+ * @param {Array} lines
+ * @return {ReturnVersion} service model
+ */
+const returnsServiceToModel = (row, lines) => {
+  const version = new ReturnVersion();
+  version.fromHash({
+    id: row.version_id,
+    isNilReturn: row.nil_return,
+    isCurrentVersion: row.current
+  });
+  if (lines) {
+    version.returnLines = lines.map(returnLineMapper.returnsServiceToModel);
+  }
+  return version;
+};
+
+exports.returnsServiceToModel = returnsServiceToModel;

--- a/src/lib/mappers/return.js
+++ b/src/lib/mappers/return.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { get } = require('lodash');
+
+const AbstractionPeriod = require('../models/abstraction-period');
+const Return = require('../models/return');
+const DateRange = require('../models/date-range');
+
+const returnsServiceToModel = (ret, allPurposeUses) => {
+  const { nald } = ret.metadata;
+
+  // Find matching purpose uses
+  const codes = get(ret, 'metadata.purposes', []).map(purpose => purpose.tertiary.code);
+  const purposeUses = allPurposeUses.filter(purposeUse => codes.includes(purposeUse.code));
+
+  // Create abs period
+  const abstractionPeriod = new AbstractionPeriod();
+  abstractionPeriod.fromHash({
+    startDay: nald.periodStartDay,
+    startMonth: nald.periodStartMonth,
+    endDay: nald.periodEndDay,
+    endMonth: nald.periodEndMonth
+  });
+
+  const r = new Return(ret.return_id);
+  return r.fromHash({
+    dateRange: new DateRange(ret.start_date, ret.end_date),
+    isUnderQuery: ret.under_query,
+    isSummer: get(ret, 'metadata.isSummer', false),
+    dueDate: ret.due_date,
+    receivedDate: ret.received_date,
+    status: ret.status,
+    purposeUses,
+    abstractionPeriod
+  });
+};
+
+exports.returnsServiceToModel = returnsServiceToModel;

--- a/src/lib/models/constants.js
+++ b/src/lib/models/constants.js
@@ -18,3 +18,9 @@ exports.CONTACT_ROLES = {
   billing: 'billing',
   licenceHolder: 'licenceHolder'
 };
+
+exports.TIME_PERIODS = {
+  day: 'day',
+  week: 'week',
+  month: 'month'
+};

--- a/src/lib/models/return-line.js
+++ b/src/lib/models/return-line.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const Model = require('./model');
+const DateRange = require('./date-range');
+
+const validators = require('./validators');
+
+const { TIME_PERIODS } = require('./constants');
+
+class ReturnLine extends Model {
+  /**
+   * Sets volume in cubic metres
+   * @param {Number} volume
+   */
+  set volume (volume) {
+    validators.assertNullableQuantity(volume);
+    this._volume = volume;
+  }
+
+  get volume () {
+    return this._volume;
+  }
+
+  /**
+   * Sets the date range of the return line
+   * @param {DateRange} dateRange
+   */
+  set dateRange (dateRange) {
+    validators.assertIsInstanceOf(dateRange, DateRange);
+    this._dateRange = dateRange;
+  }
+
+  get dateRange () {
+    return this._dateRange;
+  }
+
+  /**
+   * The return line frequency day/week/month etc
+   * @param {String} timePeriod day|week|month
+   */
+  set timePeriod (timePeriod) {
+    validators.assertEnum(timePeriod, Object.values(TIME_PERIODS));
+    this._timePeriod = timePeriod;
+  }
+
+  get timePeriod () {
+    return this._timePeriod;
+  }
+}
+
+module.exports = ReturnLine;

--- a/src/lib/models/return-version.js
+++ b/src/lib/models/return-version.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Model = require('./model');
+const ReturnLine = require('./return-line');
+
+const validators = require('./validators');
+
+class ReturnVersion extends Model {
+  /**
+   * Sets return versions
+   * @return {Array<ReturnVersion>}
+   */
+  set returnLines (returnLines) {
+    validators.assertIsArrayOfType(returnLines, ReturnLine);
+    this._returnLines = returnLines;
+  }
+
+  get returnLines () {
+    return this._returnLines;
+  }
+
+  /**
+   * Whether this return is a nil return
+   * @param {Boolean}
+   */
+  set isNilReturn (isNilReturn) {
+    validators.assertIsBoolean(isNilReturn);
+    this._isNilReturn = isNilReturn;
+  }
+
+  get isNilReturn () {
+    return this._isNilReturn;
+  }
+
+  /**
+   * Whether this return is the current version
+   * @param {Boolean}
+   */
+  set isCurrentVersion (isCurrentVersion) {
+    validators.assertIsBoolean(isCurrentVersion);
+    this._isCurrentVersion = isCurrentVersion;
+  }
+
+  get isCurrentVersion () {
+    return this._isCurrentVersion;
+  }
+}
+
+module.exports = ReturnVersion;

--- a/src/lib/models/return-version.js
+++ b/src/lib/models/return-version.js
@@ -6,6 +6,11 @@ const ReturnLine = require('./return-line');
 const validators = require('./validators');
 
 class ReturnVersion extends Model {
+  constructor (id) {
+    super(id);
+    this._returnLines = [];
+  }
+
   /**
    * Sets return versions
    * @return {Array<ReturnVersion>}

--- a/src/lib/models/return.js
+++ b/src/lib/models/return.js
@@ -18,6 +18,11 @@ const RETURN_STATUS = {
 };
 
 class Return extends Model {
+  constructor (id) {
+    super(id);
+    this._returnVersions = [];
+  }
+
   set id (id) {
     validators.assertReturnId(id);
     this._id = id;

--- a/src/lib/models/return.js
+++ b/src/lib/models/return.js
@@ -163,8 +163,7 @@ class Return extends Model {
    * @return {ReturnVersion}
    */
   get currentReturnVersion () {
-    const versions = this.returnVersions || [];
-    return versions.find(returnVersion => returnVersion.isCurrent);
+    return this._returnVersions.find(returnVersion => returnVersion.isCurrent);
   }
 
   /**

--- a/src/lib/models/return.js
+++ b/src/lib/models/return.js
@@ -23,6 +23,10 @@ class Return extends Model {
     this._id = id;
   }
 
+  get id () {
+    return this._id;
+  }
+
   /**
    * Date range of return
    * @param {DateRange} dateRange
@@ -116,7 +120,7 @@ class Return extends Model {
    */
   get isLateForBilling () {
     const comparisonDate = moment(this._dueDate).add(3, 'weeks');
-    return this.receivedDate && this.receivedDate.isAfter(comparisonDate, 'day');
+    return this._receivedDate && this._receivedDate.isAfter(comparisonDate, 'day');
   }
 
   /**

--- a/src/lib/models/return.js
+++ b/src/lib/models/return.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const moment = require('moment');
+
+const AbstractionPeriod = require('./model');
+const Model = require('./model');
+const DateRange = require('./date-range');
+const PurposeUse = require('./purpose-use');
+const ReturnVersion = require('./return-version');
+
+const validators = require('./validators');
+
+const RETURN_STATUS = {
+  completed: 'completed',
+  due: 'due',
+  received: 'received',
+  void: 'void'
+};
+
+class Return extends Model {
+  set id (id) {
+    validators.assertReturnId(id);
+    this._id = id;
+  }
+
+  /**
+   * Date range of return
+   * @param {DateRange} dateRange
+   */
+  set dateRange (dateRange) {
+    validators.assertIsInstanceOf(dateRange, DateRange);
+    this._dateRange = dateRange;
+  }
+
+  get dateRange () {
+    return this._dateRange;
+  }
+
+  /**
+   * Purpose uses
+   * @param {Array} purposeUses
+   */
+  set purposeUses (purposeUses) {
+    validators.assertIsArrayOfType(purposeUses, PurposeUse);
+    this._purposesUses = purposeUses;
+  }
+
+  get purposeUses () {
+    return this._purposesUses;
+  }
+
+  /**
+   * Whether this is a summer return
+   * @param {Boolean}
+   */
+  set isSummer (isSummer) {
+    validators.assertIsBoolean(isSummer);
+    this._isSummer = isSummer;
+  }
+
+  get isSummer () {
+    return this._isSummer;
+  }
+
+  /**
+   * Whether this return is under query
+   * @param {Boolean}
+   */
+  set isUnderQuery (isUnderQuery) {
+    validators.assertIsBoolean(isUnderQuery);
+    this._isUnderQuery = isUnderQuery;
+  }
+
+  get isUnderQuery () {
+    return this._isUnderQuery;
+  }
+
+  /**
+   * The due date
+   * Stores internally as moment
+   * @param {String}
+   */
+  set dueDate (dueDate) {
+    this._dueDate = this.getDateOrThrow(dueDate, 'dueDate');
+  }
+
+  /**
+   * Get due date as string
+   * @return {String} YYYY-MM-DD
+   */
+  get dueDate () {
+    return this._dueDate.format('YYYY-MM-DD');
+  }
+
+  /**
+   * The received date
+   * Stores internally as moment
+   * @param {String}
+   */
+  set receivedDate (receivedDate) {
+    this._receivedDate = this.getDateTimeFromValue(receivedDate);
+  }
+
+  /**
+   * Get due date as string or null
+   * @return {String|Null} YYYY-MM-DD
+   */
+  get receivedDate () {
+    return this._receivedDate ? this._receivedDate.format('YYYY-MM-DD') : null;
+  }
+
+  /**
+   * Was the return received late for billing purposes?
+   * The user must send the return date by the due date plus 3 week grace period
+   * @return {Boolean}
+   */
+  get isLateForBilling () {
+    const comparisonDate = moment(this._dueDate).add(3, 'weeks');
+    return this.receivedDate && this.receivedDate.isAfter(comparisonDate, 'day');
+  }
+
+  /**
+   * Sets the return status
+   * @param {String} status
+   */
+  set status (status) {
+    validators.assertEnum(status, Object.keys(RETURN_STATUS));
+    this._status = status;
+  }
+
+  /**
+   * Gets the return status
+   * @return {String}
+   */
+  get status () {
+    return this._status;
+  }
+
+  /**
+   * Sets return versions
+   * @return {Array<ReturnVersion>}
+   */
+  set returnVersions (returnVersions) {
+    validators.assertIsArrayOfType(returnVersions, ReturnVersion);
+    this._returnVersions = returnVersions;
+  }
+
+  get returnVersions () {
+    return this._returnVersions;
+  }
+
+  /**
+   * Gets current return version
+   * @return {ReturnVersion}
+   */
+  get currentReturnVersion () {
+    const versions = this.returnVersions || [];
+    return versions.find(returnVersion => returnVersion.isCurrent);
+  }
+
+  /**
+   * Abstraction period
+   * @return {AbstractionPeriod}
+   */
+  get abstractionPeriod () {
+    return this._abstractionPeriod;
+  }
+
+  set abstractionPeriod (abstractionPeriod) {
+    validators.assertIsInstanceOf(abstractionPeriod, AbstractionPeriod);
+    this._abstractionPeriod = abstractionPeriod;
+  }
+}
+
+module.exports = Return;
+module.exports.RETURN_STATUS = RETURN_STATUS;

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -7,6 +7,7 @@ const Joi = require('joi');
 const assert = (value, schema) => Joi.assert(value, schema, { convert: false });
 
 const dateRegex = /^\d{4}-([0][1-9]|[1][0-2])-([0][1-9]|[1-2][0-9]|[3][0-1])$/;
+const { returnIDRegex } = require('@envage/water-abstraction-helpers').returns;
 
 const VALID_DATE = Joi.string().regex(dateRegex).required();
 const VALID_NULLABLE_DATE = VALID_DATE.allow(null);
@@ -27,6 +28,7 @@ const VALID_FACTOR = Joi.number().min(0).max(1);
 const VALID_TRANSACTION_KEY = Joi.string().hex().length(32).allow(null);
 const VALID_NEGATIVE_INTEGER = VALID_INTEGER.negative();
 const VALID_EMAIL_ADDRESS = Joi.string().email();
+const VALID_RETURN_ID = Joi.string().regex(returnIDRegex);
 
 const assertIsArrayOfType = (values, Type) => {
   hoek.assert(isArray(values), 'Array expected');
@@ -79,6 +81,7 @@ const assertInteger = value => assert(value, VALID_INTEGER);
 const assertEmailAddress = value => assert(value, VALID_EMAIL_ADDRESS);
 const assertIsNullableBoolean = value => assert(value, Joi.boolean().required().allow(null));
 const assertNullableQuantityWithMaximum = (value, max) => assert(value, VALID_NULLABLE_QUANTITY.max(max));
+const assertReturnId = value => assert(value, VALID_RETURN_ID);
 
 exports.assertIsBoolean = assertIsBoolean;
 exports.assertIsInstanceOf = assertIsInstanceOf;
@@ -111,3 +114,4 @@ exports.assertInteger = assertInteger;
 exports.assertEmailAddress = assertEmailAddress;
 exports.assertIsNullableBoolean = assertIsNullableBoolean;
 exports.assertNullableQuantityWithMaximum = assertNullableQuantityWithMaximum;
+exports.assertReturnId = assertReturnId;

--- a/src/lib/services/returns/api-connector.js
+++ b/src/lib/services/returns/api-connector.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { first } = require('lodash');
+const apiConnector = require('../../connectors/returns');
+
+/**
+ * Gets the record for the current version of the return
+ * @param {String} returnId
+ * @return {Promise<Object>}
+ */
+const getCurrentVersion = async returnId => {
+  const filter = {
+    return_id: returnId,
+    current: true
+  };
+  const sort = { version_number: -1 };
+  const versions = await apiConnector.versions.findAll(filter, sort);
+  return first(versions);
+};
+
+/**
+ * Gets the lines for the supplied version ID
+ * @param {String} versionId
+ * @return {Array<Object>
+ */
+const getLines = async versionId => {
+  const filter = {
+    version_id: versionId
+  };
+  const sort = { start_date: +1 };
+  return apiConnector.lines.findAll(filter, sort);
+};
+
+exports.getCurrentVersion = getCurrentVersion;
+exports.getLines = getLines;
+exports.getReturnsForLicence = apiConnector.getReturnsForLicence;

--- a/src/lib/services/returns/index.js
+++ b/src/lib/services/returns/index.js
@@ -68,6 +68,9 @@ const decorateWithCurrentVersion = async ret => {
   }
   // Load current version
   const version = await apiConnector.getCurrentVersion(ret.id);
+  if (!version) {
+    return ret;
+  }
   // Load lines
   let lines;
   if (!version.nil_return) {

--- a/src/lib/services/returns/index.js
+++ b/src/lib/services/returns/index.js
@@ -63,18 +63,20 @@ const getPurposeUses = async returns => {
  * @return {Promise<Return>}
  */
 const decorateWithCurrentVersion = async ret => {
-  if (ret.status === RETURN_STATUS.completed) {
-    const version = await apiConnector.getCurrentVersion(ret.id);
-    if (version) {
-      let lines;
-      if (!version.nil_return) {
-        lines = await apiConnector.getLines(version.version_id);
-      }
-      ret.returnVersions = [
-        returnVersionMapper.returnsServiceToModel(version, lines)
-      ];
-    }
+  if (ret.status !== RETURN_STATUS.completed) {
+    return ret;
   }
+  // Load current version
+  const version = await apiConnector.getCurrentVersion(ret.id);
+  // Load lines
+  let lines;
+  if (!version.nil_return) {
+    lines = await apiConnector.getLines(version.version_id);
+  }
+  // Map to service models
+  ret.returnVersions = [
+    returnVersionMapper.returnsServiceToModel(version, lines)
+  ];
   return ret;
 };
 

--- a/src/lib/services/returns/index.js
+++ b/src/lib/services/returns/index.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { flatMap, uniq } = require('lodash');
+const apiConnector = require('./api-connector');
+const repos = require('../../connectors/repos');
+const purposeUseMapper = require('../../mappers/purpose-use');
+const returnMapper = require('../../mappers/return');
+const returnVersionMapper = require('../../mappers/return-version');
+
+// Models
+const { RETURN_STATUS } = require('../../models/return');
+
+const DATE_FORMAT = 'YYYY-MM-DD';
+
+/**
+ * Gets all non-void returns for the given licence number
+ * within the supplied financial year
+ * @param {String} licenceNumber
+ * @param {FinancialYear} financialYear
+ * @return {Promise<Array>}
+ */
+const fetchReturns = (licenceNumber, financialYear) => {
+  const startDate = financialYear.start.format(DATE_FORMAT);
+  const endDate = financialYear.end.format(DATE_FORMAT);
+  return apiConnector.getReturnsForLicence(licenceNumber, startDate, endDate);
+};
+
+/**
+ * Gets an array of purpose use codes from the supplied
+ * set of returns
+ * @param {Array<Object>} returns
+ * @return {Array<String>}
+ */
+const getPurposeUseCodes = returns => {
+  const codes = returns.map(ret =>
+    ret.metadata.purposes.map(purpose =>
+      purpose.tertiary.code
+    ));
+
+  return uniq(flatMap(codes));
+};
+
+/**
+ * Gets all purpose uses from water.purpose_uses
+ * for the supplied set of returns, and returns an
+ * array of PurposeUse service models
+ * @param {Array} returns
+ * @return {Array<PurposeUse>}
+ */
+const getPurposeUses = async returns => {
+  // Get purpose use codes from set of returns
+  const purposeUseCodes = getPurposeUseCodes(returns);
+
+  // Retrieve from water.purpose_uses and map to service models
+  const purposeUses = await repos.purposeUses.findByCodes(purposeUseCodes);
+  return purposeUses.map(purposeUseMapper.dbToModel);
+};
+
+/**
+ * Loads the current return version and lines, maps to service models,
+ * and decorates the supplied Return model with them
+ * @param {Return} ret
+ * @return {Promise<Return>}
+ */
+const decorateWithCurrentVersion = async ret => {
+  if (ret.status === RETURN_STATUS.completed) {
+    const version = await apiConnector.getCurrentVersion(ret.id);
+    if (version) {
+      let lines;
+      if (!version.nil_return) {
+        lines = await apiConnector.getLines(version.version_id);
+      }
+      ret.returnVersions = [
+        returnVersionMapper.returnsServiceToModel(version, lines)
+      ];
+    }
+  }
+  return ret;
+};
+
+/**
+ * Gets all returns for the licence in the supplied FinancialYear
+ * Resolves with an array of Return service model instances, each
+ * with the current version loaded
+ * @param {String} licenceNumber
+ * @param {FinancialYear} financialYear
+ * @return {Promise<Array>}
+ */
+const getReturnsForLicenceInFinancialYear = async (licenceNumber, financialYear) => {
+  // Get returns from returns service
+  const data = await fetchReturns(licenceNumber, financialYear);
+
+  // Load purpose uses from local table and map to service models
+  const allPurposeUses = await getPurposeUses(data);
+
+  // Map returns to service models
+  const rets = data.map(returnData => returnMapper.returnsServiceToModel(returnData, allPurposeUses));
+
+  // Decorate each return with its current version
+  const tasks = rets.map(decorateWithCurrentVersion);
+  return Promise.all(tasks);
+};
+
+exports.getReturnsForLicenceInFinancialYear = getReturnsForLicenceInFinancialYear;

--- a/test/lib/connectors/repos/purpose-uses.js
+++ b/test/lib/connectors/repos/purpose-uses.js
@@ -1,0 +1,54 @@
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const purposeUses = require('../../../../src/lib/connectors/repos/purpose-uses');
+const { PurposeUse } = require('../../../../src/lib/connectors/bookshelf');
+
+experiment('lib/connectors/repos/purpose-uses', () => {
+  let stub, model;
+
+  beforeEach(async () => {
+    model = {
+      toJSON: sandbox.stub().returns({ foo: 'bar' })
+    };
+
+    stub = {
+      save: sandbox.stub().resolves(model),
+      where: sandbox.stub().returnsThis(),
+      query: sandbox.stub().returnsThis(),
+      fetch: sandbox.stub().resolves(model),
+      fetchAll: sandbox.stub().resolves(model),
+      destroy: sandbox.stub().resolves()
+    };
+
+    sandbox.stub(PurposeUse, 'where').returns(stub);
+  });
+
+  afterEach(async () => sandbox.restore());
+
+  experiment('.findByCodes', () => {
+    beforeEach(async () => {
+      await purposeUses.findByCodes(['400', '401']);
+    });
+
+    test('calls model.where to find all with legacy ID matching supplied codes', async () => {
+      expect(PurposeUse.where.calledWith(
+        'legacy_id', 'in', ['400', '401']
+      )).to.be.true();
+    });
+
+    test('calls .fetchAll() on the model', async () => {
+      expect(stub.fetchAll.called).to.be.true();
+    });
+
+    test('calls toJSON() on returned collection', async () => {
+      expect(model.toJSON.callCount).to.equal(1);
+    });
+  });
+});

--- a/test/lib/models/return-line.js
+++ b/test/lib/models/return-line.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
+
+const DateRange = require('../../../src/lib/models/date-range');
+const ReturnLine = require('../../../src/lib/models/return-line');
+const { TIME_PERIODS } = require('../../../src/lib/models/constants');
+
+class TestModel { };
+
+experiment('lib/models/return-line', () => {
+  let line;
+
+  beforeEach(async () => {
+    line = new ReturnLine();
+  });
+
+  experiment('.id', () => {
+    test('can be set to a GUID', async () => {
+      const id = uuid();
+      line.id = id;
+      expect(line.id).to.equal(id);
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        line.id = null;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a non-return ID string', async () => {
+      const func = () => {
+        line.id = 'not-a-guid';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.volume', () => {
+    test('can be set to a positive number', async () => {
+      line.volume = 4.465;
+      expect(line.volume).to.equal(4.465);
+    });
+
+    test('can be set to null', async () => {
+      line.volume = null;
+      expect(line.volume).to.be.null();
+    });
+
+    test('throws an error if set to negative number', async () => {
+      const func = () => {
+        line.volume = -28.385;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to any other type', async () => {
+      const func = () => {
+        line.volume = 'a string';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.dateRange', () => {
+    test('can be set to a DateRange instance', async () => {
+      const dateRange = new DateRange('2019-09-01', null);
+      line.dateRange = dateRange;
+      expect(line.dateRange).to.equal(dateRange);
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        line.dateRange = new TestModel();
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.timePeriod', () => {
+    for (const timePeriod in TIME_PERIODS) {
+      test(`can be set to ${timePeriod}`, async () => {
+        line.timePeriod = timePeriod;
+        expect(line.timePeriod).to.equal(timePeriod);
+      });
+    }
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        line.timePeriod = null;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to an invalid time period', async () => {
+      const func = () => {
+        line.timePeriod = 'quarter-of-an-hour';
+      };
+      expect(func).to.throw();
+    });
+  });
+});

--- a/test/lib/models/return-version.js
+++ b/test/lib/models/return-version.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
+
+const ReturnVersion = require('../../../src/lib/models/return-version');
+const ReturnLine = require('../../../src/lib/models/return-line');
+
+class TestModel { };
+
+experiment('lib/models/return-version', () => {
+  let version;
+
+  beforeEach(async () => {
+    version = new ReturnVersion();
+  });
+
+  experiment('.id', () => {
+    test('can be set to a GUID', async () => {
+      const id = uuid();
+      version.id = id;
+      expect(version.id).to.equal(id);
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        version.id = null;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a non-return ID string', async () => {
+      const func = () => {
+        version.id = 'not-a-guid';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.returnLines', () => {
+    test('can be set to an array of purpose uses', async () => {
+      const returnLines = [new ReturnLine()];
+      version.returnLines = returnLines;
+      expect(version.returnLines).to.equal(returnLines);
+    });
+
+    test('throws an error if not an array', async () => {
+      const func = () => {
+        const notAnArray = new ReturnLine();
+        version.returnLines = notAnArray;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        const notReturnLines = [new TestModel()];
+        version.returnLines = notReturnLines;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.isNilReturn', () => {
+    test('can be set to a boolean true', async () => {
+      version.isNilReturn = true;
+      expect(version.isNilReturn).to.equal(true);
+    });
+
+    test('can be set to a boolean false', async () => {
+      version.isNilReturn = false;
+      expect(version.isNilReturn).to.equal(false);
+    });
+
+    test('throws an error if set to a different type', async () => {
+      const func = () => {
+        version.isNilReturn = 'not-a-boolean';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.isCurrentVersion', () => {
+    test('can be set to a boolean true', async () => {
+      version.isCurrentVersion = true;
+      expect(version.isCurrentVersion).to.equal(true);
+    });
+
+    test('can be set to a boolean false', async () => {
+      version.isCurrentVersion = false;
+      expect(version.isCurrentVersion).to.equal(false);
+    });
+
+    test('throws an error if set to a different type', async () => {
+      const func = () => {
+        version.isCurrentVersion = 'not-a-boolean';
+      };
+      expect(func).to.throw();
+    });
+  });
+});

--- a/test/lib/models/return.js
+++ b/test/lib/models/return.js
@@ -1,0 +1,280 @@
+'use strict';
+
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
+
+const AbstractionPeriod = require('../../../src/lib/models/abstraction-period');
+const DateRange = require('../../../src/lib/models/date-range');
+const PurposeUse = require('../../../src/lib/models/purpose-use');
+const Return = require('../../../src/lib/models/return');
+const ReturnVersion = require('../../../src/lib/models/return-version');
+
+class TestModel { };
+
+experiment('lib/models/return', () => {
+  let ret;
+
+  beforeEach(async () => {
+    ret = new Return();
+  });
+
+  experiment('.id', () => {
+    test('can be set to a return ID string', async () => {
+      const returnId = 'v1:1:01/123/456/789:12345678:2019-04-01:2020-03-31';
+      ret.id = returnId;
+      expect(ret.id).to.equal(returnId);
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        ret.id = null;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a non-return ID string', async () => {
+      const func = () => {
+        ret.id = uuid();
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.dateRange', () => {
+    test('can be set to a DateRange instance', async () => {
+      const dateRange = new DateRange('2019-09-01', null);
+      ret.dateRange = dateRange;
+      expect(ret.dateRange).to.equal(dateRange);
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        ret.dateRange = new TestModel();
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.purposeUses', () => {
+    test('can be set to an array of purpose uses', async () => {
+      const purposeUses = [new PurposeUse()];
+      ret.purposeUses = purposeUses;
+      expect(ret.purposeUses).to.equal(purposeUses);
+    });
+
+    test('throws an error if not an array', async () => {
+      const func = () => {
+        const notAnArray = new PurposeUse();
+        ret.purposeUses = notAnArray;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        const notPurposeUses = [new TestModel()];
+        ret.purposeUses = notPurposeUses;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.isSummer', () => {
+    test('can be set to a boolean true', async () => {
+      ret.isSummer = true;
+      expect(ret.isSummer).to.equal(true);
+    });
+
+    test('can be set to a boolean false', async () => {
+      ret.isSummer = false;
+      expect(ret.isSummer).to.equal(false);
+    });
+
+    test('throws an error if set to a different type', async () => {
+      const func = () => {
+        ret.isSummer = 'not-a-boolean';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.isUnderQuery', () => {
+    test('can be set to a boolean true', async () => {
+      ret.isUnderQuery = true;
+      expect(ret.isUnderQuery).to.equal(true);
+    });
+
+    test('can be set to a boolean false', async () => {
+      ret.isUnderQuery = false;
+      expect(ret.isUnderQuery).to.equal(false);
+    });
+
+    test('throws an error if set to a different type', async () => {
+      const func = () => {
+        ret.isUnderQuery = 'not-a-boolean';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.dueDate', () => {
+    test('can be set to a date string', async () => {
+      ret.dueDate = '2019-11-28';
+      expect(ret.dueDate).to.equal('2019-11-28');
+    });
+
+    test('throws an error if set to an invalid date', async () => {
+      const func = () => {
+        ret.dueDate = '2020-13-01';
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        ret.dueDate = null;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.receivedDate', () => {
+    test('can be set to a date string', async () => {
+      ret.receivedDate = '2019-11-28';
+      expect(ret.receivedDate).to.equal('2019-11-28');
+    });
+
+    test('can be set to null', async () => {
+      ret.receivedDate = null;
+      expect(ret.receivedDate).to.equal(null);
+    });
+
+    test('throws an error if set to an invalid date', async () => {
+      const func = () => {
+        ret.receivedDate = '2020-13-01';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.isLateForBilling', () => {
+    test('is false if the return is received on time', async () => {
+      ret.dueDate = '2019-11-28';
+      ret.receivedDate = '2019-11-05';
+      expect(ret.isLateForBilling).to.equal(false);
+    });
+
+    test('is false if the return is received on the due date', async () => {
+      ret.dueDate = '2019-11-28';
+      ret.receivedDate = '2019-11-28';
+      expect(ret.isLateForBilling).to.equal(false);
+    });
+
+    test('is false if the return is received 3 weeks past the due date', async () => {
+      ret.dueDate = '2019-11-28';
+      ret.receivedDate = '2019-12-19';
+      expect(ret.isLateForBilling).to.equal(false);
+    });
+
+    test('is true if the return is received >3 weeks past the due date', async () => {
+      ret.dueDate = '2019-11-28';
+      ret.receivedDate = '2019-12-20';
+      expect(ret.isLateForBilling).to.equal(true);
+    });
+
+    test('is undefined if the return received date is not set', async () => {
+      ret.dueDate = '2019-11-28';
+      expect(ret.isLateForBilling).to.equal(undefined);
+    });
+  });
+
+  experiment('.status', () => {
+    const returnStatuses = ['due', 'received', 'completed', 'void'];
+
+    for (const status of returnStatuses) {
+      test(`can be set to ${status}`, async () => {
+        ret.status = status;
+        expect(ret.status).to.equal(status);
+      });
+    }
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        ret.status = null;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to an invalid status', async () => {
+      const func = () => {
+        ret.status = 'dog-ate-it';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.returnVersions', () => {
+    test('can be set to an array of purpose uses', async () => {
+      const returnVersions = [new ReturnVersion()];
+      ret.returnVersions = returnVersions;
+      expect(ret.returnVersions).to.equal(returnVersions);
+    });
+
+    test('throws an error if not an array', async () => {
+      const func = () => {
+        const notAnArray = new ReturnVersion();
+        ret.returnVersions = notAnArray;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        const notReturnVersions = [new TestModel()];
+        ret.returnVersions = notReturnVersions;
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.currentReturnVersion', () => {
+    beforeEach(async () => {
+      ret.returnVersions = [
+        new ReturnVersion(uuid()),
+        new ReturnVersion(uuid()),
+        new ReturnVersion(uuid())
+      ];
+    });
+
+    test('gets the current return version when present', async () => {
+      ret.returnVersions[1].isCurrent = true;
+      expect(ret.currentReturnVersion).to.equal(ret.returnVersions[1]);
+    });
+
+    test('returns undefined when there is no current return version', async () => {
+      expect(ret.currentReturnVersion).to.equal(undefined);
+    });
+  });
+
+  experiment('.abstractionPeriod', () => {
+    test('can be set to an AbstractionPeriod instance', async () => {
+      ret.abstractionPeriod = new AbstractionPeriod();
+      expect(ret.abstractionPeriod instanceof AbstractionPeriod).to.be.true();
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        ret.abstractionPeriod = null;
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to a different model', async () => {
+      const func = () => {
+        ret.abstractionPeriod = new TestModel();
+      };
+      expect(func).to.throw();
+    });
+  });
+});

--- a/test/lib/models/return.js
+++ b/test/lib/models/return.js
@@ -277,4 +277,15 @@ experiment('lib/models/return', () => {
       expect(func).to.throw();
     });
   });
+
+  experiment('.RETURN_STATUS', () => {
+    test('defines the return statuses', async () => {
+      const { RETURN_STATUS } = Return;
+      expect(Object.keys(RETURN_STATUS).length).to.equal(4);
+      expect(RETURN_STATUS.completed).to.equal('completed');
+      expect(RETURN_STATUS.due).to.equal('due');
+      expect(RETURN_STATUS.received).to.equal('received');
+      expect(RETURN_STATUS.void).to.equal('void');
+    });
+  });
 });

--- a/test/lib/services/returns/api-connector.js
+++ b/test/lib/services/returns/api-connector.js
@@ -1,0 +1,73 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { expect } = require('@hapi/code');
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const returnsApiConnector = require('../../../../src/lib/connectors/returns');
+const apiConnector = require('../../../../src/lib/services/returns/api-connector');
+
+experiment('lib/services/returns/api-connector', () => {
+  beforeEach(async () => {
+    sandbox.stub(returnsApiConnector.versions, 'findAll').resolves([{
+      version_id: 'test-version-id'
+    }]);
+    sandbox.stub(returnsApiConnector.lines, 'findAll').resolves([{
+      line_id: 'test-line-id'
+    }]);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getCurrentVersion', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await apiConnector.getCurrentVersion('test-return-id');
+    });
+
+    test('calls the API connector with the correct filter and sort params', async () => {
+      const [filter, sort] = returnsApiConnector.versions.findAll.lastCall.args;
+      expect(filter).to.equal({
+        return_id: 'test-return-id',
+        current: true
+      });
+      expect(sort).to.equal({
+        version_number: -1
+      });
+    });
+
+    test('resolves with the first record found', async () => {
+      expect(result.version_id).to.equal('test-version-id');
+    });
+  });
+
+  experiment('.getLines', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await apiConnector.getLines('test-version-id');
+    });
+
+    test('calls the API connector with the correct filter and sort params', async () => {
+      const [filter, sort] = returnsApiConnector.lines.findAll.lastCall.args;
+      expect(filter).to.equal({
+        version_id: 'test-version-id'
+      });
+      expect(sort).to.equal({
+        start_date: +1
+      });
+    });
+
+    test('resolves with all records found', async () => {
+      expect(result).to.be.an.array().length(1);
+      expect(result[0].line_id).to.equal('test-line-id');
+    });
+  });
+});

--- a/test/lib/services/returns/index.js
+++ b/test/lib/services/returns/index.js
@@ -1,0 +1,199 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { expect } = require('@hapi/code');
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const uuid = require('uuid/v4');
+
+const repos = require('../../../../src/lib/connectors/repos');
+const apiConnector = require('../../../../src/lib/services/returns/api-connector');
+const returnsService = require('../../../../src/lib/services/returns');
+
+const FinancialYear = require('../../../../src/lib/models/financial-year');
+const Return = require('../../../../src/lib/models/return');
+const ReturnVersion = require('../../../../src/lib/models/return-version');
+const ReturnLine = require('../../../../src/lib/models/return-line');
+
+const returnId = 'v1:1:01/123/456:1234567:2019-04-01:2020-03-31';
+const versionId = uuid();
+const licenceNumber = '01/123/456';
+const financialYear = new FinancialYear(2020);
+
+const createReturns = (overrides = {}) => (
+  [{
+    return_id: returnId,
+    start_date: '2019-04-01',
+    end_date: '2020-03-31',
+    due_date: '2020-04-28',
+    received_date: '2020-04-21',
+    current: true,
+    status: overrides.status || 'completed',
+    under_query: false,
+    frequency: 'day',
+    metadata: {
+      isSummer: true,
+      purposes: [{
+        tertiary: {
+          code: '400'
+        }
+      }],
+      nald: {
+        periodStartDay: 1,
+        periodStartMonth: 5,
+        periodEndDay: 31,
+        periodEndMonth: 9
+      }
+    }
+  }]
+);
+
+const createVersion = (overrides = {}) => ({
+  version_id: versionId,
+  return_id: returnId,
+  current: true,
+  nil_return: overrides.isNilReturn || false
+});
+
+const createLines = () => ([{
+  line_id: uuid(),
+  version_id: versionId,
+  volume: 23.24,
+  start_date: '2019-04-01',
+  end_date: '2019-04-31',
+  time_period: 'month'
+}]);
+
+const createPurposeUses = () => ([{
+  purposeUseId: uuid(),
+  legacyId: '400',
+  description: 'Spray Irrigation - Direct',
+  dateCreated: '2008-01-01',
+  dateUpdated: '2008-01-01',
+  lossFactor: 'high',
+  isTwoPartTariff: true
+}]);
+
+experiment('lib/services/returns/index', () => {
+  beforeEach(async () => {
+    sandbox.stub(repos.purposeUses, 'findByCodes').resolves(createPurposeUses());
+    sandbox.stub(apiConnector, 'getReturnsForLicence').resolves(createReturns());
+    sandbox.stub(apiConnector, 'getCurrentVersion').resolves(createVersion());
+    sandbox.stub(apiConnector, 'getLines').resolves(createLines());
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getReturnsForLicenceInFinancialYear', () => {
+    let result;
+
+    experiment('when the return has a current version with lines', async () => {
+      beforeEach(async () => {
+        result = await returnsService.getReturnsForLicenceInFinancialYear(licenceNumber, financialYear);
+      });
+
+      test('returns are fetched from the API with the financial year date range', async () => {
+        expect(apiConnector.getReturnsForLicence.calledWith(
+          licenceNumber, '2019-04-01', '2020-03-31'
+        )).to.be.true();
+      });
+
+      test('the current return version is fetched from the API', async () => {
+        expect(apiConnector.getCurrentVersion.calledWith(
+          returnId
+        )).to.be.true();
+      });
+
+      test('the lines for the current return version are fetched from the API', async () => {
+        expect(apiConnector.getLines.calledWith(
+          versionId
+        )).to.be.true();
+      });
+
+      test('the purpose uses are fetched from water.purpose_uses using the codes in the return metadata', async () => {
+        expect(repos.purposeUses.findByCodes.calledWith(
+          ['400']
+        )).to.be.true();
+      });
+
+      test('resolves with array of return service models', async () => {
+        expect(result).to.be.an.array().length(1);
+        expect(result[0] instanceof Return).to.be.true();
+      });
+
+      test('the return has a version', async () => {
+        const { returnVersions } = result[0];
+        expect(returnVersions).to.be.an.array().length(1);
+        expect(returnVersions[0] instanceof ReturnVersion).to.be.true();
+      });
+
+      test('the version has lines', async () => {
+        const { returnLines } = result[0].returnVersions[0];
+        expect(returnLines).to.be.an.array().length(1);
+        expect(returnLines[0] instanceof ReturnLine).to.be.true();
+      });
+    });
+
+    experiment('when the return is incomplete', async () => {
+      beforeEach(async () => {
+        apiConnector.getReturnsForLicence.resolves(createReturns({ status: 'due' }));
+        result = await returnsService.getReturnsForLicenceInFinancialYear(licenceNumber, financialYear);
+      });
+
+      test('return versions are not fetched from the API', async () => {
+        expect(apiConnector.getCurrentVersion.called).to.be.false();
+      });
+
+      test('lines are not fetched from the API', async () => {
+        expect(apiConnector.getLines.called).to.be.false();
+      });
+
+      test('the return has no versions', async () => {
+        expect(result[0].returnVersions[0]).to.be.undefined();
+      });
+    });
+
+    experiment('when there are no return versions', async () => {
+      beforeEach(async () => {
+        apiConnector.getCurrentVersion.resolves();
+        result = await returnsService.getReturnsForLicenceInFinancialYear(licenceNumber, financialYear);
+      });
+
+      test('lines are not loaded', async () => {
+        expect(apiConnector.getLines.called).to.be.false();
+      });
+
+      test('the return has no versions', async () => {
+        expect(result[0].returnVersions[0]).to.be.undefined();
+      });
+    });
+
+    experiment('when there is a nil return', async () => {
+      beforeEach(async () => {
+        apiConnector.getCurrentVersion.resolves(createVersion({ isNilReturn: true }));
+        result = await returnsService.getReturnsForLicenceInFinancialYear(licenceNumber, financialYear);
+      });
+
+      test('lines are not loaded', async () => {
+        expect(apiConnector.getLines.called).to.be.false();
+      });
+
+      test('the return has a version', async () => {
+        const { returnVersions } = result[0];
+        expect(returnVersions).to.be.an.array().length(1);
+        expect(returnVersions[0] instanceof ReturnVersion).to.be.true();
+      });
+
+      test('the version has no lines', async () => {
+        const { returnLines } = result[0].returnVersions[0];
+        expect(returnLines).to.be.an.array().length(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
In preparation for changes to two-part tariff matching, this PR:
- Adds service models for returns, versions and lines
- Adds mappers for the above from the returns service
- Adds a returns service which retrieves returns in the service model structure for a given licence within a financial year

This code is not currently used.