### PR TITLE
Feat: Get licences without charge versions

### DIFF
--- a/config.js
+++ b/config.js
@@ -222,5 +222,9 @@ module.exports = {
     retries: 10,
     factor: 2,
     minTimeout: 5 * 1000
+  },
+
+  licences: {
+    withChargeVersionsStartDate: '1990-01-01'
   }
 };

--- a/config.js
+++ b/config.js
@@ -225,6 +225,6 @@ module.exports = {
   },
 
   licences: {
-    withChargeVersionsStartDate: '1990-01-01'
+    withChargeVersionsStartDate: '2020-01-01'
   }
 };

--- a/src/lib/connectors/repos/licences.js
+++ b/src/lib/connectors/repos/licences.js
@@ -95,10 +95,16 @@ const updateIncludeInSupplementaryBillingStatusForBatch = (batchId, from, to) =>
     .raw(queries.updateIncludeInSupplementaryBillingStatusForBatch, params);
 };
 
+const findWithoutChargeVersions = startDate =>
+  raw.multiRow(queries.getLicencesWithoutChargeVersions, {
+    startDate
+  });
+
 exports.findByBatchIdForTwoPartTariffReview = findByBatchIdForTwoPartTariffReview;
 exports.findOneByLicenceRef = findOneByLicenceRef;
 exports.findOne = findOne;
 exports.findByLicenceRef = findByLicenceRef;
+exports.findWithoutChargeVersions = findWithoutChargeVersions;
 
 exports.update = update;
 exports.updateIncludeLicenceInSupplementaryBilling = updateIncludeLicenceInSupplementaryBilling;

--- a/src/lib/services/documents-service.js
+++ b/src/lib/services/documents-service.js
@@ -42,10 +42,8 @@ const isNotDraft = doc => doc.status !== Document.DOCUMENT_STATUS.draft;
 const getValidDocumentOnDate = async (licenceNumber, date) => {
   const docs = await getDocuments(licenceNumber);
   const [doc] = docs.filter(doc => doc.dateRange.includes(date) && isNotDraft(doc));
-  if (!doc) {
-    throw new errors.NotFoundError(`Current or superseded document not found for ${licenceNumber} on ${date}`);
-  }
-  return getDocument(doc.id);
+
+  return doc ? getDocument(doc.id) : null;
 };
 
 exports.getDocuments = getDocuments;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const config = require('../../../config');
 const repos = require('../connectors/repos');
 const licenceMapper = require('../mappers/licence');
 const invoiceAccountsMapper = require('../mappers/invoice-account');
@@ -128,12 +129,18 @@ const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
 const flagForSupplementaryBilling = licenceId =>
   repos.licences.update(licenceId, { includeInSupplementaryBilling: INCLUDE_IN_SUPPLEMENTARY_BILLING.yes });
 
+const getLicencesWithoutChargeVersions = async () => {
+  const licences = await repos.licences.findWithoutChargeVersions(config.licences.withChargeVersionsStartDate);
+  return licences.map(licenceMapper.dbToModel);
+};
+
 exports.getLicenceById = getLicenceById;
 exports.getLicencesByLicenceRefs = getLicencesByLicenceRefs;
 exports.getLicenceVersionById = getLicenceVersionById;
 exports.getLicenceVersions = getLicenceVersions;
 exports.getLicenceByLicenceRef = getLicenceByLicenceRef;
 exports.getLicenceAccountsByRefAndDate = getLicenceAccountsByRefAndDate;
+exports.getLicencesWithoutChargeVersions = getLicencesWithoutChargeVersions;
 exports.updateIncludeInSupplementaryBillingStatus = updateIncludeInSupplementaryBillingStatus;
 exports.updateIncludeInSupplementaryBillingStatusForUnsentBatch = updateIncludeInSupplementaryBillingStatusForUnsentBatch;
 exports.updateIncludeInSupplementaryBillingStatusForSentBatch = updateIncludeInSupplementaryBillingStatusForSentBatch;

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -6,6 +6,7 @@ const bluebird = require('bluebird');
 const service = require('../../../lib/services/service');
 const documentsService = require('../../../lib/services/documents-service');
 const chargeVersionService = require('../../../lib/services/charge-versions');
