### PR TITLE
Feat: Adds charge element maxAnnualQuantity to JSON

### DIFF
--- a/src/lib/models/charge-element.js
+++ b/src/lib/models/charge-element.js
@@ -157,7 +157,8 @@ class ChargeElement extends Model {
   toJSON () {
     return {
       ...super.toJSON(),
-      eiucSource: this.eiucSource
+      eiucSource: this.eiucSource,
+      maxAnnualQuantity: this.maxAnnualQuantity
     };
   }
 }

--- a/test/lib/models/charge-element.js
+++ b/test/lib/models/charge-element.js
@@ -219,6 +219,13 @@ experiment('lib/models/charge-element', () => {
       const result = chargeElement.toJSON();
       expect(result.eiucSource).to.equal('tidal');
     });
+
+    test('the maxAnnualQuantity property is included', async () => {
+      chargeElement.billableAnnualQuantity = 1;
+      chargeElement.authorisedAnnualQuantity = 2;
+      const result = chargeElement.toJSON();
+      expect(result.maxAnnualQuantity).to.equal(2);
+    });
   });
 
   experiment('description', () => {


### PR DESCRIPTION
WATER-2772

Exposes the charge element maxAnnualQuantity property to the JSON object
created when calling ChargeElement.toJSON