### PR TITLE
Added proxy routes to relay information from the CRM endpoints

### DIFF
--- a/src/lib/connectors/crm-v2/companies.js
+++ b/src/lib/connectors/crm-v2/companies.js
@@ -67,6 +67,15 @@ const getCompanyContacts = companyId => {
   return serviceRequest.get(getUri(companyId, 'contacts'));
 };
 
+/**
+ * Fetches company invoice accounts from crm, from a company ID
+ * @param {String} companyId
+ */
+const getCompanyInvoiceAccountsByCompanyId = async (companyId) => {
+  const companyInvoiceAccounts = await serviceRequest.get(urlJoin(config.services.crm_v2, `companies/${companyId}/invoice-accounts`));
+  return companyInvoiceAccounts;
+};
+
 exports.createCompany = createCompany;
 exports.getCompany = getCompany;
 exports.deleteCompany = deleteCompany;
@@ -76,3 +85,4 @@ exports.deleteCompanyAddress = deleteCompanyAddress;
 exports.createCompanyContact = createCompanyContact;
 exports.deleteCompanyContact = deleteCompanyContact;
 exports.getCompanyContacts = getCompanyContacts;
+exports.getCompanyInvoiceAccountsByCompanyId = getCompanyInvoiceAccountsByCompanyId;

--- a/src/lib/connectors/crm-v2/documents.js
+++ b/src/lib/connectors/crm-v2/documents.js
@@ -2,12 +2,17 @@
 
 const urlJoin = require('url-join');
 const Joi = require('joi');
+const moment = require('moment');
 
 const { serviceRequest } = require('@envage/water-abstraction-helpers');
 const config = require('../../../../config');
 
 const VALID_LICENCE_NUMBER = Joi.string().required().example('01/123/R01');
 const VALID_GUID = Joi.string().guid().required();
