### PR TITLE
Fix issue where supplementary billing process did not create credits

### DIFF
--- a/src/lib/models/financial-year.js
+++ b/src/lib/models/financial-year.js
@@ -1,5 +1,6 @@
 const { range } = require('lodash');
 const moment = require('moment');
+const validators = require('./validators');
 
 class FinancialYear {
   /**
@@ -7,6 +8,7 @@ class FinancialYear {
    * @param {Number} yearEnding The year the financial year ends e.g. 2019 would be the year 01/04/2018 to 31/03/2019
    */
   constructor (yearEnding) {
+    validators.assertPositiveInteger(yearEnding);
     this.yearEnding = yearEnding;
   }
 
@@ -36,6 +38,17 @@ class FinancialYear {
    */
   get end () {
     return moment(`${this.endYear}-03-31`);
+  }
+
+  /**
+   * Checks if this financial year is equal to the one
+   * supplied
+   * @param {FinancialYear} financialYear
+   * @return {Boolean}
+   */
+  isEqualTo (financialYear) {
+    validators.assertIsInstanceOf(financialYear, FinancialYear);
+    return this.yearEnding === financialYear.yearEnding;
   }
 
   /**

--- a/src/lib/models/financial-year.js
+++ b/src/lib/models/financial-year.js
@@ -9,7 +9,7 @@ class FinancialYear {
    */
   constructor (yearEnding) {
     validators.assertPositiveInteger(yearEnding);
-    this.yearEnding = yearEnding;
+    this.yearEnding = parseInt(yearEnding);
   }
 
   /**

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -112,6 +112,17 @@ class Invoice extends Model {
   }
 
   /**
+   * Gets the invoice licence with specified licence number
+   * @param {String} licenceNumber
+   * @return {InvoiceLicence|undefined}
+   */
+  getInvoiceLicenceByLicenceNumber (licenceNumber) {
+    return this._invoiceLicences.find(
+      invoiceLicence => invoiceLicence.licence.licenceNumber === licenceNumber
+    );
+  }
+
+  /**
    * Get the licence numbers for this invoice by inspecting
    * the Licence objects associated with each InvoiceLicence
    * object associated with this invoice

--- a/src/lib/models/transaction.js
+++ b/src/lib/models/transaction.js
@@ -44,7 +44,7 @@ class Transaction extends Model {
     const transaction = new Transaction();
     transaction.pickFrom(this, [
       'value', 'authorisedDays', 'billableDays', 'agreements', 'chargePeriod',
-      'isCompensationCharge', 'description', 'chargeElement', 'volume'
+      'isCompensationCharge', 'description', 'chargeElement', 'volume', 'isTwoPartTariffSupplementary'
     ]);
     transaction.fromHash({
       isCredit: true,

--- a/src/modules/billing/mappers/invoice.js
+++ b/src/modules/billing/mappers/invoice.js
@@ -43,7 +43,7 @@ const modelToDb = (batch, invoice) => ({
   financialYearEnding: invoice.financialYear.endYear
 });
 
-const crmToModel = row => {
+const crmToModel = (row, financialYearEnding) => {
   const invoice = new Invoice();
 
   // Create invoice account model

--- a/src/modules/billing/services/supplementary-billing-service.js
+++ b/src/modules/billing/services/supplementary-billing-service.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const { uniq, groupBy, find } = require('lodash');
+const { uniq, groupBy } = require('lodash');
+const { getFinancialYear } = require('@envage/water-abstraction-helpers').charging;
 
 const newRepos = require('../../../lib/connectors/repos');
 const crmV2Connector = require('../../../lib/connectors/crm-v2');
 const mappers = require('../mappers');
 const batchService = require('./batch-service');
+const FinancialYear = require('../../../lib/models/financial-year');
 
 /**
  * Builds an index where the most recent transaction with a given key
@@ -69,43 +71,87 @@ const getUniqueInvoiceAccountIds = transactions => {
   return uniq(ids);
 };
 
-const decorateBatchWithInvoices = async (batch, transactions) => {
-  const invoiceAccountIds = getUniqueInvoiceAccountIds(transactions);
-
-  // Load invoice account data from CRM
-  const invoiceAccounts = await crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds(invoiceAccountIds);
-
-  // Add invoices to batch
-  batch.invoices = invoiceAccounts.map(mappers.invoice.crmToModel);
-
-  return batch;
+/**
+ * Finds or creates the Invoice model in the batch for the supplied invoice account
+ * number and financial year ending
+ * @param {Batch} batch
+ * @param {String} invoiceAccountNumber
+ * @param {Number} financialYearEnding
+ * @param {Array} crmInvoiceAccounts
+ * @return {Batch}
+ */
+const getOrCreateInvoice = (batch, invoiceAccountNumber, financialYearEnding, crmInvoiceAccounts) => {
+  // Find existing invoice model in batch
+  const financialYear = new FinancialYear(financialYearEnding);
+  let invoice = batch.getInvoiceByAccountNumberAndFinancialYear(invoiceAccountNumber, financialYear);
+  if (!invoice) {
+    // If not found, create new invoice model using CRM data
+    const crmInvoiceAccount = crmInvoiceAccounts.find(row => row.invoiceAccountNumber === invoiceAccountNumber);
+    invoice = mappers.invoice.crmToModel(crmInvoiceAccount);
+    invoice.financialYear = financialYear;
+    batch.invoices.push(invoice);
+  }
+  return invoice;
 };
 
-const getLicenceGroup = row =>
-  [
-    row.billingInvoiceLicence.companyId,
-    row.billingInvoiceLicence.contactId,
-    row.billingInvoiceLicence.addressId,
-    row.billingInvoiceLicence.licence.licenceRef,
-    row.billingInvoiceLicence.billingInvoice.invoiceAccountId
-  ].join(':');
-
-const decorateBatchWithLicences = (batch, transactions) => {
-  const groups = groupBy(transactions, getLicenceGroup);
-
-  Object.values(groups).forEach(transactions => {
-    // Create InvoiceLicence and map transactions
-    const invoiceLicence = mappers.invoiceLicence.dbToModel(transactions[0].billingInvoiceLicence);
-    invoiceLicence.transactions = transactions.map(
-      row => mappers.transaction.dbToModel(row).toCredit()
-    );
-
-    // Append to correct invoice in batch
-    const invoice = find(batch.invoices,
-      invoice => invoice.invoiceAccount.id === getInvoiceAccountId(transactions[0])
-    );
+/**
+ * Finds or creates the InvoiceLicence model in the batch for the supplied invoice
+ * and licence number
+ * @param {Invoice} invoice
+ * @param {String} licenceNumber
+ * @param {Array} transactions
+ * @return {InvoiceLicence}
+ */
+const getOrCreateInvoiceLicence = (invoice, licenceNumber, transactions) => {
+  let invoiceLicence = invoice.getInvoiceLicenceByLicenceNumber(licenceNumber);
+  if (!invoiceLicence) {
+    invoiceLicence = mappers.invoiceLicence.dbToModel(transactions[0].billingInvoiceLicence);
     invoice.invoiceLicences.push(invoiceLicence);
+  }
+  return invoiceLicence;
+};
+
+/**
+ * Decorates the supplied invoice licence with an array of Transaction instances
+ * created using the supplied transactions data.
+ * Each transaction is converted to a credit
+ * @param {InvoiceLicence} invoiceLicence
+ * @param {Array} transactions
+ */
+const decorateInvoiceLicenceWithCredits = (invoiceLicence, transactions) => {
+  const newTransactions = transactions.map(
+    row => mappers.transaction.dbToModel(row).toCredit()
+  );
+  invoiceLicence.transactions.push(...newTransactions);
+  return invoiceLicence;
+};
+
+/**
+ * Decorates the supplied batch with invoices, invoice licences and transactions.
+ * If the invoice or invoice licences are missing in the batch, they are created.
+ * All the supplied transactions are converted to credits
+ * @param {Batch} batch
+ * @param {Array} transactions
+ */
+const decorateBatchWithCreditTransactions = async (batch, transactions) => {
+  // Load invoice account data from CRM
+  const invoiceAccountIds = getUniqueInvoiceAccountIds(transactions);
+  const invoiceAccounts = await crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds(invoiceAccountIds);
+
+  // Group transactions by invoice/invoice licence
+  const groups = groupBy(transactions, transaction => {
+    const financialYearEnding = getFinancialYear(transaction.startDate);
+    return `${transaction.billingInvoiceLicence.billingInvoice.invoiceAccountNumber}_${financialYearEnding}_${transaction.billingInvoiceLicence.licenceRef}`;
   });
+
+  for (const key in groups) {
+    const [invoiceAccountNumber, financialYearEnding, licenceNumber] = key.split('_');
+    const invoice = getOrCreateInvoice(batch, invoiceAccountNumber, financialYearEnding, invoiceAccounts);
+    const invoiceLicence = getOrCreateInvoiceLicence(invoice, licenceNumber, transactions);
+    decorateInvoiceLicenceWithCredits(invoiceLicence, transactions);
+  }
+
+  return batch;
 };
 
 /**
@@ -124,8 +170,8 @@ const addCreditsToBatch = async (batchId, transactionIds) => {
     newRepos.billingTransactions.find(transactionIds)
   ]);
 
-  await decorateBatchWithInvoices(batch, transactions);
-  decorateBatchWithLicences(batch, transactions);
+  // Add credits to current batch
+  await decorateBatchWithCreditTransactions(batch, transactions);
 
   // Persist batch
   return batchService.saveInvoicesToDB(batch);

--- a/test/lib/models/batch.js
+++ b/test/lib/models/batch.js
@@ -16,10 +16,11 @@ class TestClass {
 }
 const TEST_MODEL = new TestClass();
 
-const createInvoice = accountNumber => {
+const createInvoice = (accountNumber, financialYearEnding = 2020) => {
   const invoice = new Invoice();
   invoice.invoiceAccount = new InvoiceAccount();
   invoice.invoiceAccount.accountNumber = accountNumber;
+  invoice.financialYear = new FinancialYear(financialYearEnding);
   return invoice;
 };
 
@@ -199,21 +200,22 @@ experiment('lib/models/batch', () => {
     });
   });
 
-  experiment('.getInvoiceByAccountNumber', () => {
+  experiment('.getInvoiceByAccountNumberAndFinancialYear', () => {
     let invoices;
 
     beforeEach(async () => {
-      invoices = [createInvoice('S12345678A'), createInvoice('S87654321A')];
+      invoices = [createInvoice('S12345678A', 2019), createInvoice('S87654321A', 2019), createInvoice('S87654321A', 2020)];
       batch.addInvoices(invoices);
     });
 
-    test('gets an invoice when an invoice with the account number is found', async () => {
-      const invoice = batch.getInvoiceByAccountNumber('S87654321A');
+    test('gets an invoice when an invoice with the account number and financial year is found', async () => {
+      const invoice = batch.getInvoiceByAccountNumberAndFinancialYear('S87654321A', new FinancialYear(2020));
       expect(invoice.invoiceAccount.accountNumber).to.equal('S87654321A');
+      expect(invoice.financialYear.yearEnding).to.equal(2020);
     });
 
     test('returns undefined when an invoice with the account number is not found', async () => {
-      const invoice = batch.getInvoiceByAccountNumber('NOT_HERE');
+      const invoice = batch.getInvoiceByAccountNumberAndFinancialYear('NOT_HERE', new FinancialYear(2020));
       expect(invoice).to.equal(undefined);
     });
   });

--- a/test/lib/models/financial-year.js
+++ b/test/lib/models/financial-year.js
@@ -4,6 +4,8 @@ const moment = require('moment');
 
 const FinancialYear = require('../../../src/lib/models/financial-year');
 
+class TestModel {};
+
 experiment('lib/models/financial-year', () => {
   test('.startYear is the year before the year ending value', async () => {
     const financialYear = new FinancialYear(2019);
@@ -53,6 +55,28 @@ experiment('lib/models/financial-year', () => {
       expect(financialYears[2].endYear).to.equal(2022);
       expect(financialYears[2].start).to.equal(moment('2021-04-01'));
       expect(financialYears[2].end).to.equal(moment('2022-03-31'));
+    });
+  });
+
+  experiment('.isEqualTo', () => {
+    test('returns true if the financial year is the same as the one supplied', async () => {
+      const financialYear = new FinancialYear(2019);
+      const comparison = new FinancialYear(2019);
+      expect(financialYear.isEqualTo(comparison)).to.equal(true);
+    });
+
+    test('returns false if the financial year is different same as the one supplied', async () => {
+      const financialYear = new FinancialYear(2019);
+      const comparison = new FinancialYear(2020);
+      expect(financialYear.isEqualTo(comparison)).to.equal(false);
+    });
+
+    test('throws an error if the argument is not a FinancialYear instance', async () => {
+      const func = () => {
+        const financialYear = new FinancialYear(2019);
+        return financialYear.isEqualTo(new TestModel());
+      };
+      expect(func).to.throw();
     });
   });
 });

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -115,4 +115,30 @@ experiment('lib/models/invoice', () => {
       expect(invoice.getLicenceNumbers()).to.equal([]);
     });
   });
+
+  experiment('.getInvoiceLicenceByLicenceNumber', () => {
+    let invoiceLicenceA, invoiceLicenceB, invoice;
+
+    const createInvoiceLicence = licenceNumber => {
+      const licence = new Licence();
+      licence.licenceNumber = licenceNumber;
+      const invoiceLicence = new InvoiceLicence();
+      return invoiceLicence.fromHash({ licence });
+    };
+
+    beforeEach(async () => {
+      invoiceLicenceA = createInvoiceLicence('01/123');
+      invoiceLicenceB = createInvoiceLicence('02/345');
+      invoice = new Invoice();
+      invoice.invoiceLicences = [invoiceLicenceA, invoiceLicenceB];
+    });
+
+    test('gets an invoice licence by licence number', async () => {
+      expect(invoice.getInvoiceLicenceByLicenceNumber('02/345')).to.equal(invoiceLicenceB);
+    });
+
+    test('returns undefined if not found', async () => {
+      expect(invoice.getInvoiceLicenceByLicenceNumber('01/999')).to.be.undefined();
+    });
+  });
 });

--- a/test/lib/models/transaction.js
+++ b/test/lib/models/transaction.js
@@ -4,6 +4,7 @@ const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi
 const { expect } = require('@hapi/code');
 const uuid = require('uuid/v4');
 const sandbox = require('sinon').createSandbox();
+const { omit } = require('lodash');
 
 const hashers = require('../../../src/lib/hash');
 const Transaction = require('../../../src/lib/models/transaction');
@@ -53,9 +54,6 @@ const getTestDataForHashing = () => {
   transaction.chargeElement = chargeElement;
   transaction.volume = 3;
   transaction.isCompensationCharge = true;
-  transaction.calculatedVolume = 4;
-  transaction.twoPartTariffStatus = null;
-  transaction.twoPartTariffError = false;
   transaction.isTwoPartTariffSupplementary = true;
 
   transaction.agreements = [
@@ -104,6 +102,29 @@ experiment('lib/models/transaction', () => {
       expect(transaction.id).to.equal(id);
       expect(transaction.value).to.equal(100);
       expect(transaction.isCredit).to.be.true();
+    });
+  });
+
+  experiment('.toCredit', () => {
+    let credit, transaction;
+
+    beforeEach(async () => {
+      transaction = getTestDataForHashing().transaction;
+      credit = transaction.toCredit();
+    });
+
+    test('the id is not set', async () => {
+      expect(credit.id).to.be.undefined();
+    });
+
+    test('the isCredit flag is true', async () => {
+      expect(credit.isCredit).to.be.true();
+    });
+
+    test('the transactions match except for the id and credit flag', async () => {
+      const originalData = omit(transaction.toJSON(), ['id', 'isCredit']);
+      const creditData = omit(credit.toJSON(), ['id', 'isCredit']);
+      expect(originalData).to.equal(creditData);
     });
   });
 

--- a/test/modules/billing/services/billing-volumes-service.js
+++ b/test/modules/billing/services/billing-volumes-service.js
@@ -133,8 +133,8 @@ experiment('modules/billing/services/billing-volumes-service', () => {
           .onSecondCall().resolves(billingVolumesData[1]);
 
         mappers.billingVolume.dbToModel
-          .onFirstCall().returns(createBillingVolume(createBillingVolume(billingVolumesData[0])))
-          .onSecondCall().returns(createBillingVolume(createBillingVolume(billingVolumesData[1])));
+          .onFirstCall().returns(createBillingVolume(billingVolumesData[0]))
+          .onSecondCall().returns(createBillingVolume(billingVolumesData[1]));
 
         result = await billingVolumesService.getVolumes(chargeElements, '12/34/567', 2019, true, batch);
       });

--- a/test/modules/billing/services/charge-processor-service/data.js
+++ b/test/modules/billing/services/charge-processor-service/data.js
@@ -133,7 +133,8 @@ const createInvoice = () => {
   const invoice = new Invoice();
   return invoice.fromHash({
     invoiceAccount,
-    invoiceLicences: [invoiceLicence]
+    invoiceLicences: [invoiceLicence],
+    financialYear: new FinancialYear(2019)
   });
 };
 

--- a/test/modules/billing/services/supplementary-billing-service.js
+++ b/test/modules/billing/services/supplementary-billing-service.js
@@ -10,6 +10,11 @@ const { expect } = require('@hapi/code');
 const sandbox = require('sinon').createSandbox();
 
 const { Batch } = require('../../../../src/lib/models');
+const Invoice = require('../../../../src/lib/models/invoice');
+const InvoiceLicence = require('../../../../src/lib/models/invoice-licence');
+const InvoiceAccount = require('../../../../src/lib/models/invoice-account');
+const Licence = require('../../../../src/lib/models/licence');
+
 const { CHARGE_SEASON } = require('../../../../src/lib/models/constants');
 const batchService = require('../../../../src/modules/billing/services/batch-service');
 
@@ -17,17 +22,20 @@ const crmV2Connector = require('../../../../src/lib/connectors/crm-v2');
 const newRepos = require('../../../../src/lib/connectors/repos');
 
 const supplementaryBillingService = require('../../../../src/modules/billing/services/supplementary-billing-service');
+const FinancialYear = require('../../../../src/lib/models/financial-year');
 
 const batchId = '398b6f31-ff01-4621-b939-e720f1a77deb';
 const invoiceAccountId = '398b6f31-ff01-4621-b939-e720f1a77deb';
 const invoiceAccountNumber = 'A12345678A';
+const licenceNumber = '01/123/ABC';
 
 const createTransactionRow = (index, transactionKey, isCredit = false) => ({
   billingTransactionId: `00000000-0000-0000-0000-00000000000${index}`,
   isCredit,
   transactionKey,
   billingVolume: [],
-  isTwoPartTariffSupplementary: false
+  isTwoPartTariffSupplementary: false,
+  startDate: '2019-04-01'
 });
 
 const createFullTransaction = (...args) => ({
@@ -51,7 +59,7 @@ const createFullTransaction = (...args) => ({
     },
     licence: {
       licenceId: '4b4f2427-984e-48f6-8b20-f17380b870a8',
-      licenceRef: '01/123/ABC',
+      licenceRef: licenceNumber,
       regions: { historicalAreaCode: 'ARCA', regionalChargeArea: 'Anglian' },
       startDate: '2019-02-01',
       expiredDate: null,
@@ -109,6 +117,31 @@ const data = {
 
 const createBatch = () => new Batch(batchId);
 
+const createInvoice = invoiceAccountNumber => {
+  // Create invoice account
+  const invoiceAccount = new InvoiceAccount();
+  invoiceAccount.accountNumber = invoiceAccountNumber;
+
+  // Create invoice
+  const invoice = new Invoice();
+  return invoice.fromHash({
+    invoiceAccount,
+    financialYear: new FinancialYear(2020)
+  });
+};
+
+const createInvoiceLicence = licenceNumber => {
+  // Create licence
+  const licence = new Licence();
+  licence.licenceNumber = licenceNumber;
+
+  // Create invoice licence
+  const invoiceLicence = new InvoiceLicence();
+  return invoiceLicence.fromHash({
+    licence
+  });
+};
+
 experiment('modules/billing/services/supplementary-billing-service', () => {
   let batch;
 
@@ -136,78 +169,104 @@ experiment('modules/billing/services/supplementary-billing-service', () => {
       newRepos.billingTransactions.find.resolves(data.creditTransactions);
       crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds.resolves(data.crmResponse);
       batchService.getBatchById.resolves(batch);
-      await supplementaryBillingService.processBatch(data.batchId);
     });
 
-    test('calls billingTransactions.findByBatchId with correct batch ID', async () => {
-      expect(newRepos.billingTransactions.findByBatchId.calledWith(
-        data.batchId
-      )).to.be.true();
-    });
+    experiment('for an empty batch', () => {
+      beforeEach(async () => {
+        await supplementaryBillingService.processBatch(data.batchId);
+      });
 
-    test('calls billingTransactions.findHistoryByBatchId with correct batch ID', async () => {
-      expect(newRepos.billingTransactions.findHistoryByBatchId.calledWith(
-        data.batchId
-      )).to.be.true();
-    });
-
-    test('current batch transactions which have already been charged are deleted', async () => {
-      expect(newRepos.billingTransactions.delete.calledWith(
-        ['00000000-0000-0000-0000-000000000001']
-      )).to.be.true();
-    });
-
-    experiment('historical charges which have no charge in the current batch', () => {
-      test('are fetched from the repo', async () => {
-        expect(newRepos.billingTransactions.find.calledWith(
-          ['00000000-0000-0000-0000-000000000005']
+      test('calls billingTransactions.findByBatchId with correct batch ID', async () => {
+        expect(newRepos.billingTransactions.findByBatchId.calledWith(
+          data.batchId
         )).to.be.true();
       });
 
-      test('have their invoice account fetched from the CRM', async () => {
-        expect(crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds.calledWith(
-          [data.creditTransactions[0].billingInvoiceLicence.billingInvoice.invoiceAccountId]
+      test('calls billingTransactions.findHistoryByBatchId with correct batch ID', async () => {
+        expect(newRepos.billingTransactions.findHistoryByBatchId.calledWith(
+          data.batchId
         )).to.be.true();
       });
 
-      experiment('persist the batch', () => {
-        let batch;
+      test('current batch transactions which have already been charged are deleted', async () => {
+        expect(newRepos.billingTransactions.delete.calledWith(
+          ['00000000-0000-0000-0000-000000000001']
+        )).to.be.true();
+      });
 
-        beforeEach(async () => {
-          batch = batchService.saveInvoicesToDB.lastCall.args[0];
+      experiment('historical charges which have no charge in the current batch', () => {
+        test('are fetched from the repo', async () => {
+          expect(newRepos.billingTransactions.find.calledWith(
+            ['00000000-0000-0000-0000-000000000005']
+          )).to.be.true();
         });
 
-        test('to be the correct batch', async () => {
-          expect(batch.id).to.equal(batchId);
+        test('have their invoice account fetched from the CRM', async () => {
+          expect(crmV2Connector.invoiceAccounts.getInvoiceAccountsByIds.calledWith(
+            [data.creditTransactions[0].billingInvoiceLicence.billingInvoice.invoiceAccountId]
+          )).to.be.true();
         });
 
-        test('only the correct number of transactions are credited', async () => {
-          expect(batch.invoices).to.have.length(1);
-          expect(batch.invoices[0].invoiceLicences).to.have.length(1);
-          expect(batch.invoices[0].invoiceLicences[0].transactions).to.have.length(1);
-        });
+        experiment('persist the batch', () => {
+          let batch;
 
-        test('the invoice details are correctly loaded from the CRM', async () => {
-          expect(batch.invoices[0].invoiceAccount.id).to.equal(data.crmResponse[0].invoiceAccountId);
-          expect(batch.invoices[0].invoiceAccount.accountNumber).to.equal(data.crmResponse[0].invoiceAccountNumber);
-          expect(batch.invoices[0].invoiceAccount.company.id).to.equal(data.crmResponse[0].company.companyId);
-          expect(batch.invoices[0].address.id).to.equal(data.crmResponse[0].invoiceAccountAddresses[0].address.addressId);
-        });
+          beforeEach(async () => {
+            batch = batchService.saveInvoicesToDB.lastCall.args[0];
+          });
 
-        test('the licence details are taken from the historical transaction', async () => {
-          const [invoiceAccountLicence] = batch.invoices[0].invoiceLicences;
-          expect(invoiceAccountLicence.licence.id).to.equal(data.creditTransactions[0].billingInvoiceLicence.licence.licenceId);
-          expect(invoiceAccountLicence.licence.licenceNumber).to.equal(data.creditTransactions[0].billingInvoiceLicence.licence.licenceRef);
-        });
+          test('to be the correct batch', async () => {
+            expect(batch.id).to.equal(batchId);
+          });
 
-        test('the new credit transaction has the correct details', async () => {
-          const [transaction] = batch.invoices[0].invoiceLicences[0].transactions;
-          expect(transaction.id).to.be.undefined();
-          expect(transaction.isCredit).to.be.true();
-          expect(transaction.status).to.equal('candidate');
-          expect(transaction.description).to.equal(data.creditTransactions[0].description);
-          expect(transaction.chargeElement.id).to.equal(data.creditTransactions[0].chargeElement.chargeElementId);
+          test('only the correct number of transactions are credited', async () => {
+            expect(batch.invoices).to.have.length(1);
+            expect(batch.invoices[0].invoiceLicences).to.have.length(1);
+            expect(batch.invoices[0].invoiceLicences[0].transactions).to.have.length(1);
+          });
+
+          test('the invoice details are correctly loaded from the CRM', async () => {
+            expect(batch.invoices[0].invoiceAccount.id).to.equal(data.crmResponse[0].invoiceAccountId);
+            expect(batch.invoices[0].invoiceAccount.accountNumber).to.equal(data.crmResponse[0].invoiceAccountNumber);
+            expect(batch.invoices[0].invoiceAccount.company.id).to.equal(data.crmResponse[0].company.companyId);
+            expect(batch.invoices[0].address.id).to.equal(data.crmResponse[0].invoiceAccountAddresses[0].address.addressId);
+          });
+
+          test('the licence details are taken from the historical transaction', async () => {
+            const [invoiceAccountLicence] = batch.invoices[0].invoiceLicences;
+            expect(invoiceAccountLicence.licence.id).to.equal(data.creditTransactions[0].billingInvoiceLicence.licence.licenceId);
+            expect(invoiceAccountLicence.licence.licenceNumber).to.equal(data.creditTransactions[0].billingInvoiceLicence.licence.licenceRef);
+          });
+
+          test('the new credit transaction has the correct details', async () => {
+            const [transaction] = batch.invoices[0].invoiceLicences[0].transactions;
+            expect(transaction.id).to.be.undefined();
+            expect(transaction.isCredit).to.be.true();
+            expect(transaction.status).to.equal('candidate');
+            expect(transaction.description).to.equal(data.creditTransactions[0].description);
+            expect(transaction.chargeElement.id).to.equal(data.creditTransactions[0].chargeElement.chargeElementId);
+          });
         });
+      });
+    });
+
+    experiment('when transactions are added to existing invoices/invoice licences', async () => {
+      beforeEach(async () => {
+        // Create existing invoice/invoice licence
+        batch = createBatch();
+        const invoice = createInvoice(invoiceAccountNumber);
+        invoice.invoiceLicences = [
+          createInvoiceLicence(licenceNumber)
+        ];
+        batch.invoices = [invoice];
+        batchService.getBatchById.resolves(batch);
+
+        await supplementaryBillingService.processBatch(data.batchId);
+      });
+
+      test('transactions are attached to the existing invoice', async () => {
+        expect(batch.invoices).to.be.an.array().length(1);
+        expect(batch.invoices[0].invoiceLicences).to.be.an.array().length(1);
+        expect(batch.invoices[0].invoiceLicences[0].transactions).to.be.an.array().length(1);
       });
     });
   });

--- a/test/modules/billing/services/two-part-tariff-service/test-batch.js
+++ b/test/modules/billing/services/two-part-tariff-service/test-batch.js
@@ -54,7 +54,8 @@ invoiceLicence.transactions = [transaction];
 const invoice = new Invoice();
 invoice.fromHash({
   invoiceLicences: [invoiceLicence],
-  invoiceAccount
+  invoiceAccount,
+  financialYear: new FinancialYear(2019)
 });
 
 const batch = new Batch();

--- a/test/modules/billing/test-data/test-billing-data.js
+++ b/test/modules/billing/test-data/test-billing-data.js
@@ -117,7 +117,8 @@ const createInvoice = (options = {}, invoiceLicences) => {
   return invoice.fromHash({
     invoiceLicences: invoiceLicences || [createInvoiceLicence()],
     invoiceAccount,
-    options
+    options,
+    financialYear: new FinancialYear(2020)
   });
 };
 


### PR DESCRIPTION
Fixes an issue where due to a recent change (where invoices are now per financial year) the supplementary billing service was not correctly assembling the object graph of batch / invoices / invoice licences / transactions before persisting credits.
