### PR TITLE
Feat: Licence include in supplementary billing

### DIFF
--- a/integration-tests/billing/services/data/licences.js
+++ b/integration-tests/billing/services/data/licences.js
@@ -1,6 +1,6 @@
 exports.l1 = {
   licenceRef : 'L1',
-  includeInSupplementaryBilling : false,
+  includeInSupplementaryBilling : 'no',
   isWaterUndertaker : false,
   regions : {
     historicalAreaCode: 'ARCA',
@@ -27,4 +27,4 @@ exports.l1 = {
   }]
 };
 
-exports.l2 = Object.assign({}, exports.l1, { includeInSupplementaryBilling: true })
+exports.l2 = Object.assign({}, exports.l1, { includeInSupplementaryBilling: 'yes' })

--- a/migrations/20200728085519-update-licences-include-in-supplementary-billing.js
+++ b/migrations/20200728085519-update-licences-include-in-supplementary-billing.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200728085519-update-licences-include-in-supplementary-billing-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200728085519-update-licences-include-in-supplementary-billing-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200728085519-update-licences-include-in-supplementary-billing-down.sql
+++ b/migrations/sqls/20200728085519-update-licences-include-in-supplementary-billing-down.sql
@@ -1,0 +1,21 @@
+
+alter table water.licences
+  add column include_in_supplementary_billing_temp boolean;
+
+update water.licences
+set include_in_supplementary_billing_temp =
+  case
+    when include_in_supplementary_billing = 'yes'::water.include_in_supplementary_billing then true
+    else false
+  end;
+
+alter table water.licences
+  drop column include_in_supplementary_billing;
+
+alter table water.licences
+  rename column include_in_supplementary_billing_temp to include_in_supplementary_billing;
+
+alter table water.licences
+  alter column include_in_supplementary_billing set not null;
+
+drop type water.include_in_supplementary_billing;

--- a/migrations/sqls/20200728085519-update-licences-include-in-supplementary-billing-up.sql
+++ b/migrations/sqls/20200728085519-update-licences-include-in-supplementary-billing-up.sql
@@ -1,0 +1,20 @@
+create type water.include_in_supplementary_billing as enum ('yes', 'no', 'reprocess');
+
+alter table water.licences
+  add column include_in_supplementary_billing_temp water.include_in_supplementary_billing;
+
+update water.licences
+set include_in_supplementary_billing_temp =
+  case
+    when include_in_supplementary_billing = true then 'yes'::water.include_in_supplementary_billing
+    else 'no'::water.include_in_supplementary_billing
+  end;
+
+alter table water.licences
+  drop column include_in_supplementary_billing;
+
+alter table water.licences
+  rename column include_in_supplementary_billing_temp to include_in_supplementary_billing;
+
+alter table water.licences
+  alter column include_in_supplementary_billing set not null;

--- a/src/lib/connectors/repos/licences.js
+++ b/src/lib/connectors/repos/licences.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { Licence } = require('../bookshelf');
+const { Licence, bookshelf } = require('../bookshelf');
+const queries = require('./queries/licences');
 
 /**
  * Gets a list of licence agreements of the given types for the specified
@@ -21,4 +22,45 @@ const findOne = async licenceId => {
   return model ? model.toJSON() : null;
 };
 
+/**
+ * Updates a water.licences record for the given id
+ *
+ * @param {String} licenceId UUID of the licence to update
+ * @param {Object} changes Key values pairs of the changes to make
+ */
+const update = (licenceId, changes) => Licence
+  .forge({ licenceId })
+  .save(changes, { patch: true });
+
+const updateIncludeLicenceInSupplementaryBilling = (licenceId, from, to) => {
+  const options = {
+    require: false,
+    patch: true
+  };
+
+  return Licence
+    .forge({ licenceId, includeInSupplementaryBilling: from })
+    .save({ includeInSupplementaryBilling: to }, options);
+};
+
+/**
+ * For all licences associated with a batch update the
+ * include_in_supplementary_billing value to a new value where the current
+ * value is equal to the 'from' parameter value.
+ *
+ * @param {String} batchId
+ * @param {String} from The status value to move from (enum water.include_in_supplementary_billing)
+ * @param {String} to The status value to move to (enum water.include_in_supplementary_billing)
+ */
+const updateIncludeInSupplementaryBillingStatusForBatch = (batchId, from, to) => {
+  const params = { batchId, from, to };
+
+  return bookshelf
+    .knex
+    .raw(queries.updateIncludeInSupplementaryBillingStatusForBatch, params);
+};
+
 exports.findOne = findOne;
