### PR TITLE
Add endpoints to patch and delete charge version workflows

### DIFF
--- a/src/lib/connectors/repos/charge-version-workflows.js
+++ b/src/lib/connectors/repos/charge-version-workflows.js
@@ -16,6 +16,14 @@ const findAll = () =>
 const create = data =>
   helpers.create(ChargeVersionWorkflow, data);
 
+const update = (id, changes) =>
+  helpers.update(ChargeVersionWorkflow, 'chargeVersionWorkflowId', id, changes);
+
+const deleteOne = id =>
+  helpers.deleteOne(ChargeVersionWorkflow, 'chargeVersionWorkflowId', id);
+
 exports.findOne = findOne;
 exports.findAll = findAll;
 exports.create = create;
+exports.update = update;
+exports.deleteOne = deleteOne;

--- a/src/lib/connectors/repos/lib/helpers.js
+++ b/src/lib/connectors/repos/lib/helpers.js
@@ -25,6 +25,13 @@ exports.create = async (bookShelfModel, data) => {
   return model.toJSON();
 };
 
+exports.update = async (bookshelfModel, idKey, id, changes) => {
+  const result = await bookshelfModel
+    .forge({ [idKey]: id })
+    .save(changes);
+  return result.toJSON();
+};
+
 exports.deleteOne = async (bookShelfModel, idKey, id) => {
   return bookShelfModel
     .forge({ [idKey]: id })

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
+const mapErrorResponse = require('./map-error-response');
 
 /**
  * Gets an entity via a service layer function, and either returns it if present,
@@ -29,5 +30,22 @@ const getEntities = async (id, serviceFunc, rowMapper) => {
   return { data: rowMapper ? entities.map(rowMapper) : entities };
 };
 
+/**
+ * Deletes an entity via a service function
+ *
+ * @param {Function} serviceFunc - the service layer function that will delete the entity
+ * @param {Object} h - hapi response toolkit
+ * @param {String} id - id
+ */
+const deleteEntity = async (serviceFunc, h, ...args) => {
+  try {
+    await serviceFunc(...args);
+    return h.response().code(204);
+  } catch (err) {
+    return mapErrorResponse(err);
+  }
+};
+
 exports.getEntities = getEntities;
 exports.getEntity = getEntity;
+exports.deleteEntity = deleteEntity;

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -11,6 +11,7 @@ const invoiceLicenceService = require('./services/invoice-licences-service');
 const batchService = require('./services/batch-service');
 const { createBatchEvent } = require('./lib/batch-event');
 
+const controller = require('../../lib/controller');
 const mapErrorResponse = require('../../lib/map-error-response');
 const mappers = require('./mappers');
 
@@ -118,6 +119,14 @@ const deleteBatchInvoice = async (request, h) => {
   }
 };
 
