### PR TITLE
Fix: Updates a migration that won't run on dev server

### DIFF
--- a/migrations/sqls/20200529094058-add-batchId-to-billing-volumes-table-up.sql
+++ b/migrations/sqls/20200529094058-add-batchId-to-billing-volumes-table-up.sql
@@ -1,5 +1,9 @@
-/* Replace with your SQL commands */
 alter table water.billing_volumes
-  add column billing_batch_id uuid not null
-    constraint billing_volumes_billing_batch_id_fkey
+  add column if not exists billing_batch_id uuid not null;
+
+alter table water.billing_volumes drop constraint if exists billing_volumes_billing_batch_id_fkey;
+
+alter table water.billing_volumes
+  add constraint billing_volumes_billing_batch_id_fkey
+    foreign key(billing_batch_id)
     references water.billing_batches (billing_batch_id);


### PR DESCRIPTION
The column already exists on the development server for some reason so
this prevents the migrations from failing so future migrations can
execute.