+exports.update = update;
+exports.updateIncludeLicenceInSupplementaryBilling = updateIncludeLicenceInSupplementaryBilling;
+exports.updateIncludeInSupplementaryBillingStatusForBatch = updateIncludeInSupplementaryBillingStatusForBatch;

--- a/src/lib/connectors/repos/queries/billing-batch-charge-versions.js
+++ b/src/lib/connectors/repos/queries/billing-batch-charge-versions.js
@@ -5,7 +5,7 @@ select :billingBatchId, cv.charge_version_id
 from water.licences l
   join water.charge_versions cv on l.licence_ref = cv.licence_ref
 where
-  l.include_in_supplementary_billing = true
+  l.include_in_supplementary_billing = 'yes'::water.include_in_supplementary_billing
   and l.region_id = :regionId::uuid
   and cv.status='current'
   and (cv.end_date is null or cv.end_date > :fromDate)

--- a/src/lib/connectors/repos/queries/licences.js
+++ b/src/lib/connectors/repos/queries/licences.js
@@ -1,0 +1,20 @@
+/**
+ * Updates the include_in_supplementary_billing value in the
+ * water licences table from a value to a value for a given batch
+ */
+const updateIncludeInSupplementaryBillingStatusForBatch = `
+  update water.licences l
+  set include_in_supplementary_billing = :to
+  from
+    water.billing_batches b
+      join water.billing_batch_charge_versions bcv
+        on b.billing_batch_id = bcv.billing_batch_id
+      join water.charge_versions cv
+        on bcv.charge_version_id = cv.charge_version_id
+  where l.licence_ref = cv.licence_ref
+  and b.billing_batch_id = :batchId
+  and b.batch_type = 'supplementary'
+  and l.include_in_supplementary_billing = :from;
+`;
+
+exports.updateIncludeInSupplementaryBillingStatusForBatch = updateIncludeInSupplementaryBillingStatusForBatch;

--- a/src/lib/models/constants.js
+++ b/src/lib/models/constants.js
@@ -29,3 +29,9 @@ exports.RETURN_SEASONS = {
   summer: 'summer',
   winterAllYear: 'winterAllYear'
 };
+
+exports.INCLUDE_IN_SUPPLEMENTARY_BILLING = {
+  yes: 'yes',
+  no: 'no',
+  reprocess: 'reprocess'
+};

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { get, flatMap } = require('lodash');
+const { uniq, get, flatMap } = require('lodash');
 
 const { assertIsInstanceOf, assertIsArrayOfType, assertIsNullableInstanceOf } = require('./validators');
 const Model = require('./model');
