### PR TITLE
WATER-2786 - Added GET /water/1.0/licences/licence-accounts

### DIFF
--- a/src/lib/connectors/crm-v2/companies.js
+++ b/src/lib/connectors/crm-v2/companies.js
@@ -67,6 +67,14 @@ const getCompanyContacts = companyId => {
   return serviceRequest.get(getUri(companyId, 'contacts'));
 };
 
+
+/**
+ * Returns the invoice accounts associated with a company by its GUID
+ * @param {String} companyId
+ */
+
+const getInvoiceAccountsByCompanyId = async companyId => serviceRequest.get(getUri(`${companyId}/invoice-accounts`))
+
 exports.createCompany = createCompany;
 exports.getCompany = getCompany;
 exports.deleteCompany = deleteCompany;
@@ -76,3 +84,4 @@ exports.deleteCompanyAddress = deleteCompanyAddress;
 exports.createCompanyContact = createCompanyContact;
 exports.deleteCompanyContact = deleteCompanyContact;
 exports.getCompanyContacts = getCompanyContacts;
+exports.getInvoiceAccountsByCompanyId = getInvoiceAccountsByCompanyId;

--- a/src/lib/connectors/crm-v2/companies.js
+++ b/src/lib/connectors/crm-v2/companies.js
@@ -67,13 +67,12 @@ const getCompanyContacts = companyId => {
   return serviceRequest.get(getUri(companyId, 'contacts'));
 };
 
-
 /**
  * Returns the invoice accounts associated with a company by its GUID
  * @param {String} companyId
  */
 
-const getInvoiceAccountsByCompanyId = async companyId => serviceRequest.get(getUri(`${companyId}/invoice-accounts`))
+const getInvoiceAccountsByCompanyId = async companyId => serviceRequest.get(getUri(`${companyId}/invoice-accounts`));
 
 exports.createCompany = createCompany;
 exports.getCompany = getCompany;

--- a/src/lib/connectors/crm-v2/documents.js
+++ b/src/lib/connectors/crm-v2/documents.js
@@ -2,12 +2,17 @@
 
 const urlJoin = require('url-join');
 const Joi = require('joi');
+const moment = require('moment');
 
 const { serviceRequest } = require('@envage/water-abstraction-helpers');
 const config = require('../../../../config');
 
 const VALID_LICENCE_NUMBER = Joi.string().required().example('01/123/R01');
 const VALID_GUID = Joi.string().guid().required();
