### PR TITLE
Fix issue with migrations when volume column already exists

### DIFF
--- a/migrations/sqls/20200618093833-add-volume-to-billing-volumes-table-down.sql
+++ b/migrations/sqls/20200618093833-add-volume-to-billing-volumes-table-down.sql
@@ -1,2 +1,2 @@
 alter table water.billing_volumes
-  drop column volume;
+  drop column if exists volume;

--- a/migrations/sqls/20200618093833-add-volume-to-billing-volumes-table-up.sql
+++ b/migrations/sqls/20200618093833-add-volume-to-billing-volumes-table-up.sql
@@ -1,2 +1,2 @@
 alter table water.billing_volumes
-  add column volume numeric;
+  add column if not exists volume numeric;


### PR DESCRIPTION
Fixes an issue where migrations didn't run in some environments due to column already being present