### PR TITLE
Add legacyId to returnRequirement model and mapper

### DIFF
--- a/src/lib/mappers/return-requirement.js
+++ b/src/lib/mappers/return-requirement.js
@@ -10,7 +10,7 @@ const mapReturnRequirementPurposes = rows => rows.map(returnRequirementPurposeMa
 
 const dbToModelMapper = createMapper()
   .map('returnRequirementId').to('id')
-  .copy('isSummer', 'externalId')
+  .copy('isSummer', 'externalId', 'legacyId')
   .map('returnRequirementPurposes').to('returnRequirementPurposes', mapReturnRequirementPurposes);
 
 /**

--- a/src/lib/models/return-requirement.js
+++ b/src/lib/models/return-requirement.js
@@ -68,6 +68,19 @@ class ReturnRequirement extends Model {
   get externalId () {
     return this._externalId;
   }
+
+  /**
+   * Legacy ID (NALD return reference)
+   * @param {Number}
+   */
+  set legacyId (legacyId) {
+    validators.assertNullablePositiveInteger(legacyId);
+    this._legacyId = legacyId;
+  }
+
+  get legacyId () {
+    return this._legacyId;
+  }
 }
 
 module.exports = ReturnRequirement;

--- a/test/lib/mappers/return-requirement.js
+++ b/test/lib/mappers/return-requirement.js
@@ -19,6 +19,7 @@ const createDBRow = () => ({
   returnRequirementId: uuid(),
   isSummer: true,
   externalId: '1:123',
+  legacyId: 123,
   returnRequirementPurposes: [
     {
       returnRequirementPurposeId: uuid(),
@@ -65,6 +66,10 @@ experiment('modules/billing/mappers/return-requirement', () => {
 
       test('has an empty array of returnRequirementPurposes', async () => {
         expect(result.returnRequirementPurposes).to.equal([]);
+      });
+
+      test('has the .legacyId property', async () => {
+        expect(result.legacyId).to.equal(dbRow.legacyId);
       });
     });
 

--- a/test/lib/models/return-requirement.js
+++ b/test/lib/models/return-requirement.js
@@ -126,4 +126,23 @@ experiment('lib/models/return-requirement', () => {
       expect(returnRequirement.isTwoPartTariffPurposeUse).to.be.false();
     });
   });
+
+  experiment('.legacyId', () => {
+    test('can be set to a number', async () => {
+      returnRequirement.legacyId = 1234;
+      expect(returnRequirement.legacyId).to.equal(1234);
+    });
+
+    test('can be set to null', async () => {
+      returnRequirement.legacyId = null;
+      expect(returnRequirement.legacyId).to.equal(null);
+    });
+
+    test('throws an error if set to a non-numeric/null value', async () => {
+      const func = () => {
+        returnRequirement.legacyId = 'not-a-number';
+      };
+      expect(func).to.throw();
+    });
+  });
 });


### PR DESCRIPTION
WATER-2853

Adds the `legacyId` property to the ReturnRequirement model and mapper code.

This property is needed to support the paper forms UI flow.