+
+const getDocumentUrl = (...tail) => {
+  return urlJoin(config.services.crm_v2, 'document', ...tail);
+};
 
 const getDocumentsUrl = (...tail) => {
   return urlJoin(config.services.crm_v2, 'documents', ...tail);
@@ -57,7 +62,22 @@ const getDocumentRole = documentRoleId => {
   return serviceRequest.get(getDocumentRolesUrl(documentRoleId));
 };
 
+/**
+ * Fetch a document by documentRef and date, to identify the responsible company
+ *  @param {String} documentRef
+ *  @param {String} date 
+ */
+const getDocumentByRefAndDate = async (documentRef, date) => {
+  return serviceRequest.get(getDocumentUrl("search"), {
+    qs: {
+      date: moment(date).format('YYYY-MM-DD'),
+      documentRef
+    }
+  });
+}
+
 exports.createDocumentRole = createDocumentRole;
 exports.getDocument = getDocument;
 exports.getDocumentRole = getDocumentRole;
 exports.getDocuments = getDocuments;
+exports.getDocumentByRefAndDate = getDocumentByRefAndDate;

--- a/src/lib/connectors/crm-v2/documents.js
+++ b/src/lib/connectors/crm-v2/documents.js
@@ -10,10 +10,6 @@ const config = require('../../../../config');
 const VALID_LICENCE_NUMBER = Joi.string().required().example('01/123/R01');
 const VALID_GUID = Joi.string().guid().required();
 
-const getDocumentUrl = (...tail) => {
-  return urlJoin(config.services.crm_v2, 'document', ...tail);
-};
-
 const getDocumentsUrl = (...tail) => {
   return urlJoin(config.services.crm_v2, 'documents', ...tail);
 };
@@ -68,7 +64,7 @@ const getDocumentRole = documentRoleId => {
  *  @param {String} date
  */
 const getDocumentByRefAndDate = async (documentRef, date) => {
-  return serviceRequest.get(getDocumentUrl('search'), {
+  return serviceRequest.get(getDocumentsUrl('search'), {
     qs: {
       date: moment(date).format('YYYY-MM-DD'),
       documentRef

--- a/src/lib/connectors/crm-v2/documents.js
+++ b/src/lib/connectors/crm-v2/documents.js
@@ -65,16 +65,16 @@ const getDocumentRole = documentRoleId => {
 /**
  * Fetch a document by documentRef and date, to identify the responsible company
  *  @param {String} documentRef
- *  @param {String} date 
+ *  @param {String} date
  */
 const getDocumentByRefAndDate = async (documentRef, date) => {
-  return serviceRequest.get(getDocumentUrl("search"), {
+  return serviceRequest.get(getDocumentUrl('search'), {
     qs: {
       date: moment(date).format('YYYY-MM-DD'),
       documentRef
     }
   });
-}
+};
 
 exports.createDocumentRole = createDocumentRole;
 exports.getDocument = getDocument;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -113,18 +113,18 @@ const updateIncludeInSupplementaryBillingStatusForSentBatch = async batchId => {
 /**
  * Fetches the invoice accounts associated with a licence using the licence ref and date as input.
  *  @param {String} documentRef
- *  @param {String} date 
+ *  @param {String} date
  */
 const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
-  //First, fetch the company ID from the CRM
+  //  First, fetch the company ID from the CRM
   const { companyId } = await crmDocsConnector.getDocumentByRefAndDate(documentRef, date);
-  
-  //Secondly, take the company ID and fetch the invoice accounts for that company from the CRM
+
+  //  Secondly, take the company ID and fetch the invoice accounts for that company from the CRM
   const invoiceAccounts = await crmCompaniesConnector.getInvoiceAccountsByCompanyId(companyId);
 
-  //Return the invoice accounts
-  return invoiceAccounts
-}
+  //  Return the invoice accounts
+  return invoiceAccounts;
+};
 
 exports.getLicenceAgreementById = getLicenceAgreementById;
 exports.getLicenceAgreementsByLicenceRef = getLicenceAgreementsByLicenceRef;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -124,8 +124,7 @@ const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
   const invoiceAccounts = await crmCompaniesConnector.getInvoiceAccountsByCompanyId(companyId);
 
   //  Return the invoice accounts
-  return invoiceAccounts.length < 1 ? invoiceAccountsMapper.crmToModel(invoiceAccounts) : [];
-  //return invoiceAccounts;
+  return invoiceAccounts ? invoiceAccounts.map(invoiceAccount => invoiceAccountsMapper.crmToModel(invoiceAccount)) : [];
 };
 
 exports.getLicenceAgreementById = getLicenceAgreementById;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -3,6 +3,7 @@
 const repos = require('../connectors/repos');
 const licenceAgreementMapper = require('../mappers/licence-agreement');
 const licenceMapper = require('../mappers/licence');
+const invoiceAccountsMapper = require('../mappers/invoice-account');
 const licenceVersionMapper = require('../mappers/licence-version');
 const { INCLUDE_IN_SUPPLEMENTARY_BILLING } = require('../models/constants');
 
@@ -123,7 +124,8 @@ const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
   const invoiceAccounts = await crmCompaniesConnector.getInvoiceAccountsByCompanyId(companyId);
 
   //  Return the invoice accounts
-  return invoiceAccounts;
+  return invoiceAccounts.length < 1 ? invoiceAccountsMapper.crmToModel(invoiceAccounts) : [];
+  //return invoiceAccounts;
 };
 
 exports.getLicenceAgreementById = getLicenceAgreementById;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -7,6 +7,8 @@ const licenceVersionMapper = require('../mappers/licence-version');
 const { INCLUDE_IN_SUPPLEMENTARY_BILLING } = require('../models/constants');
 
 const service = require('./service');
+const crmDocsConnector = require('../connectors/crm-v2/documents');
+const crmCompaniesConnector = require('../connectors/crm-v2/companies');
 
 /**
  * Gets a licence model by ID
@@ -108,13 +110,29 @@ const updateIncludeInSupplementaryBillingStatusForSentBatch = async batchId => {
   return updateIncludeInSupplementaryBillingStatusForUnsentBatch(batchId);
 };
 
+/**
+ * Fetches the invoice accounts associated with a licence using the licence ref and date as input.
+ *  @param {String} documentRef
+ *  @param {String} date 
+ */
+const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
+  //First, fetch the company ID from the CRM
+  const { companyId } = await crmDocsConnector.getDocumentByRefAndDate(documentRef, date);
+  
+  //Secondly, take the company ID and fetch the invoice accounts for that company from the CRM
+  const invoiceAccounts = await crmCompaniesConnector.getInvoiceAccountsByCompanyId(companyId);
+
+  //Return the invoice accounts
+  return invoiceAccounts
+}
+
 exports.getLicenceAgreementById = getLicenceAgreementById;
 exports.getLicenceAgreementsByLicenceRef = getLicenceAgreementsByLicenceRef;
 exports.getLicenceById = getLicenceById;
 exports.getLicenceVersionById = getLicenceVersionById;
 exports.getLicenceVersions = getLicenceVersions;
 exports.getLicenceByLicenceRef = getLicenceByLicenceRef;
-
+exports.getLicenceAccountsByRefAndDate = getLicenceAccountsByRefAndDate;
 exports.updateIncludeInSupplementaryBillingStatus = updateIncludeInSupplementaryBillingStatus;
 exports.updateIncludeInSupplementaryBillingStatusForUnsentBatch = updateIncludeInSupplementaryBillingStatusForUnsentBatch;
 exports.updateIncludeInSupplementaryBillingStatusForSentBatch = updateIncludeInSupplementaryBillingStatusForSentBatch;

--- a/src/modules/licences/controllers/licences.js
+++ b/src/modules/licences/controllers/licences.js
@@ -9,5 +9,9 @@ const getLicence = async request =>
 const getLicenceVersions = async request =>
   licencesService.getLicenceVersions(request.params.licenceId);
 
+const getLicenceAccountsByRefAndDate = async request => 
+  licencesService.getLicenceAccountsByRefAndDate(request.query.documentRef, request.query.date)
+
 exports.getLicence = getLicence;
 exports.getLicenceVersions = getLicenceVersions;
+exports.getLicenceAccountsByRefAndDate = getLicenceAccountsByRefAndDate;

--- a/src/modules/licences/controllers/licences.js
+++ b/src/modules/licences/controllers/licences.js
@@ -9,8 +9,8 @@ const getLicence = async request =>
 const getLicenceVersions = async request =>
   licencesService.getLicenceVersions(request.params.licenceId);
 
-const getLicenceAccountsByRefAndDate = async request => 
-  licencesService.getLicenceAccountsByRefAndDate(request.query.documentRef, request.query.date)
+const getLicenceAccountsByRefAndDate = async request =>
+  licencesService.getLicenceAccountsByRefAndDate(request.query.documentRef, request.query.date);
 
 exports.getLicence = getLicence;
 exports.getLicenceVersions = getLicenceVersions;

--- a/src/modules/licences/routes/licences.js
+++ b/src/modules/licences/routes/licences.js
@@ -34,5 +34,20 @@ module.exports = {
         }
       }
     }
+  },
+
+  getLicenceAccountsByRefAndDate: {
+    method: 'GET',
+    path: `${pathPrefix}licence-accounts`,
+    handler: controller.getLicenceAccountsByRefAndDate,
+    config: {
+      description: 'Gets the licence accounts by licence ref and a date',
+      validate: {
+        query: {
+          documentRef: Joi.string().required(),
+          date: Joi.string().required()
+        }
+      }
+    }
   }
 };

--- a/test/lib/connectors/crm-v2/documents.js
+++ b/test/lib/connectors/crm-v2/documents.js
@@ -124,4 +124,35 @@ experiment('lib/connectors/crm-2/documents', () => {
       expect(result).to.equal(documentRole);
     });
   });
