### PR TITLE
Feat/water 2799 - adds return requirements tables to water service

### DIFF
--- a/migrations/20200813133609-return-version-tables.js
+++ b/migrations/20200813133609-return-version-tables.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200813133609-return-version-tables-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200813133609-return-version-tables-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200813133609-return-version-tables-down.sql
+++ b/migrations/sqls/20200813133609-return-version-tables-down.sql
@@ -1,0 +1,11 @@
+/* Replace with your SQL commands */
+drop table water.return_requirement_purposes;
+
+drop table water.return_requirements;
+
+drop type returns_frequency;
+
+drop table water.return_versions;
+
+drop type return_version_status;
+

--- a/migrations/sqls/20200813133609-return-version-tables-up.sql
+++ b/migrations/sqls/20200813133609-return-version-tables-up.sql
@@ -15,7 +15,7 @@ create table water.return_versions (
 );
 
 /* Create return requirements table - these show the need to do an individual return each year */
-create type returns_frequency as enum('day', 'week', 'month', 'quarter', 'year');
+create type returns_frequency as enum('day', 'week', 'fortnight', 'month', 'quarter', 'year');
 
 create table water.return_requirements (
   return_requirement_id uuid primary key default public.gen_random_uuid(),
@@ -23,10 +23,11 @@ create table water.return_requirements (
   returns_frequency returns_frequency not null,
   is_summer boolean not null,
   is_upload boolean not null,
-  abstraction_period_start_day smallint not null,
-  abstraction_period_start_month smallint not null,
-  abstraction_period_end_day smallint not null,
-  abstraction_period_end_month smallint not null,
+  abstraction_period_start_day smallint,
+  abstraction_period_start_month smallint,
+  abstraction_period_end_day smallint,
+  abstraction_period_end_month smallint,
+  site_description varchar,
   description varchar,
   legacy_id integer,
   date_created timestamp not null,

--- a/migrations/sqls/20200813133609-return-version-tables-up.sql
+++ b/migrations/sqls/20200813133609-return-version-tables-up.sql
@@ -1,0 +1,53 @@
+/* Create return versions table */
+create type return_version_status as enum('draft', 'superseded', 'current');
+
+create table water.return_versions (
+  return_version_id uuid primary key default public.gen_random_uuid(),
+  licence_id uuid not null references licences(licence_id),
+  version_number integer not null,
+  start_date date not null,
+  end_date date,
+  status return_version_status not null,
+  date_created timestamp not null,
+  date_updated timestamp,
+  external_id varchar,
+  unique(external_id)
+);
+
+/* Create return requirements table - these show the need to do an individual return each year */
+create type returns_frequency as enum('day', 'week', 'month', 'quarter', 'year');
+
+create table water.return_requirements (
+  return_requirement_id uuid primary key default public.gen_random_uuid(),
+  return_version_id uuid not null references return_versions(return_version_id),
+  returns_frequency returns_frequency not null,
+  is_summer boolean not null,
+  is_upload boolean not null,
+  abstraction_period_start_day smallint not null,
+  abstraction_period_start_month smallint not null,
+  abstraction_period_end_day smallint not null,
+  abstraction_period_end_month smallint not null,
+  description varchar,
+  legacy_id integer,
+  date_created timestamp not null,
+  date_updated timestamp,
+  external_id varchar,
+  unique(external_id)
+);
+
+
+create table water.return_requirement_purposes (
+  return_requirement_purpose_id uuid primary key default public.gen_random_uuid(),
+  return_requirement_id uuid not null references return_requirements(return_requirement_id),
+  purpose_primary_id uuid not null references purposes_primary(purpose_primary_id),
+  purpose_secondary_id uuid not null references purposes_secondary(purpose_secondary_id),
+  purpose_use_id uuid not null references purposes_uses(purpose_use_id),
+  purpose_alias varchar,
+  date_created timestamp not null,
+  date_updated timestamp,
+  external_id varchar,
+  unique(external_id)
+);
+
+
+


### PR DESCRIPTION
Adds return requirement tables to the water service.

This is so that two-part tariff billing can take into account which returns seasons are needed for a particular licence.