+const errors = require('../../../lib/errors');
 
 // Repos
 const chargeVersionWorkflowsRepo = require('../../../lib/connectors/repos/charge-version-workflows');
@@ -41,6 +42,11 @@ const getLicenceHolderRole = async chargeVersionWorkflow => {
   const { licenceNumber } = chargeVersionWorkflow.licence;
   const { startDate } = chargeVersionWorkflow.chargeVersion.dateRange;
   const doc = await documentsService.getValidDocumentOnDate(licenceNumber, startDate);
+
+  if (!doc) {
+    throw new errors.NotFoundError(`Current or superseded document not found for ${licenceNumber} on ${startDate}`);
+  }
+
   return {
     chargeVersionWorkflow,
     licenceHolderRole: doc.getRoleOnDate(Role.ROLE_NAMES.licenceHolder, startDate)

--- a/src/modules/licences/controllers/licences.js
+++ b/src/modules/licences/controllers/licences.js
@@ -38,8 +38,24 @@ const getValidLicenceDocumentByDate = async request => {
   return documentsService.getValidDocumentOnDate(licence.licenceNumber, date);
 };
 
+const getLicencesWithoutChargeVersions = async () => {
+  const licences = await licencesService.getLicencesWithoutChargeVersions();
+
+  const promises = licences.map(licence => {
+    return documentsService.getValidDocumentOnDate(licence.licenceNumber, licence.startDate)
+      .then(document => document.roles.find(role => {
+        return role.isRoleName('licenceHolder');
+      }))
+      .then(role => ({ licence, role }));
+  });
+
+  const licencesWithLicenceHolderRole = await Promise.all(promises);
+  return { data: licencesWithLicenceHolderRole };
+};
+
 exports.getLicence = getLicence;
 exports.getLicenceVersions = getLicenceVersions;
 exports.getLicenceAccountsByRefAndDate = getLicenceAccountsByRefAndDate;
 exports.getLicenceDocument = getLicenceDocument;
 exports.getValidLicenceDocumentByDate = getValidLicenceDocumentByDate;
+exports.getLicencesWithoutChargeVersions = getLicencesWithoutChargeVersions;

--- a/src/modules/licences/controllers/licences.js
+++ b/src/modules/licences/controllers/licences.js
@@ -43,9 +43,11 @@ const getLicencesWithoutChargeVersions = async () => {
 
   const promises = licences.map(licence => {
     return documentsService.getValidDocumentOnDate(licence.licenceNumber, licence.startDate)
-      .then(document => document.roles.find(role => {
-        return role.isRoleName('licenceHolder');
-      }))
+      .then(document => {
+        return document
+          ? document.roles.find(role => role.isRoleName('licenceHolder'))
+          : null;
+      })
       .then(role => ({ licence, role }));
   });
 

--- a/src/modules/licences/routes/licences.js
+++ b/src/modules/licences/routes/licences.js
@@ -78,5 +78,14 @@ module.exports = {
         }
       }
     }
+  },
+
+  getLicencesWithoutChargeVersions: {
+    method: 'GET',
+    path: `${pathPrefix}without-charge-versions`,
+    handler: controller.getLicencesWithoutChargeVersions,
+    config: {
+      description: 'Gets the licences and roles for licences without charge versions'
+    }
   }
 };

--- a/test/lib/connectors/repos/licences.js
+++ b/test/lib/connectors/repos/licences.js
@@ -221,4 +221,16 @@ experiment('lib/connectors/repos/licences.js', () => {
       )).to.be.true();
     });
   });
+
+  experiment('.findWithoutChargeVersions', () => {
+    beforeEach(async () => {
+      await licencesRepo.findWithoutChargeVersions('2000-01-01');
+    });
+
+    test('calls raw.multiRow with correct query and params', async () => {
+      const [query, params] = raw.multiRow.lastCall.args;
+      expect(query).to.equal(licenceQueries.getLicencesWithoutChargeVersions);
+      expect(params).to.equal({ startDate: '2000-01-01' });
+    });
+  });
 });