+
+  experiment('.getDocumentByRefAndDate', () => {
+    let documentRef;
+    let date;
+    let result;
+
+    beforeEach(async () => {
+      documentId = uuid();
+      documentRef = 'xxyyzz';
+      date = '2020-10-10';
+
+      expectedResponse = {
+        documentId,
+        documentRef,
+        regime: 'water',
+        documentType: 'abstraction_licence'
+      };
+
+      serviceRequest.get.resolves(expectedResponse);
+      result = await documentsConnector.getDocumentByRefAndDate(documentRef, date);
+    });
+
+    test('makes a get request to the expected URL', async () => {
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal(`${config.services.crm_v2}/documents/search`);
+    });
+
+    test('returns the received data from the CRM', async () => {
+      expect(result.documentId).to.equal(documentId);
+    });
+  });
 });

--- a/test/lib/connectors/crm-v2/documents.js
+++ b/test/lib/connectors/crm-v2/documents.js
@@ -126,9 +126,7 @@ experiment('lib/connectors/crm-2/documents', () => {
   });
 
   experiment('.getDocumentByRefAndDate', () => {
-    let documentRef;
-    let date;
-    let result;
+    let documentRef, documentId, date, result, expectedResponse;
 
     beforeEach(async () => {
       documentId = uuid();

--- a/test/modules/licences/controllers/licences.js
+++ b/test/modules/licences/controllers/licences.js
@@ -6,6 +6,7 @@ const { afterEach, beforeEach, experiment, test } = exports.lab = require('@hapi
 const controller = require('../../../../src/modules/licences/controllers/licences');
 const licencesService = require('../../../../src/lib/services/licences');
 const Licence = require('../../../../src/lib/models/licence');
+const InvoiceAccount = require('../../../../src/lib/models/invoice-account');
 
 const sandbox = require('sinon').createSandbox();
 
@@ -13,6 +14,7 @@ experiment('modules/licences/controllers/licences.js', () => {
   beforeEach(async () => {
     sandbox.stub(licencesService, 'getLicenceById');
     sandbox.stub(licencesService, 'getLicenceVersions');
+    sandbox.stub(licencesService, 'getLicenceAccountsByRefAndDate');
   });
 
   afterEach(async () => {
@@ -87,6 +89,36 @@ experiment('modules/licences/controllers/licences.js', () => {
 
     test('returns the licence versions', async () => {
       expect(result).to.equal(licenceVersions);
+    });
+  });
+
+  experiment('.getLicenceAccountsByRefAndDate', () => {
+    let result;
+    let request;
+    let exampleLicenceAccount;
+
+    beforeEach(async () => {
+      exampleLicenceAccount = new InvoiceAccount();
+
+      licencesService.getLicenceAccountsByRefAndDate.resolves([exampleLicenceAccount]);
+
+      request = {
+        query: {
+          documentRef: 'test-doc-id',
+          date: '2020-10-10'
+        }
+      };
+
+      result = await controller.getLicenceAccountsByRefAndDate(request);
+    });
+
+    test('passes the document ref to the service layer', async () => {
+      const [documentRef] = licencesService.getLicenceAccountsByRefAndDate.lastCall.args;
+      expect(documentRef).to.equal(request.query.documentRef);
+    });
+
+    test('returns an array', async () => {
+      expect(result).to.equal([exampleLicenceAccount]);
     });
   });
 });


### PR DESCRIPTION
Original ticket for context: https://eaflood.atlassian.net/browse/WATER-2786

This adds an endpoint that proxies the two newly added CRMv2 Routes for fetching information about the responsible company for a licence, and the invoice accounts associated with that licence. 