### PR TITLE
Fix: Chucks documents query to prevent large query string

### DIFF
--- a/src/modules/communications/controller.js
+++ b/src/modules/communications/controller.js
@@ -41,11 +41,7 @@ const formatEvent = evt => {
 };
 
 const getLicenceDocuments = async licenceNumbers => {
-  const documents = await crmDocumentConnector.findAll({
-    system_external_id: {
-      $in: licenceNumbers
-    }
-  });
+  const documents = await crmDocumentConnector.getDocumentsByLicenceNumbers(licenceNumbers);
 
   if (!documents.length) {
     throw Boom.notFound(`No document found for ${licenceNumbers.join()}`);

--- a/test/lib/connectors/crm/documents.js
+++ b/test/lib/connectors/crm/documents.js
@@ -13,6 +13,7 @@ experiment('lib/connectors/crm/documents', () => {
     sandbox.stub(serviceRequest, 'patch').resolves({});
     sandbox.stub(serviceRequest, 'delete').resolves({});
     sandbox.stub(documentsConnector, 'updateOne').resolves({});
+    sandbox.stub(documentsConnector, 'findAll').resolves();
   });
 
   afterEach(async () => {
@@ -61,6 +62,80 @@ experiment('lib/connectors/crm/documents', () => {
       const args = documentsConnector.updateOne.lastCall.args;
       expect(args[0]).to.equal('doc-id');
       expect(args[1].document_name).to.equal('name');
+    });
+  });
+
+  experiment('.getDocumentsByLicenceNumbers', () => {
+    experiment('for a single licence number', () => {
+      let result;
+
+      beforeEach(async () => {
+        documentsConnector.findAll.resolves([{
+          document_id: 'test-document-id',
+          system_external_id: 'test-licence-number'
+        }]);
+
+        result = await documentsConnector.getDocumentsByLicenceNumbers(['test-licence-number']);
+      });
+
+      test('returns the expected result', async () => {
+        expect(result.length).to.equal(1);
+        expect(result[0].document_id).to.equal('test-document-id');
+      });
+
+      test('creates the expected query filter', async () => {
+        const [filter] = documentsConnector.findAll.lastCall.args;
+        expect(filter).to.equal({
+          system_external_id: {
+            $in: ['test-licence-number']
+          }
+        });
+      });
+    });
+
+    experiment('for more than 20 licence numbers', () => {
+      let result;
+      let licenceNumbers;
+
+      beforeEach(async () => {
+        licenceNumbers = Array.from({ length: 21 }, (val, key) => {
+          return `licence-number-${key}`;
+        });
+
+        documentsConnector.findAll.onFirstCall().resolves([{
+          document_id: 'test-document-id-1',
+          system_external_id: 'test-licence-number'
+        }]);
+
+        documentsConnector.findAll.onSecondCall().resolves([{
+          document_id: 'test-document-id-2',
+          system_external_id: 'test-licence-number'
+        }]);
+
+        result = await documentsConnector.getDocumentsByLicenceNumbers(licenceNumbers);
+      });
+
+      test('returns the expected result', async () => {
+        expect(result.length).to.equal(2);
+        expect(result[0].document_id).to.equal('test-document-id-1');
+        expect(result[1].document_id).to.equal('test-document-id-2');
+      });
+
+      test('creates the expected query filters split over two calls', async () => {
+        const [firstFilter] = documentsConnector.findAll.firstCall.args;
+        expect(firstFilter).to.equal({
+          system_external_id: {
+            $in: licenceNumbers.slice(0, -1)
+          }
+        });
+
+        const [secondFilter] = documentsConnector.findAll.secondCall.args;
+        expect(secondFilter).to.equal({
+          system_external_id: {
+            $in: licenceNumbers.slice(-1)
+          }
+        });
+      });
     });
   });
 });

--- a/test/modules/communications/controller.js
+++ b/test/modules/communications/controller.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { expect } = require('@hapi/code');
 const {
   beforeEach,
@@ -69,7 +71,7 @@ experiment('getCommunication', () => {
   beforeEach(async () => {
     sandbox.stub(notificationsController.repository, 'find').resolves(notificationResult);
     sandbox.stub(eventsController.repository, 'find').resolves(eventResult);
-    sandbox.stub(crmDocumentConnector, 'findMany').resolves(crmResponses.singleResponse());
+    sandbox.stub(crmDocumentConnector, 'getDocumentsByLicenceNumbers').resolves(crmResponses.singleResponse().data);
 
     request = {
       params: {
@@ -115,7 +117,7 @@ experiment('getCommunication', () => {
   });
 
   test('returns a 404 if the licence document is not found', async () => {
-    crmDocumentConnector.findMany.resolves(crmResponses.notFound());
+    crmDocumentConnector.getDocumentsByLicenceNumbers.resolves(crmResponses.notFound());
 
     const response = await controller.getCommunication(request);
 


### PR DESCRIPTION
WATER-2788

For notifications sent to many licences there was an issue with the
generated querystring becoming too large.

This change chucks the queries into batches of 20 to prevent exceeding
the max querystring size