@@ -131,6 +131,17 @@ class Invoice extends Model {
     return flatMap(this.invoiceLicences, invoiceLicence => {
       return get(invoiceLicence, 'licence.licenceNumber');
     });
+  }
+
+  /**
+   * Get the licence ids for this invoice by inspecting
+   * the Licence objects associated with each InvoiceLicence
+   * object associated with this invoice
+   */
+  getLicenceIds () {
+    return uniq(flatMap(this.invoiceLicences, invoiceLicence => {
+      return get(invoiceLicence, 'licence.id');
+    }));
   }
 
   /**

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -3,6 +3,7 @@
 const repos = require('../connectors/repos');
 const licenceMapper = require('../mappers/licence');
 const licenceVersionMapper = require('../mappers/licence-version');
+const { INCLUDE_IN_SUPPLEMENTARY_BILLING } = require('../models/constants');
 
 /**
  * Gets a licence model by ID
@@ -25,6 +26,59 @@ const getLicenceVersionById = async licenceVersionId => {
   return licenceVersion && licenceVersionMapper.dbToModel(licenceVersion);
 };
 
+/**
+ * Updates the includeInSupplementaryBilling value for the given licence ids
+ *
+ * @param {String} from The status to move from (yes, no, reprocess)
+ * @param {String} to The status to move to (yes, no, reprocess)
+ * @param  {...String} licenceIds One or many licences ids to update
+ */
+const updateIncludeInSupplementaryBillingStatus = async (from, to, ...licenceIds) => {
+  for (const licenceId of licenceIds) {
+    await repos.licences.updateIncludeLicenceInSupplementaryBilling(licenceId, from, to);
+  }
+};
+
+/**
+ * Sets the water.licences.include_in_supplementary_billing value
+ * from reprocess to yes for situtations where the batch has not got
+ * through the the sent phase. This allows the licences to be picked up
+ * in a future supplementary bill run.
+ *
+ * @param {String} batchId
+ */
+const updateIncludeInSupplementaryBillingStatusForUnsentBatch = batchId => {
+  return repos.licences.updateIncludeInSupplementaryBillingStatusForBatch(
+    batchId,
+    INCLUDE_IN_SUPPLEMENTARY_BILLING.reprocess,
+    INCLUDE_IN_SUPPLEMENTARY_BILLING.yes
+  );
+};
+
+/**
+ * Sets the water.licences.include_in_supplementary_billing value
+ * from yes to no, then reprocess to yes for situtations where the batch has
+ * been sent and therefore the licences don't need to be includes in
+ * a future supplementary bill run.
+ *
+ * @param {String} batchId
+ */
+const updateIncludeInSupplementaryBillingStatusForSentBatch = async batchId => {
+  await repos.licences.updateIncludeInSupplementaryBillingStatusForBatch(
+    batchId,
+    INCLUDE_IN_SUPPLEMENTARY_BILLING.yes,
+    INCLUDE_IN_SUPPLEMENTARY_BILLING.no
+  );
+
+  // use the unsent function to save writing the same logic twice, even though
+  // the function name is a little misleading here.
+  return updateIncludeInSupplementaryBillingStatusForUnsentBatch(batchId);
+};
+
 exports.getLicenceById = getLicenceById;
 exports.getLicenceVersionById = getLicenceVersionById;
 exports.getLicenceVersions = getLicenceVersions;
+
+exports.updateIncludeInSupplementaryBillingStatus = updateIncludeInSupplementaryBillingStatus;
+exports.updateIncludeInSupplementaryBillingStatusForUnsentBatch = updateIncludeInSupplementaryBillingStatusForUnsentBatch;
+exports.updateIncludeInSupplementaryBillingStatusForSentBatch = updateIncludeInSupplementaryBillingStatusForSentBatch;

--- a/src/modules/billing/jobs/lib/batch-job.js
+++ b/src/modules/billing/jobs/lib/batch-job.js
@@ -3,6 +3,7 @@
 const { get } = require('lodash');
 
 const batchService = require('../../services/batch-service');
+const licencesService = require('../../../../lib/services/licences');
 const { logger } = require('../../../../logger');
 
 const getRequestName = job => job.data.request.name;
@@ -43,6 +44,7 @@ const failBatch = (job, messageQueue, errorCode) => {
 
   return Promise.all([
     batchService.setErrorStatus(batchId, errorCode),
+    licencesService.updateIncludeInSupplementaryBillingStatusForUnsentBatch(batchId),
     messageQueue.deleteQueue(name)
   ]);
 };

--- a/src/modules/billing/services/invoice-licences-service.js
+++ b/src/modules/billing/services/invoice-licences-service.js
@@ -4,6 +4,7 @@ const newRepos = require('../../../lib/connectors/repos');
 
 const mappers = require('../mappers');
 const { NotFoundError } = require('../../../lib/errors');
+const { INCLUDE_IN_SUPPLEMENTARY_BILLING } = require('../../../lib/models/constants');
 const { BatchStatusError } = require('../lib/errors');
 const Batch = require('../../../lib/models/batch');
 const batchService = require('./batch-service');