+const deleteBatch = (request, h) => controller.deleteEntity(
+  batchService.deleteBatch,
+  h,
+  request.pre.batch,
+  request.defra.internalCallingUser
+);
+
+/*
 const deleteBatch = async (request, h) => {
   const { batch } = request.pre;
   const { internalCallingUser } = request.defra;
@@ -129,6 +138,7 @@ const deleteBatch = async (request, h) => {
   await batchService.deleteBatch(batch, internalCallingUser);
   return h.response().code(204);
 };
+*/
 
 const postApproveBatch = async (request, h) => {
   const { batch } = request.pre;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -66,8 +66,8 @@ const saveEvent = (type, status, user, batch) => {
 };
 
 const deleteBatch = async (batch, internalCallingUser) => {
-  if (batch.statusIsOneOf(Batch.BATCH_STATUS.sent)) {
-    throw new BatchStatusError(`Sent batch ${batch.id} cannot be deleted`);
+  if (!batch.canBeDeleted()) {
+    throw new BatchStatusError(`Batch ${batch.id} cannot be deleted - status is ${batch.status}`);
   }
 
   try {

--- a/src/modules/charge-versions/controllers/charge-version-workflow.js
+++ b/src/modules/charge-versions/controllers/charge-version-workflow.js
@@ -66,15 +66,8 @@ const patchChargeVersionWorkflow = async (request, h) => {
   }
 };
 
-const deleteChargeVersionWorkflow = async (request, h) => {
-  const { chargeVersionWorkflowId } = request.params;
-  try {
-    await chargeVersionsWorkflowService.delete(chargeVersionWorkflowId);
-    return h.response().code(204);
-  } catch (err) {
-    return mapErrorResponse(err);
-  }
-};
+const deleteChargeVersionWorkflow = (request, h) =>
+  controller.deleteEntity(chargeVersionsWorkflowService.delete, h, request.params.chargeVersionWorkflowId);
 
 exports.getChargeVersionWorkflows = getChargeVersionWorkflows;
 exports.getChargeVersionWorkflow = getChargeVersionWorkflow;

--- a/src/modules/charge-versions/controllers/pre-handlers.js
+++ b/src/modules/charge-versions/controllers/pre-handlers.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const chargeVersionMapper = require('../../../lib/mappers/charge-version');
+const userMapper = require('../../../lib/mappers/user');
+
+const Boom = require('@hapi/boom');
+const { logger } = require('../../../logger');
+
+/**
+ * Maps a pojo representation of a charge version in the request payload
+ * to a ChargeVersion service model
+ * If mapping fails, a Boom badData error is returned
+ * @param {Object} request.payload.chargeVersion
+ * @param {Object} h - hapi response toolkit
+ * @return {ChargeVersion} - if mapped
+ */
+const mapChargeVersion = (request, h) => {
+  const { chargeVersion } = request.payload;
+
+  if (chargeVersion) {
+    try {
+      return chargeVersionMapper.pojoToModel(chargeVersion);
+    } catch (err) {
+      logger.error('Error mapping charge version', err);
+      return Boom.badData('Invalid charge version data');
+    }
+  }
+
+  return h.continue;
+};
+
+/**
+ * Maps a pojo representation of a user in the request payload
+ * to a User service model
+ * If mapping fails, a Boom badData error is returned
+ * @param {Object} request.defra.internalCallingUser
+ * @param {Object} h - hapi response toolkit
+ * @return {User} - if mapped
+ */
+const mapInternalCallingUser = (request, h) => {
+  const { internalCallingUser } = request.defra;
+  try {
+    return userMapper.pojoToModel(internalCallingUser);
+  } catch (err) {
+    logger.error('Error mapping user', err);
+    return Boom.badData('Invalid user data');
+  };
+};
+
+exports.mapChargeVersion = mapChargeVersion;
+exports.mapInternalCallingUser = mapInternalCallingUser;

--- a/src/modules/charge-versions/controllers/pre-handlers.js
+++ b/src/modules/charge-versions/controllers/pre-handlers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { get } = require('lodash');
+
 const chargeVersionMapper = require('../../../lib/mappers/charge-version');
 const userMapper = require('../../../lib/mappers/user');
 
@@ -38,7 +40,7 @@ const mapChargeVersion = (request, h) => {
  * @return {User} - if mapped
  */
 const mapInternalCallingUser = (request, h) => {
-  const { internalCallingUser } = request.defra;
+  const internalCallingUser = get(request, 'defra.internalCallingUser', null);
   try {
     return userMapper.pojoToModel(internalCallingUser);
   } catch (err) {

--- a/src/modules/charge-versions/routes/charge-version-workflows.js
+++ b/src/modules/charge-versions/routes/charge-version-workflows.js
@@ -4,6 +4,7 @@ const { ROLES: { chargeVersionWorkflowEditor, chargeVersionWorkflowApprover } } 
 
 const controller = require('../controllers/charge-version-workflow');
 const Joi = require('joi');
+const preHandlers = require('../controllers/pre-handlers');
 
 const headers = async values => {
   Joi.assert(values['defra-internal-user-id'], Joi.number().integer().required());
@@ -59,6 +60,48 @@ module.exports = {
           licenceId: Joi.string().guid().required(),
           chargeVersion: Joi.object().required()
         }
+      },
+      pre: [
+        { method: preHandlers.mapChargeVersion, assign: 'chargeVersion' },
+        { method: preHandlers.mapInternalCallingUser, assign: 'user' }
+      ]
+    }
+  },
+
+  patchChargeVersionWorkflow: {
+    method: 'PATCH',
+    path: '/water/1.0/charge-version-workflows/{chargeVersionWorkflowId}',
+    handler: controller.patchChargeVersionWorkflow,
+    options: {
+      description: 'Updates an existing charge version workflow record',
+      auth: {
+        scope: [chargeVersionWorkflowEditor, chargeVersionWorkflowApprover]
+      },
+      validate: {
+        headers,
+        payload: {
+          status: Joi.string(),
+          chargeVersion: Joi.object(),
+          approverComments: Joi.string()
+        }
+      },
+      pre: [
+        { method: preHandlers.mapChargeVersion, assign: 'chargeVersion' }
+      ]
+    }
+  },
+
+  deleteChargeVersionWorkflow: {
+    method: 'DELETE',
+    path: '/water/1.0/charge-version-workflows/{chargeVersionWorkflowId}',
+    handler: controller.deleteChargeVersionWorkflow,
+    options: {
+      description: 'Deletes an existing charge version workflow record',
+      auth: {
+        scope: [chargeVersionWorkflowEditor, chargeVersionWorkflowApprover]
+      },
+      validate: {
+        headers
       }
     }
   }

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -135,6 +135,11 @@ const update = async (chargeVersionWorkflowId, changes) => {
   return chargeVersionWorkflowMapper.dbToModel(data);
 };
 
+/**
+ * Deletes a charge version workflow record by ID
+ * @param {String} chargeVersionWorkflowId
+ * @return {Promise}
+ */
 const deleteById = async chargeVersionWorkflowId => {
   try {
     await chargeVersionWorkflowsRepo.deleteOne(chargeVersionWorkflowId);

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -20,6 +20,9 @@ const ChargeVersion = require('../../../lib/models/charge-version');
 const User = require('../../../lib/models/user');
 const Licence = require('../../../lib/models/licence');
 const Role = require('../../../lib/models/role');
+const { NotFoundError, InvalidEntityError } = require('../../../lib/errors');
+const { logger } = require('../../../logger');
+const chargeVersionWorkflows = require('../routes/charge-version-workflows');
 
 /**
  * Gets all charge version workflows from the DB
@@ -71,6 +74,21 @@ const getByIdWithLicenceHolder = async id => {
 };
 
 /**
+ * Updates the properties on the model - if any errors,
+ * an InvalidEntityError is thrown
+ * @param {ChargeVersionWorkflow} chargeVersionWorkflow
+ * @param {Object} changes - a hash of properties to update
+ */
+const setOrThrowInvalidEntityError = (chargeVersionWorkflow, changes) => {
+  try {
+    return chargeVersionWorkflow.fromHash(changes);
+  } catch (err) {
+    logger.error(err);
+    throw new InvalidEntityError('Invalid data for charge version worklow');
+  }
+};
+
+/**
  * Create a new charge version workflow record
  * @param {Licence} licence
  * @param {ChargeVersion} chargeVersion
@@ -85,7 +103,7 @@ const create = async (licence, chargeVersion, user) => {
   // Map all data to ChargeVersionWorkflow model
   const chargeVersionWorkflow = new ChargeVersionWorkflow();
 
-  chargeVersionWorkflow.fromHash({
+  setOrThrowInvalidEntityError(chargeVersionWorkflow, {
     createdBy: user,
     licence: licence,
     chargeVersion,
@@ -97,9 +115,40 @@ const create = async (licence, chargeVersion, user) => {
   return chargeVersionWorkflowMapper.dbToModel(updated);
 };
 
+/**
+ * Updates a ChargeVersionWorkflow model
+ * @param {String} chargeVersionWorkflowId
+ * @param {Object} changes
+ * @return {Promise<ChargeVersionWorkflow} - updated service model
+ */
+const update = async (chargeVersionWorkflowId, changes) => {
+  // Load existing model
+  const model = await getById(chargeVersionWorkflowId);
+  if (!model) {
+    throw new NotFoundError(`Charge version workflow ${chargeVersionWorkflowId} not found`);
+  }
+
+  setOrThrowInvalidEntityError(model, changes);
+
+  // Persist
+  const dbRow = chargeVersionWorkflowMapper.modelToDb(model);
+  const data = await chargeVersionWorkflowsRepo.update(chargeVersionWorkflowId, dbRow);
+  return chargeVersionWorkflowMapper.dbToModel(data);
+};
+
+const deleteById = async chargeVersionWorkflowId => {
+  try {
+    await chargeVersionWorkflowsRepo.deleteOne(chargeVersionWorkflowId);
+  } catch (err) {
+    throw new NotFoundError(`Charge version workflow ${chargeVersionWorkflowId} not found`);
+  }
+};
+
 exports.getAll = getAll;
 exports.getAllWithLicenceHolder = getAllWithLicenceHolder;
 exports.getById = getById;
 exports.getByIdWithLicenceHolder = getByIdWithLicenceHolder;
 exports.create = create;
 exports.getLicenceHolderRole = getLicenceHolderRole;
+exports.update = update;
+exports.delete = deleteById;

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -83,7 +83,7 @@ const setOrThrowInvalidEntityError = (chargeVersionWorkflow, changes) => {
     return chargeVersionWorkflow.fromHash(changes);
   } catch (err) {
     logger.error(err);
-    throw new InvalidEntityError('Invalid data for charge version worklow');
+    throw new InvalidEntityError(`Invalid data for charge version worklow ${chargeVersionWorkflow.id}`);
   }
 };
 

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -22,7 +22,6 @@ const Licence = require('../../../lib/models/licence');
 const Role = require('../../../lib/models/role');
 const { NotFoundError, InvalidEntityError } = require('../../../lib/errors');
 const { logger } = require('../../../logger');
-const chargeVersionWorkflows = require('../routes/charge-version-workflows');
 
 /**
  * Gets all charge version workflows from the DB

--- a/test/lib/connectors/repos/charge-version-workflows.js
+++ b/test/lib/connectors/repos/charge-version-workflows.js
@@ -20,6 +20,8 @@ experiment('lib/connectors/repos/charge-version-workflows', () => {
     sandbox.stub(helpers, 'findOne');
     sandbox.stub(helpers, 'findMany');
     sandbox.stub(helpers, 'create');
+    sandbox.stub(helpers, 'update');
+    sandbox.stub(helpers, 'deleteOne');
   });
 
   afterEach(async () => {
@@ -68,6 +70,32 @@ experiment('lib/connectors/repos/charge-version-workflows', () => {
       const [model, data] = helpers.create.lastCall.args;
       expect(model).to.equal(ChargeVersionWorkflow);
       expect(data).to.equal({ foo: 'bar' });
+    });
+  });
+
+  experiment('.update', () => {
+    beforeEach(async () => {
+      await chargeVersionWorkflowsRepo.update('test-id', {
+        foo: 'bar'
+      });
+    });
+
+    test('delegates to the update helper', async () => {
+      expect(helpers.update.calledWith(
+        ChargeVersionWorkflow, 'chargeVersionWorkflowId', 'test-id', { foo: 'bar' }
+      )).to.be.true();
+    });
+  });
+
+  experiment('.deleteOne', () => {
+    beforeEach(async () => {
+      await chargeVersionWorkflowsRepo.deleteOne('test-id');
+    });
+
+    test('delegates to the delete helper', async () => {
+      expect(helpers.deleteOne.calledWith(
+        ChargeVersionWorkflow, 'chargeVersionWorkflowId', 'test-id'
+      )).to.be.true();
     });
   });
 });

--- a/test/lib/connectors/repos/lib/helpers.js
+++ b/test/lib/connectors/repos/lib/helpers.js
@@ -220,13 +220,9 @@ experiment('lib/connectors/repos/lib/helpers', () => {
   });
 
   experiment('.deleteOne', () => {
-    let result;
     let model;
 
     beforeEach(async () => {
-      result = {
-        toJSON: sandbox.spy()
-      };
       model = {
         forge: sandbox.stub().returnsThis(),
         destroy: sandbox.stub()

--- a/test/lib/connectors/repos/lib/helpers.js
+++ b/test/lib/connectors/repos/lib/helpers.js
@@ -181,4 +181,69 @@ experiment('lib/connectors/repos/lib/helpers', () => {
       expect(destroy).to.equal({ require: false });
     });
   });
+
+  experiment('.update', () => {
+    let result;
+    let model;
+
+    beforeEach(async () => {
+      result = {
+        toJSON: sandbox.spy()
+      };
+      model = {
+        forge: sandbox.stub().returnsThis(),
+        save: sandbox.stub().resolves(result)
+      };
+
+      await helpers.update(model, 'id', 'test-id', {
+        day: 'Friday'
+      });
+    });
+
+    test('calls forge on the model with the correct id', async () => {
+      const [data] = model.forge.lastCall.args;
+      expect(data).to.equal({
+        id: 'test-id'
+      });
+    });
+
+    test('calls save on the model with the correct data', async () => {
+      const [data] = model.save.lastCall.args;
+      expect(data).to.equal({
+        day: 'Friday'
+      });
+    });
+
+    test('returns the entity as JSON', async () => {
+      expect(result.toJSON.called).to.equal(true);
+    });
+  });
+
+  experiment('.deleteOne', () => {
+    let result;
+    let model;
+
+    beforeEach(async () => {
+      result = {
+        toJSON: sandbox.spy()
+      };
+      model = {
+        forge: sandbox.stub().returnsThis(),
+        destroy: sandbox.stub()
+      };
+
+      await helpers.deleteOne(model, 'id', 'test-id');
+    });
+
+    test('calls forge on the model with the correct id', async () => {
+      const [data] = model.forge.lastCall.args;
+      expect(data).to.equal({
+        id: 'test-id'
+      });
+    });
+
+    test('calls destroy on the model', async () => {
+      expect(model.destroy.called).to.be.true();
+    });
+  });
 });

--- a/test/modules/billing/controller.js
+++ b/test/modules/billing/controller.js
@@ -495,77 +495,15 @@ experiment('modules/billing/controller', () => {
       };
     });
 
-    experiment('for a batch that is processing', () => {
-      test('a 422 is returned because the batch cannot be deleted yet', async () => {
-        batch.status = Batch.BATCH_STATUS.processing;
-
-        await controller.deleteBatch(request, h);
-
-        expect(batchService.deleteBatch.called).to.equal(false);
-        expect(hapiResponseStub.code.calledWith(422)).to.be.true();
-
-        const [message] = h.response.lastCall.args;
-
-        expect(message).to.equal('Cannot delete batch when status is processing');
-      });
-    });
-
-    experiment('for a batch that is sent', () => {
-      test('a 422 is returned because the batch cannot be deleted', async () => {
-        batch.status = Batch.BATCH_STATUS.sent;
-
-        await controller.deleteBatch(request, h);
-
-        expect(batchService.deleteBatch.called).to.equal(false);
-        expect(hapiResponseStub.code.calledWith(422)).to.be.true();
-
-        const [message] = h.response.lastCall.args;
-
-        expect(message).to.equal('Cannot delete batch when status is sent');
-      });
-    });
-
-    experiment('for a batch that is in review', () => {
+    experiment('when the deletion succeeds', () => {
       test('deletes the batch via the batch service', async () => {
-        batch.status = Batch.BATCH_STATUS.review;
+        // batch.status = Batch.BATCH_STATUS.review;
         await controller.deleteBatch(request, h);
         expect(batchService.deleteBatch.calledWith(batch, internalCallingUser)).to.be.true();
       });
 
       test('returns a 204 response', async () => {
         batch.status = Batch.BATCH_STATUS.review;
-        await controller.deleteBatch(request, h);
-
-        const [code] = hapiResponseStub.code.lastCall.args;
-        expect(code).to.equal(204);
-      });
-    });
-
-    experiment('for a batch that is ready', () => {
-      test('deletes the batch via the batch service', async () => {
-        batch.status = Batch.BATCH_STATUS.ready;
-        await controller.deleteBatch(request, h);
-        expect(batchService.deleteBatch.calledWith(batch, internalCallingUser)).to.be.true();
-      });
-
-      test('returns a 204 response', async () => {
-        batch.status = Batch.BATCH_STATUS.ready;
-        await controller.deleteBatch(request, h);
-
-        const [code] = hapiResponseStub.code.lastCall.args;
-        expect(code).to.equal(204);
-      });
-    });
-
-    experiment('for a batch that has errored', () => {
-      test('deletes the batch via the batch service', async () => {
-        batch.status = Batch.BATCH_STATUS.error;
-        await controller.deleteBatch(request, h);
-        expect(batchService.deleteBatch.calledWith(batch, internalCallingUser)).to.be.true();
-      });
-
-      test('returns a 204 response', async () => {
-        batch.status = Batch.BATCH_STATUS.error;
         await controller.deleteBatch(request, h);
 
         const [code] = hapiResponseStub.code.lastCall.args;

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -309,7 +309,7 @@ experiment('modules/billing/services/batch-service', () => {
         const func = () => batchService.deleteBatch(batch, internalCallingUser);
         const err = await expect(func()).to.reject();
         expect(err instanceof BatchStatusError);
-        expect(err.message).to.equal(`Sent batch ${batch.id} cannot be deleted`);
+        expect(err.message).to.equal(`Batch ${batch.id} cannot be deleted - status is sent`);
       });
     });
 

--- a/test/modules/charge-versions/controllers/charge-version-workflows.js
+++ b/test/modules/charge-versions/controllers/charge-version-workflows.js
@@ -169,6 +169,30 @@ experiment('modules/charge-versions/controllers/charge-version-workflows', () =>
       });
     });
 
+    experiment('when there are no errors, and no charge version in payload', () => {
+      beforeEach(async () => {
+        delete request.pre.chargeVersion;
+        chargeVersionWorkflowService.update.resolves(
+          new ChargeVersionWorkflow()
+        );
+        response = await cvWorkflowsController.patchChargeVersionWorkflow(request);
+      });
+
+      test('the service update() method is called with the correct ID and params', async () => {
+        expect(chargeVersionWorkflowService.update.calledWith(
+          request.params.chargeVersionWorkflowId,
+          {
+            status: 'draft',
+            approverComments: 'Pull your socks up'
+          }
+        )).to.be.true();
+      });
+
+      test('resolves with the ChargeVersionWorkflow model', async () => {
+        expect(response).to.be.an.instanceof(ChargeVersionWorkflow);
+      });
+    });
+
     experiment('when the record is not found', () => {
       beforeEach(async () => {
         chargeVersionWorkflowService.update.rejects(

--- a/test/modules/charge-versions/controllers/charge-version-workflows.js
+++ b/test/modules/charge-versions/controllers/charge-version-workflows.js
@@ -84,6 +84,10 @@ experiment('modules/charge-versions/controllers/charge-version-workflows', () =>
               startDate: '2020-09-01'
             }
           }
+        },
+        pre: {
+          chargeVersion: new ChargeVersion(uuid()),
+          user: new User(123, 'mail@example.com')
         }
       };
 
@@ -103,32 +107,6 @@ experiment('modules/charge-versions/controllers/charge-version-workflows', () =>
       });
     });
 
-    experiment('when the interal user cannot be mapped', () => {
-      beforeEach(async () => {
-        request.defra.internalCallingUser.email = 'NotAnEmailAddress';
-        result = await cvWorkflowsController.postChargeVersionWorkflow(request);
-      });
-
-      test('a 422 response is generated', async () => {
-        expect(result.isBoom).to.be.true();
-        expect(result.output.statusCode).to.equal(422);
-        expect(result.message).to.equal('Invalid user data');
-      });
-    });
-
-    experiment('when the charge version cannot be mapped', () => {
-      beforeEach(async () => {
-        request.payload.chargeVersion.dateRange.startDate = 'not-a-valid-date';
-        result = await cvWorkflowsController.postChargeVersionWorkflow(request);
-      });
-
-      test('a 422 response is generated', async () => {
-        expect(result.isBoom).to.be.true();
-        expect(result.output.statusCode).to.equal(422);
-        expect(result.message).to.equal('Invalid charge version data');
-      });
-    });
-
     experiment('when all submitted data is valid', async () => {
       beforeEach(async () => {
         await cvWorkflowsController.postChargeVersionWorkflow(request);
@@ -137,8 +115,8 @@ experiment('modules/charge-versions/controllers/charge-version-workflows', () =>
       test('the charge version workflow service creates the record', async () => {
         const [licence, chargeVersion, user] = chargeVersionWorkflowService.create.lastCall.args;
         expect(licence).to.be.an.instanceof(Licence);
-        expect(chargeVersion).to.be.an.instanceof(ChargeVersion);
-        expect(user).to.be.an.instanceof(User);
+        expect(chargeVersion).to.equal(request.pre.chargeVersion);
+        expect(user).to.be.equal(request.pre.user);
       });
     });
   });

--- a/test/modules/charge-versions/routes/charge-version-workflows.js
+++ b/test/modules/charge-versions/routes/charge-version-workflows.js
@@ -191,6 +191,15 @@ experiment('modules/charge-versions/routes/charge-version-workflows', () => {
       expect(response.statusCode).to.equal(200);
     });
 
+    test('http 422 unprocessable entity when the payload cannot be mapped', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      request.payload.chargeVersion = {
+        status: 'not-a-valid-status'
+      };
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(422);
+    });
+
     test('http 400 bad request when the defra-internal-user-id is invalid', async () => {
       request.auth.credentials.scope = [chargeVersionWorkflowApprover];
       request.headers['defra-internal-user-id'] = 'invalid';

--- a/test/modules/charge-versions/routes/charge-version-workflows.js
+++ b/test/modules/charge-versions/routes/charge-version-workflows.js
@@ -111,7 +111,11 @@ experiment('modules/charge-versions/routes/charge-version-workflows', () => {
       request = makePost('/water/1.0/charge-version-workflows');
       request.payload = {
         licenceId: uuid(),
-        chargeVersion: {}
+        chargeVersion: {
+          dateRange: {
+            startDate: '2019-01-01'
+          }
+        }
       };
     });
 

--- a/test/modules/charge-versions/routes/charge-version-workflows.js
+++ b/test/modules/charge-versions/routes/charge-version-workflows.js
@@ -30,6 +30,8 @@ const makeRequest = (method, url) => ({
 
 const makeGet = url => makeRequest('get', url);
 const makePost = url => makeRequest('post', url);
+const makePatch = url => makeRequest('patch', url);
+const makeDelete = url => makeRequest('delete', url);
 
 experiment('modules/charge-versions/routes/charge-version-workflows', () => {
   let server;
@@ -153,6 +155,94 @@ experiment('modules/charge-versions/routes/charge-version-workflows', () => {
     test('http 400 bad request when the charge version data is not an object', async () => {
       request.auth.credentials.scope = [chargeVersionWorkflowApprover];
       request.payload.chargeVersion = 'not-an-object';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  experiment('.patchChargeVersionWorkflow', () => {
+    let request;
+
+    beforeEach(async () => {
+      server = await testHelpers.createServerForRoute(routes.patchChargeVersionWorkflow, true);
+
+      id = uuid();
+      request = makePatch(`/water/1.0/charge-version-workflows/${id}`);
+      request.payload = {
+        status: 'draft',
+        approverComments: 'Good work'
+      };
+    });
+
+    test('http 403 error when user has insufficient scope', async () => {
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(403);
+    });
+
+    test('http 200 OK when user has workflow editor scope', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowEditor];
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('http 200 OK when user has workflow approver scope', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('http 400 bad request when the defra-internal-user-id is invalid', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      request.headers['defra-internal-user-id'] = 'invalid';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('http 400 bad request when the licence ID is invalid', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      request.payload.licenceId = 'not-a-guid';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('http 400 bad request when the charge version data is not an object', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      request.payload.chargeVersion = 'not-an-object';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  experiment('.deleteChargeVersionWorkflow', () => {
+    let request;
+
+    beforeEach(async () => {
+      server = await testHelpers.createServerForRoute(routes.deleteChargeVersionWorkflow, true);
+
+      id = uuid();
+      request = makeDelete(`/water/1.0/charge-version-workflows/${id}`);
+    });
+
+    test('http 403 error when user has insufficient scope', async () => {
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(403);
+    });
+
+    test('http 200 OK when user has workflow editor scope', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowEditor];
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('http 200 OK when user has workflow approver scope', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('http 400 bad request when the defra-internal-user-id is invalid', async () => {
+      request.auth.credentials.scope = [chargeVersionWorkflowApprover];
+      request.headers['defra-internal-user-id'] = 'invalid';
       const response = await server.inject(request);
       expect(response.statusCode).to.equal(400);
     });


### PR DESCRIPTION
WATER-2818

Adds further endpoints to charge version workflows to:
* patch an existing record
* delete an existing record.

The endpoint to POST /water/1.0/charge-versions/create-from-workflow/{chargeVersionWorkflowId} 
will be submitted in a separate PR