--- a/test/lib/services/documents-service.js
+++ b/test/lib/services/documents-service.js
@@ -66,20 +66,19 @@ experiment('modules/billing/services/documents-service', () => {
 
   experiment('.getValidDocumentOnDate', () => {
     experiment('when no documents are found', async () => {
-      let err;
+      let result;
 
       beforeEach(async () => {
         documentsConnector.getDocuments.resolves([]);
-        const func = () => documentsService.getValidDocumentOnDate(licenceNumber, date);
-        err = await expect(func()).to.reject();
+        result = await documentsService.getValidDocumentOnDate(licenceNumber, date);
       });
 
       test('gets documents for the supplied licence number', async () => {
         expect(documentsConnector.getDocuments.calledWith(licenceNumber)).to.be.true();
       });
 
-      test('throws a not found error', async () => {
-        expect(err).to.be.an.instanceof(NotFoundError);
+      test('returns null', async () => {
+        expect(result).to.equal(null);
       });
     });
 
@@ -153,10 +152,9 @@ experiment('modules/billing/services/documents-service', () => {
         }]);
       });
 
-      test('rejects with a NotFound error', async () => {
-        const func = () => documentsService.getValidDocumentOnDate(licenceNumber, date);
-        const err = await expect(func()).to.reject();
-        expect(err).to.be.an.instanceof(NotFoundError);
+      test('returns null', async () => {
+        const result = await documentsService.getValidDocumentOnDate(licenceNumber, date);
+        expect(result).to.equal(null);
       });
     });
   });

--- a/test/modules/charge-versions/services/charge-version-workflows.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.js
@@ -374,4 +374,29 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
       expect(chargeVersionWorkflowRepo.deleteOne.calledWith(chargeVersionWorkflow.id)).to.be.true();
     });
   });
+
+  experiment('getLicenceHolderRole', () => {
+    experiment('when no document is found for the licence and start date', () => {
+      beforeEach(async () => {
+        documentsService.getValidDocumentOnDate.resolves(null);
+      });
+
+      test('a not found error is thrown', async () => {
+        const result = await expect(chargeVersionWorkflowService.getLicenceHolderRole({
+          licence: {
+            licenceNumber: '123'
+          },
+          chargeVersion: {
+            dateRange: {
+              startDate: '2000-01-01'
+            }
+          }
+        })
+        ).to.reject();
+
+        expect(result.name).to.equal('NotFoundError');
+        expect(result.message).to.equal('Current or superseded document not found for 123 on 2000-01-01');
+      });
+    });
+  });
 });

--- a/test/modules/charge-versions/services/charge-version-workflows.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.js
@@ -382,7 +382,7 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
       });
 
       test('a not found error is thrown', async () => {
-        const result = await expect(chargeVersionWorkflowService.getLicenceHolderRole({
+        result = await expect(chargeVersionWorkflowService.getLicenceHolderRole({
           licence: {
             licenceNumber: '123'
           },

--- a/test/modules/licences/routes/licences.js
+++ b/test/modules/licences/routes/licences.js
@@ -124,4 +124,21 @@ experiment('modules/licences/routes/licences', () => {
       expect(output.statusCode).to.equal(200);
     });
   });
+
+  experiment('.getLicencesWithoutChargeVersions', () => {
+    let server, request;
+
+    beforeEach(async () => {
+      request = {
+        method: 'GET',
+        url: '/water/1.0/licences/without-charge-versions'
+      };
+      server = await testHelpers.createServerForRoute(routes.getLicencesWithoutChargeVersions, false);
+    });
+
+    test('responds to the get request', async () => {
+      const output = await server.inject(request);
+      expect(output.statusCode).to.equal(200);
+    });
+  });
 });


### PR DESCRIPTION
WATER-2888

Adds the start date for fetching licences without charge version to the
config file.

Adds SQL query to find all licences that have no charge versions where
the licence version is current or superseded.

Adds new route, controller handler and service code to combine licences
with licence holder role.