@@ -85,6 +86,15 @@ const deleteInvoiceLicence = async invoiceLicenceId => {
 
   // Delete invoice licence
   await newRepos.billingInvoiceLicences.delete(invoiceLicenceId);
+
+  // If the licence was marked for supplmenetary billing then
+  // change the status to 'reprocess' to be left for supplementary
+  // billing in the future.
+  await newRepos.licences.updateIncludeLicenceInSupplementaryBilling(
+    invoiceLicence.licenceId,
+    INCLUDE_IN_SUPPLEMENTARY_BILLING.yes,
+    INCLUDE_IN_SUPPLEMENTARY_BILLING.reprocess
+  );
 
   // Set batch to empty if required
   return batchService.setStatusToEmptyWhenNoTransactions(batch);

--- a/test/lib/connectors/repository/LicenceRepository.js
+++ b/test/lib/connectors/repository/LicenceRepository.js
@@ -18,7 +18,7 @@ const data = {
     licence_id: 'f5d78402-8dc4-490a-8326-b1be90e12729',
     region_id: '11131a93-0f5c-477a-a68a-91f55f4c48f9',
     licence_ref: '01/123/ABC',
-    include_in_supplementary_billing: false
+    include_in_supplementary_billing: 'no'
   }]
 };
 

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -2,6 +2,7 @@
 
 const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
 const { expect } = require('@hapi/code');
+const uuid = require('uuid/v4');
 
 const Invoice = require('../../../src/lib/models/invoice');
 const InvoiceAccount = require('../../../src/lib/models/invoice-account');
@@ -113,6 +114,39 @@ experiment('lib/models/invoice', () => {
     test('returns an empty array if there is no licence data', async () => {
       const invoice = new Invoice();
       expect(invoice.getLicenceNumbers()).to.equal([]);
+    });
+  });
+
+  experiment('.getLicenceIds', () => {
+    experiment('when there are licences', () => {
+      test('returns an array of the unique ids', async () => {
+        const id1 = uuid();
+        const id2 = uuid();
+
+        const licence1 = new Licence(id1);
+        const licence2 = new Licence(id2);
+        const licence3 = new Licence(id1);
+
+        const invoiceLicence1 = new InvoiceLicence().fromHash({ licence: licence1 });
+        const invoiceLicence2 = new InvoiceLicence().fromHash({ licence: licence2 });
+        const invoiceLicence3 = new InvoiceLicence().fromHash({ licence: licence3 });
+
+        const invoice = new Invoice();
+        invoice.invoiceLicences = [invoiceLicence1, invoiceLicence2, invoiceLicence3];
+
+        const licenceIds = invoice.getLicenceIds();
+
+        expect(licenceIds.length).to.equal(2);
+        expect(licenceIds).to.contain(id1);
+        expect(licenceIds).to.contain(id2);
+      });
+    });
+
+    experiment('when there are no licences', () => {
+      test('returns an empty array', async () => {
+        const invoice = new Invoice();
+        expect(invoice.getLicenceIds()).to.equal([]);
+      });
     });
   });
 

--- a/test/modules/billing/jobs/lib/batch-job.js
+++ b/test/modules/billing/jobs/lib/batch-job.js
@@ -12,6 +12,7 @@ const sandbox = require('sinon').createSandbox();
 
 const batchJob = require('../../../../../src/modules/billing/jobs/lib/batch-job');
 const batchService = require('../../../../../src/modules/billing/services/batch-service');
