### PR TITLE
Use shared knex query mapper from helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
       }
     },
     "@envage/water-abstraction-helpers": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.3.4.tgz",
-      "integrity": "sha512-JgAyXLsGh1ew4uZu52jcqIhlkJNXgeMCsO9/E7k+QEYqhafg4RzZurWlqjRdlIvsPV14ELbg0XOX6ve5QmYj0w==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.3.6.tgz",
+      "integrity": "sha512-SrA3DW81Jzd+U/ZcvFSAo7G8kd2yPL12xCfiIuhlRr7ia9v0G5Ah0uLE2jDX+/4RWqU/44t7Ywc9Xu3E+DCxCw==",
       "requires": {
         "@hapi/joi": "^15.1.1",
         "airbrake-js": "^1.6.8",
@@ -5472,7 +5472,7 @@
         },
         "jsonwebtoken": {
           "version": "8.2.1",
-          "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
           "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
           "requires": {
             "jws": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^5.0.0",
-    "@envage/water-abstraction-helpers": "^4.3.4",
+    "@envage/water-abstraction-helpers": "^4.3.6",
     "@hapi/boom": "^7.4.11",
     "@hapi/catbox-redis": "^6.0.1",
     "@hapi/good": "^8.2.4",

--- a/src/lib/connectors/db.js
+++ b/src/lib/connectors/db.js
@@ -1,48 +1,8 @@
 'use strict';
 
+const { db } = require('@envage/water-abstraction-helpers');
 const knex = require('./knex');
-
-/**
- * Allows a query to be run with same arguments
- * as pg.pool.query(query, params)
- * The query and params are altered to make them
- * compatible with knex.raw
- *
- * @param {String} sqlQuery - bound params are specified as $1, $2 etc.
- * @param {Array} [params] - array params
- * @return {Promise<Object>} query result
- */
-const query = (sqlQuery, params = []) => {
-  if (params.length === 0) {
-    return knex.knex.raw(sqlQuery);
-  }
-
-  const data = params.reduce((acc, param, i) => {
-    // This is the parameter name for the knex query - in knex
-    // parameters are passed as a hash
-    const key = `param_${i}`;
-
-    // This regex is looking for a pattern such as $4 in the query
-    // as this is how bound parameters are specified in the underlying
-    // pg library.
-    // It is made up of:
-    // \\$ a dollar symbol with the necessary escaping since $ is a special char in regex
-    // ${i + 1} is the integer to search for
-    // (?![0-9]) is a negative lookahead, and ensures the integer isn't followed by another integer
-    // - this avoids e.g. $11 being a match when we are replacing $1
-    const r = new RegExp(`\\$${i + 1}(?![0-9])`, 'g');
-
-    return {
-      params: {
-        ...acc.params,
-        [key]: param
-      },
-      sqlQuery: acc.sqlQuery.replace(r, `:${key}`)
-    };
-  }, { sqlQuery, params: {} });
-
-  return knex.knex.raw(data.sqlQuery, data.params);
-};
+const query = (...args) => knex.knex.raw(...db.mapQueryToKnex(...args));
 
 exports.pool = {
   query


### PR DESCRIPTION
Moves the logic for mapping pool.query queries to knex.raw from service to helpers, since it is used in multiple projects.