+
+const getDocumentUrl = (...tail) => {
+  return urlJoin(config.services.crm_v2, 'document', ...tail);
+};
 
 const getDocumentsUrl = (...tail) => {
   return urlJoin(config.services.crm_v2, 'documents', ...tail);
@@ -48,6 +53,14 @@ const createDocumentRole = async (documentId, documentRole) => {
   return serviceRequest.post(url, { body: documentRole });
 };
 
+const getDocumentByRefAndDate = async (regime, documentType, documentRef, date) => {
+  return serviceRequest.get(getDocumentUrl('search'), {
+    qs: {
+      regime, documentType, documentRef, date: moment(date).format('YYYY-MM-DD')
+    }
+  });
+};
+
 /**
  * Get a single document role for the requested ID
  * @param {String} licenceNumber
@@ -61,3 +74,4 @@ exports.createDocumentRole = createDocumentRole;
 exports.getDocument = getDocument;
 exports.getDocumentRole = getDocumentRole;
 exports.getDocuments = getDocuments;
+exports.getDocumentByRefAndDate = getDocumentByRefAndDate;

--- a/src/lib/services/companies-service.js
+++ b/src/lib/services/companies-service.js
@@ -13,6 +13,10 @@ const getCompanyAddresses = async companyId => {
   return companyAddresses.map(mappers.companyAddress.crmToModel);
 };
 
+const getInvoiceAccountsByCompanyId = async companyId => {
+  return companiesConnector.getCompanyInvoiceAccountsByCompanyId(companyId);
+};
+
 const createCompany = async companyModel => {
   const company = await companiesConnector.createCompany(mappers.company.modelToCrm(companyModel));
   return mappers.company.crmToModel(company);
@@ -53,3 +57,4 @@ exports.getCompanyModel = getCompanyModel;
 exports.deleteCompany = deleteCompany;
 exports.deleteCompanyAddress = deleteCompanyAddress;
 exports.deleteCompanyContact = deleteCompanyContact;
+exports.getInvoiceAccountsByCompanyId = getInvoiceAccountsByCompanyId;

--- a/src/lib/services/invoice-accounts-service.js
+++ b/src/lib/services/invoice-accounts-service.js
@@ -176,9 +176,14 @@ const isNewEntity = entity => {
   return values.length > 0 && values.some(value => !isEmpty(value));
 };
 
+const getCompanyInvoiceAccounts = async companyId => {
+  return companiesService.getInvoiceAccountsByCompanyId(companyId);
+};
+
 exports.getByInvoiceAccountIds = getByInvoiceAccountIds;
 exports.getByInvoiceAccountId = getByInvoiceAccountId;
 exports.deleteInvoiceAccount = deleteInvoiceAccount;
 exports.getInvoiceAccount = getInvoiceAccount;
 exports.persist = persist;
 exports._isNewEntity = isNewEntity;
+exports.getCompanyInvoiceAccounts = getCompanyInvoiceAccounts;

--- a/src/modules/companies/controller.js
+++ b/src/modules/companies/controller.js
@@ -91,10 +91,19 @@ const createCompanyInvoiceAccount = async (request, h) => {
 
 const getCompanyContacts = async (request) => {
   const { companyId } = request.params;
-
   try {
     const companyContacts = await companyContactsService.getCompanyContacts(companyId);
     return envelope(companyContacts);
+  } catch (err) {
+    return mapErrorResponse(err);
+  }
+};
+
+const getCompanyInvoiceAccounts = async (request, h) => {
+  const companyId = request.params.companyId;
+  try {
+    const invoiceAccounts = await invoiceAccountsService.getCompanyInvoiceAccounts(companyId);
+    return h.response(invoiceAccounts).code(201);
   } catch (err) {
     return mapErrorResponse(err);
   }
@@ -105,3 +114,4 @@ exports.getCompany = getCompany;
 exports.getCompanyAddresses = getCompanyAddresses;
 exports.createCompanyInvoiceAccount = createCompanyInvoiceAccount;
 exports.getCompanyContacts = getCompanyContacts;
+exports.getCompanyInvoiceAccounts = getCompanyInvoiceAccounts;

--- a/src/modules/companies/routes.js
+++ b/src/modules/companies/routes.js
@@ -86,6 +86,20 @@ module.exports = {
     }
   },
 
+  getCompanyInvoiceAccounts: {
+    path: '/water/1.0/companies/{companyId}/invoice-accounts',
+    method: 'GET',
+    handler: controller.getCompanyInvoiceAccounts,
+    config: {
+      description: 'Gets the invoice accounts for the specified company',
+      validate: {
+        params: {
+          companyId: Joi.string().guid().required()
+        }
+      }
+    }
+  },
+
   createCompanyInvoiceAccount: {
     path: '/water/1.0/companies/{companyId}/invoice-accounts',
     method: 'POST',

--- a/src/modules/licences/routes/documents.js
+++ b/src/modules/licences/routes/documents.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi');
 const controller = require('../controllers/documents');
 const { version } = require('../../../../config');
-
+const singularPrefix = `/water/${version}/document/`;
 const pathPrefix = `/water/${version}/documents/`;
 
 module.exports = {
@@ -123,6 +123,23 @@ module.exports = {
       validate: {
         params: {
           documentId: Joi.string().guid().required()
+        }
+      }
+    }
+  },
+
+  getLicenceDocumentByDocRefAndDate: {
+    method: 'GET',
+    path: `${singularPrefix}search`,
+    handler: controller.getLicenceDocumentByDocRefAndDate,
+    config: {
+      description: 'Returns the document for a given document ref and a specified date, including a company identifier',
+      validate: {
+        query: {
+          regime: Joi.string().default('water'),
+          documentType: Joi.string().default('abstraction_licence'),
+          documentRef: Joi.string().required(),
+          date: Joi.date()
         }
       }
     }


### PR DESCRIPTION
Adds two endpoints:
- `GET /water/1.0/document/search`
- `GET /water/1.0/companies/{companyId}/invoice-accounts`

Please refer to the ticket for context: https://eaflood.atlassian.net/browse/WATER-2786

Linked to https://github.com/DEFRA/water-abstraction-tactical-crm/compare/feat/water-2786-get-company-n-invoice-accs-from-crm?expand=1