### PR TITLE
Fix bill run issues due to CM statuses

### DIFF
--- a/config.js
+++ b/config.js
@@ -216,5 +216,11 @@ module.exports = {
     password: process.env.REDIS_PASSWORD || '',
     ...!(isLocal || isTravis) && { tls: {} },
     db: 2
+  },
+
+  chargeModuleConnector: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 5 * 1000
   }
 };

--- a/src/lib/connectors/charge-module/bill-runs-with-retry.js
+++ b/src/lib/connectors/charge-module/bill-runs-with-retry.js
@@ -29,7 +29,8 @@ const getOrThrowIfGeneratingSummary = async (method, ...args) => {
 };
 
 /**
- *
+ * Wraps a charge module API method so that it retries a number
+ * of times, awaiting a status other than 'generating_summary'
  * @param {String} method - charge module bill run connector method
  * @param  {...any} args - additional arguments
  */

--- a/src/lib/connectors/charge-module/bill-runs-with-retry.js
+++ b/src/lib/connectors/charge-module/bill-runs-with-retry.js
@@ -8,6 +8,12 @@ const billRunsApi = require('./bill-runs');
 
 const isCMGeneratingSummary = cmResponse => get(cmResponse, 'billRun.status') === 'generating_summary';
 
+const options = {
+  retries: 10,
+  factor: 2,
+  minTimeout: 5 * 1000
+};
+
 /**
  * Gets data from the CM API, throwing an error if summary generation still in progress
  * @param {String} method - charge module bill run connector method
@@ -28,12 +34,6 @@ const getOrThrowIfGeneratingSummary = async (method, ...args) => {
  * @param  {...any} args - additional arguments
  */
 const retry = (method, ...args) => {
-  const options = {
-    retries: 10,
-    factor: 2,
-    minTimeout: 5 * 1000
-  };
-
   const func = (retry, number) => {
     logger.log('info', `Calling ${method} ${args.join(', ')} attempt ${number}`);
     return getOrThrowIfGeneratingSummary(method, ...args)
@@ -45,3 +45,4 @@ const retry = (method, ...args) => {
 
 exports.get = partial(retry, 'get');
 exports.getCustomer = partial(retry, 'getCustomer');
+exports.options = options;

--- a/src/lib/connectors/charge-module/bill-runs-with-retry.js
+++ b/src/lib/connectors/charge-module/bill-runs-with-retry.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { get, partial } = require('lodash');
+const promiseRetry = require('promise-retry');
+const { logger } = require('../../../logger');
+
+const billRunsApi = require('./bill-runs');
+
+const isCMGeneratingSummary = cmResponse => get(cmResponse, 'billRun.status') === 'generating_summary';
+
+/**
+ * Gets data from the CM API, throwing an error if summary generation still in progress
+ * @param {String} method - charge module bill run connector method
+ * @param  {...any} args - additional arguments
+ */
+const getOrThrowIfGeneratingSummary = async (method, ...args) => {
+  // Call base API method
+  const data = await billRunsApi[method](...args);
+  if (isCMGeneratingSummary(data)) {
+    throw new Error(`Charge module still generating summary for ${method} ${args.join(', ')}`);
+  }
+  return data;
+};
+
+/**
+ *
+ * @param {String} method - charge module bill run connector method
+ * @param  {...any} args - additional arguments
+ */
+const retry = (method, ...args) => {
+  const options = {
+    retries: 10,
+    factor: 2,
+    minTimeout: 5 * 1000
+  };
+
+  const func = (retry, number) => {
+    logger.log('info', `Calling ${method} ${args.join(', ')} attempt ${number}`);
+    return getOrThrowIfGeneratingSummary(method, ...args)
+      .catch(retry);
+  };
+
+  return promiseRetry(func, options);
+};
+
+exports.get = partial(retry, 'get');
+exports.getCustomer = partial(retry, 'getCustomer');

--- a/src/lib/connectors/charge-module/bill-runs-with-retry.js
+++ b/src/lib/connectors/charge-module/bill-runs-with-retry.js
@@ -3,16 +3,11 @@
 const { get, partial } = require('lodash');
 const promiseRetry = require('promise-retry');
 const { logger } = require('../../../logger');
+const config = require('../../../../config');
 
 const billRunsApi = require('./bill-runs');
 
 const isCMGeneratingSummary = cmResponse => get(cmResponse, 'billRun.status') === 'generating_summary';
-
-const options = {
-  retries: 10,
-  factor: 2,
-  minTimeout: 5 * 1000
-};
 
 /**
  * Gets data from the CM API, throwing an error if summary generation still in progress
@@ -41,9 +36,8 @@ const retry = (method, ...args) => {
       .catch(retry);
   };
 
-  return promiseRetry(func, options);
+  return promiseRetry(func, config.chargeModuleConnector);
 };
 
 exports.get = partial(retry, 'get');
 exports.getCustomer = partial(retry, 'getCustomer');
-exports.options = options;

--- a/src/lib/connectors/charge-module/bill-runs.js
+++ b/src/lib/connectors/charge-module/bill-runs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const request = require('./request');
 
 /**

--- a/src/modules/billing/controller.js
+++ b/src/modules/billing/controller.js
@@ -126,20 +126,6 @@ const deleteBatch = (request, h) => controller.deleteEntity(
   request.defra.internalCallingUser
 );
 
-/*
-const deleteBatch = async (request, h) => {
-  const { batch } = request.pre;
-  const { internalCallingUser } = request.defra;
-
-  if (!batch.canBeDeleted()) {
-    return h.response(`Cannot delete batch when status is ${batch.status}`).code(422);
-  }
-
-  await batchService.deleteBatch(batch, internalCallingUser);
-  return h.response().code(204);
-};
-*/
-
 const postApproveBatch = async (request, h) => {
   const { batch } = request.pre;
   const { internalCallingUser } = request.defra;

--- a/src/modules/billing/jobs/create-charge-complete.js
+++ b/src/modules/billing/jobs/create-charge-complete.js
@@ -83,16 +83,15 @@ const finaliseEmptyBatch = async (job, messageQueue) => {
 
 /**
  * If batch is ready, clean up any unwanted invoices/invoice licences,
- * publish the refresh totals job, and set batch ready status
+ * publish the refresh totals job
  * @param {Object} job
  * @param {Object} messageQueue - PG boss instance
  * @return {Promise}
  */
 const finaliseReadyBatch = async (job, messageQueue) => {
-  const { eventId, batchId } = parseJob(job);
+  const { batchId } = parseJob(job);
   await batchService.cleanup(batchId);
   await messageQueue.publish(refreshTotalsJob.createMessage(batchId));
-  await jobService.setReadyJob(eventId, batchId);
   await batchJob.deleteOnCompleteQueue(job, messageQueue);
 };
 

--- a/src/modules/billing/mappers/charge-module-decorators.js
+++ b/src/modules/billing/mappers/charge-module-decorators.js
@@ -10,10 +10,7 @@ const { TransactionStatusError } = require('../lib/errors');
 
 const mappers = require('../mappers');
 
-const { isEmpty, uniq, get } = require('lodash');
-
-const isBatchReadyOrSent = batch =>
-  batch.statusIsOneOf(Batch.BATCH_STATUS.ready, Batch.BATCH_STATUS.sent);
+const { isEmpty, uniq } = require('lodash');
 
 const findCustomer = (cmResponse, customerReference) =>
   cmResponse.billRun.customers.find(customer => customer.customerReference === customerReference);

--- a/src/modules/billing/mappers/charge-module-decorators.js
+++ b/src/modules/billing/mappers/charge-module-decorators.js
@@ -10,7 +10,7 @@ const { TransactionStatusError } = require('../lib/errors');
 
 const mappers = require('../mappers');
 
-const { isEmpty, uniq } = require('lodash');
+const { isEmpty, uniq, get } = require('lodash');
 
 const isBatchReadyOrSent = batch =>
   batch.statusIsOneOf(Batch.BATCH_STATUS.ready, Batch.BATCH_STATUS.sent);
@@ -106,11 +106,6 @@ const decorateInvoice = (invoice, cmResponse) => {
 const decorateBatch = (batch, cmResponse) => {
   validators.assertIsInstanceOf(batch, Batch);
   validators.assertObject(cmResponse);
-
-  // Don't do any mapping unless batch is ready/sent
-  if (!isBatchReadyOrSent(batch)) {
-    return batch;
-  }
 
   // Set batch totals
   batch.totals = mappers.totals.chargeModuleBillRunToBatchModel(cmResponse.billRun.summary);

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -12,6 +12,7 @@ const { BatchStatusError } = require('../lib/errors');
 const { NotFoundError } = require('../../../lib/errors');
 const { INCLUDE_IN_SUPPLEMENTARY_BILLING } = require('../../../lib/models/constants');
 const chargeModuleBillRunConnector = require('../../../lib/connectors/charge-module/bill-runs');
+const chargeModuleBillRunWithRetryConnector = require('../../../lib/connectors/charge-module/bill-runs-with-retry');
 
 const Batch = require('../../../lib/models/batch');
 const validators = require('../../../lib/models/validators');
@@ -210,14 +211,18 @@ const refreshTotals = async batchId => {
   }
   const batch = mappers.batch.dbToModel(data);
 
-  // Load CM data and decorate service models
-  const cmResponse = await chargeModuleBillRunConnector.get(batch.externalId);
+  // Load CM data
+  const cmResponse = await chargeModuleBillRunWithRetryConnector.get(batch.externalId);
+
+  // Decorate batch and persist totals
   chargeModuleDecorators.decorateBatch(batch, cmResponse);
 
-  return Promise.all([
+  await Promise.all([
     transactionsService.persistDeMinimis(batch),
     persistTotals(batch)
   ]);
+
+  return setStatus(batchId, Batch.BATCH_STATUS.ready);
 };
 
 /**
@@ -355,6 +360,9 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     throw new BatchStatusError(`Cannot delete invoice from batch when status is ${batch.status}`);
   }
 
+  // Set batch status back to 'processing'
+  await setStatus(batch.id, Batch.BATCH_STATUS.processing);
+
   // Load invoice
   const invoice = await newRepos.billingInvoices.findOne(invoiceId);
   if (!invoice) {
@@ -378,6 +386,7 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     const invoiceModel = mappers.invoice.dbToModel(invoice);
     await updateInvoiceLicencesForSupplementaryReprocessing(invoiceModel);
 
+    // Mark batch as 'empty' if needed
     return setStatusToEmptyWhenNoTransactions(batch);
   } catch (err) {
     await setErrorStatus(batch.id, Batch.BATCH_ERROR_CODE.failedToDeleteInvoice);

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -183,15 +183,19 @@ const decorateBatchWithTotals = async batch => {
 
 /**
  * Persists the batch totals to water.billing_batches
+ * Also sets batch status to 'ready'
  * @param {Batch} batch
  * @return {Promise}
  */
 const persistTotals = batch => {
-  const changes = batch.totals.pick([
-    'invoiceCount',
-    'creditNoteCount',
-    'netTotal'
-  ]);
+  const changes = {
+    status: Batch.BATCH_STATUS.ready,
+    ...batch.totals.pick([
+      'invoiceCount',
+      'creditNoteCount',
+      'netTotal'
+    ])
+  };
   return newRepos.billingBatches.update(batch.id, changes);
 };
 
@@ -221,8 +225,6 @@ const refreshTotals = async batchId => {
     transactionsService.persistDeMinimis(batch),
     persistTotals(batch)
   ]);
-
-  return setStatus(batchId, Batch.BATCH_STATUS.ready);
 };
 
 /**

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { find, partialRight } = require('lodash');
+const { find, partialRight, pickBy, pick } = require('lodash');
 const pWaterfall = require('p-waterfall');
 
 // Connectors
@@ -122,7 +122,9 @@ const getInvoice = async context => {
 const decorateInvoiceWithCRMData = (invoice, context) => {
   const crmInvoiceAccount = find(context.crmInvoiceAccounts, { invoiceAccountId: invoice.invoiceAccount.id });
   const tempInvoice = mappers.invoice.crmToModel(crmInvoiceAccount);
-  return invoice.pickFrom(tempInvoice, ['invoiceAccount', 'address', 'agentCompany', 'contact']);
+
+  const properties = pick(tempInvoice, ['invoiceAccount', 'address', 'agentCompany', 'contact']);
+  return Object.assign(invoice, pickBy(properties));
 };
 
 /**

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { find, partialRight } = require('lodash');
+const { find, partialRight, pickBy } = require('lodash');
 const pWaterfall = require('p-waterfall');
 
 // Connectors
@@ -121,15 +121,15 @@ const getInvoice = async context => {
  */
 const decorateInvoiceWithCRMData = (invoice, context) => {
   const crmInvoiceAccount = find(context.crmInvoiceAccounts, { invoiceAccountId: invoice.invoiceAccount.id });
-  const { invoiceAccount, address, agentCompany, contact } = mappers.invoice.crmToModel(crmInvoiceAccount);
-  if (address) {
-    invoice.address = address;
-  }
-  return invoice.fromHash({
-    invoiceAccount,
-    agentCompany,
-    contact
-  });
+
+  const properties = mappers.invoice.crmToModel(crmInvoiceAccount).pick(
+    'address',
+    'invoiceAccount',
+    'agentCompany',
+    'contact'
+  );
+
+  return invoice.fromHash(pickBy(properties));
 };
 
 /**

--- a/src/modules/billing/services/invoice-service.js
+++ b/src/modules/billing/services/invoice-service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { find, partialRight, pickBy, pick } = require('lodash');
+const { find, partialRight } = require('lodash');
 const pWaterfall = require('p-waterfall');
 
 // Connectors
@@ -121,10 +121,15 @@ const getInvoice = async context => {
  */
 const decorateInvoiceWithCRMData = (invoice, context) => {
   const crmInvoiceAccount = find(context.crmInvoiceAccounts, { invoiceAccountId: invoice.invoiceAccount.id });
-  const tempInvoice = mappers.invoice.crmToModel(crmInvoiceAccount);
-
-  const properties = pick(tempInvoice, ['invoiceAccount', 'address', 'agentCompany', 'contact']);
-  return Object.assign(invoice, pickBy(properties));
+  const { invoiceAccount, address, agentCompany, contact } = mappers.invoice.crmToModel(crmInvoiceAccount);
+  if (address) {
+    invoice.address = address;
+  }
+  return invoice.fromHash({
+    invoiceAccount,
+    agentCompany,
+    contact
+  });
 };
 
 /**

--- a/test/lib/connectors/charge-module/bill-runs-with-retry.js
+++ b/test/lib/connectors/charge-module/bill-runs-with-retry.js
@@ -13,11 +13,13 @@ const sandbox = sinon.createSandbox();
 const request = require('../../../../src/lib/connectors/charge-module/request');
 const billRunsApiConnectorWithRetry = require('../../../../src/lib/connectors/charge-module/bill-runs-with-retry');
 
+const config = require('../../../../config');
+
 experiment('lib/connectors/charge-module/bill-runs-with-retry', () => {
   let result;
 
   beforeEach(async () => {
-    sandbox.stub(billRunsApiConnectorWithRetry.options, 'minTimeout').value(100);
+    sandbox.stub(config.chargeModuleConnector, 'minTimeout').value(100);
     sandbox.stub(request, 'get').resolves({
       billRun: {
         status: 'generating_summary'

--- a/test/lib/connectors/charge-module/bill-runs-with-retry.js
+++ b/test/lib/connectors/charge-module/bill-runs-with-retry.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const request = require('../../../../src/lib/connectors/charge-module/request');
+const billRunsApiConnectorWithRetry = require('../../../../src/lib/connectors/charge-module/bill-runs-with-retry');
+
+experiment('lib/connectors/charge-module/bill-runs-with-retry', () => {
+  let result;
+
+  beforeEach(async () => {
+    sandbox.stub(billRunsApiConnectorWithRetry.options, 'minTimeout').value(100);
+    sandbox.stub(request, 'get').resolves({
+      billRun: {
+        status: 'generating_summary'
+      }
+    });
+    request.get.onCall(1).resolves({
+      billRun: {
+        status: 'initialised',
+        summary: {}
+      }
+    });
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.get', () => {
+    beforeEach(async () => {
+      result = await billRunsApiConnectorWithRetry.get('test-id');
+    });
+
+    test('the method is GET', async () => {
+      expect(request.get.called).to.be.true();
+    });
+
+    test('the correct endpoint is called', async () => {
+      const [path] = request.get.lastCall.args;
+      expect(request.get.callCount).to.equal(2);
+      expect(path).to.equal('v1/wrls/billruns/test-id');
+    });
+
+    test('resolves with data only when the status has changed from "generating_summary"', async () => {
+      expect(result.billRun.summary).to.be.an.object();
+    });
+  });
+
+  experiment('.getCustomer', () => {
+    beforeEach(async () => {
+      result = await billRunsApiConnectorWithRetry.getCustomer('test-id', 'customer-id');
+    });
+
+    test('the method is GET', async () => {
+      expect(request.get.called).to.be.true();
+    });
+
+    test('the correct endpoint is called', async () => {
+      const [path] = request.get.lastCall.args;
+      expect(request.get.callCount).to.equal(2);
+      expect(path).to.equal('v1/wrls/billruns/test-id');
+    });
+
+    test('the correct customer is specified', async () => {
+      const [, query] = request.get.lastCall.args;
+      expect(query).to.equal({
+        customerReference: 'customer-id'
+      });
+    });
+
+    test('resolves with data only when the status has changed from "generating_summary"', async () => {
+      expect(result.billRun.summary).to.be.an.object();
+    });
+  });
+});

--- a/test/modules/billing/jobs/create-charge-complete.js
+++ b/test/modules/billing/jobs/create-charge-complete.js
@@ -151,12 +151,6 @@ experiment('modules/billing/jobs/create-charge-complete', () => {
       expect(data.batchId).to.equal(BATCH_ID);
     });
 
-    test('the job is marked as ready', async () => {
-      expect(jobService.setReadyJob.calledWith(
-        EVENT_ID, BATCH_ID
-      )).to.be.true();
-    });
-
     test('remaining onComplete jobs are deleted', async () => {
       expect(batchJob.deleteOnCompleteQueue.calledWith(
         job, messageQueue

--- a/test/modules/billing/mappers/charge-module-decorators.js
+++ b/test/modules/billing/mappers/charge-module-decorators.js
@@ -130,15 +130,6 @@ experiment('modules/billing/mappers/charge-module-decorators', () => {
     cmResponse = createCMResponse();
   });
 
-  const { BATCH_STATUS } = Batch;
-  [BATCH_STATUS.processing, BATCH_STATUS.empty, BATCH_STATUS.error, BATCH_STATUS.review].forEach(status => {
-    test(`when batch has "${status}" status, no mapping takes place`, async () => {
-      batch.status = status;
-      const decoratedBatch = chargeModuleDecorators.decorateBatch(batch, cmResponse);
-      expect(decoratedBatch.totals).to.be.undefined();
-    });
-  });
-
   experiment('when batch status is ready/sent', () => {
     let updatedBatch;
 

--- a/test/modules/billing/services/invoice-service.js
+++ b/test/modules/billing/services/invoice-service.js
@@ -419,8 +419,8 @@ experiment('modules/billing/services/invoiceService', () => {
 
       test('has the correct CRM company, agent and contact', async () => {
         expect(invoice.invoiceAccount.company.id).to.equal(IDS.companies[2]);
-        expect(invoice.agentCompany).to.equal(null);
-        expect(invoice.contact).to.equal(null);
+        expect(invoice.agentCompany).to.be.undefined();
+        expect(invoice.contact).to.be.undefined();
       });
 
       test('has a correct financial summary', async () => {
@@ -554,8 +554,8 @@ experiment('modules/billing/services/invoiceService', () => {
 
       test('has the correct CRM company, agent and contact', async () => {
         expect(invoice.invoiceAccount.company.id).to.equal(IDS.companies[2]);
-        expect(invoice.agentCompany).to.equal(null);
-        expect(invoice.contact).to.equal(null);
+        expect(invoice.agentCompany).to.be.undefined();
+        expect(invoice.contact).to.be.undefined();
       });
 
       test('has 2 transactions', async () => {


### PR DESCRIPTION
WATER-2870

Fixes issues arising because the CM now responds with an incomplete payload depending on bill run status.

* Wraps the CM API connector code in a method which will retry up to 10 times with exponential back-off
* Does not move batch from 'processing' to 'ready' until the 'refreshTotals' job has completed
* Puts the batch back into 'processing' status while a customer is removed