+const licenceService = require('../../../../../src/lib/services/licences');
 const { logger } = require('../../../../../src/logger');
 
 experiment('modules/billing/jobs/lib/batch-job', () => {
@@ -22,6 +23,11 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
 
     sandbox.stub(logger, 'info');
     sandbox.stub(logger, 'error');
+
+    sandbox.stub(
+      licenceService,
+      'updateIncludeInSupplementaryBillingStatusForUnsentBatch'
+    ).resolves();
 
     messageQueue = {
       deleteQueue: sandbox.spy()
@@ -60,6 +66,11 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
       const [id, code] = batchService.setErrorStatus.lastCall.args;
       expect(id).to.equal(batchId);
       expect(code).to.equal(10);
+    });
+
+    test('updates the supplementary billing status of any licences', async () => {
+      const [id] = licenceService.updateIncludeInSupplementaryBillingStatusForUnsentBatch.lastCall.args;
+      expect(id).to.equal(batchId);
     });
 
     test('deletes the queue', async () => {

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -30,11 +30,12 @@ const newRepos = require('../../../../src/lib/connectors/repos');
 const chargeModuleBillRunConnector = require('../../../../src/lib/connectors/charge-module/bill-runs');
 
 const batchService = require('../../../../src/modules/billing/services/batch-service');
-const invoiceAccountsService = require('../../../../src/lib/services/invoice-accounts-service');
-const invoiceService = require('../../../../src/modules/billing/services/invoice-service');
-const invoiceLicencesService = require('../../../../src/modules/billing/services/invoice-licences-service');
-const transactionsService = require('../../../../src/modules/billing/services/transactions-service');
 const billingVolumesService = require('../../../../src/modules/billing/services/billing-volumes-service');
+const invoiceAccountsService = require('../../../../src/lib/services/invoice-accounts-service');
+const invoiceLicencesService = require('../../../../src/modules/billing/services/invoice-licences-service');
+const invoiceService = require('../../../../src/modules/billing/services/invoice-service');
+const licencesService = require('../../../../src/lib/services/licences');
+const transactionsService = require('../../../../src/modules/billing/services/transactions-service');
 const { createBatch } = require('../test-data/test-billing-data');
 const config = require('../../../../config');
 
@@ -102,6 +103,10 @@ experiment('modules/billing/services/batch-service', () => {
 
     sandbox.stub(invoiceService, 'saveInvoiceToDB');
     sandbox.stub(invoiceAccountsService, 'getByInvoiceAccountId');
+
+    sandbox.stub(licencesService, 'updateIncludeInSupplementaryBillingStatus').resolves();
+    sandbox.stub(licencesService, 'updateIncludeInSupplementaryBillingStatusForSentBatch').resolves();
+    sandbox.stub(licencesService, 'updateIncludeInSupplementaryBillingStatusForUnsentBatch').resolves();
 
     sandbox.stub(chargeModuleBillRunConnector, 'create').resolves();
     sandbox.stub(chargeModuleBillRunConnector, 'get').resolves();
@@ -298,6 +303,11 @@ experiment('modules/billing/services/batch-service', () => {
         await batchService.deleteBatch(batch, internalCallingUser);
       });
 
+      test('update the include in supplementary bill run status for all the licences', async () => {
+        const [batchId] = licencesService.updateIncludeInSupplementaryBillingStatusForUnsentBatch.lastCall.args;
+        expect(batchId).to.equal(batch.id);
+      });
+
       test('delete the batch at the charge module', async () => {
         const [externalId] = chargeModuleBillRunConnector.delete.lastCall.args;
         expect(externalId).to.equal(batch.externalId);
@@ -403,6 +413,7 @@ experiment('modules/billing/services/batch-service', () => {
 
     beforeEach(async () => {
       batch = {
+        id: uuid(),
         externalId: uuid()
       };
 
@@ -434,6 +445,11 @@ experiment('modules/billing/services/batch-service', () => {
         expect(savedEvent.status).to.equal('sent');
         expect(savedEvent.metadata.user).to.equal(internalCallingUser);
         expect(savedEvent.metadata.batch).to.equal(batch);
+      });
+
+      test('updates the include in supplementary billing status for the batch licences', async () => {
+        const [batchId] = licencesService.updateIncludeInSupplementaryBillingStatusForSentBatch.lastCall.args;
+        expect(batchId).to.equal(batch.id);
       });
 
       test('sets the status of the batch to sent', async () => {
@@ -1015,13 +1031,45 @@ experiment('modules/billing/services/batch-service', () => {
       });
 
       experiment('when the invoice is found and there are no errors', () => {
+        let licenceId;
+        let billingInvoiceId;
+
         beforeEach(async () => {
+          billingInvoiceId = uuid();
+          licenceId = uuid();
+
           newRepos.billingInvoices.findOne.resolves({
+            billingInvoiceId,
             invoiceAccountNumber: 'A12345678A',
             financialYearEnding: 2020,
             billingBatch: {
               externalId: batch.externalId
-            }
+            },
+            billingInvoiceLicences: [
+              {
+                billingInvoiceId,
+                billingInvoiceLicenceId: uuid(),
+                licenceId,
+                licence: {
+                  licenceRef: '123/321',
+                  licenceId,
+                  region: {
+                    regionId: uuid(),
+                    name: 'test',
+                    chargeRegionId: 'T',
+                    displayName: 'test'
+                  },
+                  regions: {
+                    historicalAreaCode: 'ABCD',
+                    regionalChargeArea: 'The Moon'
+                  },
+                  startDate: '2000-01-01',
+                  expiredDate: null,
+                  lapsedDate: null,
+                  revokedDate: null
+                }
+              }
+            ]
           });
           newRepos.billingTransactions.findByBatchId.resolves([]);
           await batchService.deleteBatchInvoice(batch, invoiceId);
@@ -1055,6 +1103,13 @@ experiment('modules/billing/services/batch-service', () => {
 
         test('deletes invoice from batch', async () => {
           expect(newRepos.billingInvoices.delete.calledWith(invoiceId)).to.be.true();
+        });
+
+        test('updates the include in supplementary billing status to reprocess where currently yes', async () => {
+          const [from, to, licenceIds] = licencesService.updateIncludeInSupplementaryBillingStatus.lastCall.args;
+          expect(from).to.equal('yes');
+          expect(to).to.equal('reprocess');
+          expect(licenceIds).to.equal([licenceId]);
         });
 
         test('sets status of batch to empty when there are no transactions', () => {

--- a/test/modules/billing/services/invoice-licences-service.js
+++ b/test/modules/billing/services/invoice-licences-service.js
@@ -38,6 +38,8 @@ experiment('modules/billing/services/invoice-licences-service', () => {
       licenceRef: '01/123'
     });
 
+    sandbox.stub(newRepos.licences, 'updateIncludeLicenceInSupplementaryBilling');
+
     sandbox.stub(batchService, 'setStatusToEmptyWhenNoTransactions').resolves();
   });
 
@@ -239,8 +241,11 @@ experiment('modules/billing/services/invoice-licences-service', () => {
     });
 
     experiment('when the invoice licence is found, and the batch status is "review"', () => {
+      let licenceId;
+
       beforeEach(async () => {
         newRepos.billingInvoiceLicences.findOne.resolves({
+          licenceId: licenceId = uuid(),
           billingInvoice: {
             billingBatch: {
               billingBatchId,
@@ -273,6 +278,13 @@ experiment('modules/billing/services/invoice-licences-service', () => {
       test('the batch status is set to empty if no transactions remain', async () => {
         const [batch] = batchService.setStatusToEmptyWhenNoTransactions.lastCall.args;
         expect(batch.id).to.equal(billingBatchId);
+      });
+
+      test('the licence includeInSupplementary billing status is updated', async () => {
+        const [id, statusFrom, statusTo] = newRepos.licences.updateIncludeLicenceInSupplementaryBilling.lastCall.args;
+        expect(id).to.equal(licenceId);
+        expect(statusFrom).to.equal('yes');
+        expect(statusTo).to.equal('reprocess');
       });
     });
   });


### PR DESCRIPTION
WATER-2728

Updates the water.licences table to use an enum rather than a flag for
include_in_supplementary_billing

Updates references to use the new enum value

Sets licence status when invoice is deleted from batch

If an invoice or invoice licence is deleted from a batch then set the
licence's include-in-supplementary billing status from 'yes' to
'reprocess'

Updates the licence's includeInSupplementaryBilling status when the
batch is ended, either through error or cancellation, or when the batch
is sent.