### PR TITLE
Bugfix: Marking billing volumes are errored not required.

### DIFF
--- a/src/lib/connectors/repos/billing-volumes.js
+++ b/src/lib/connectors/repos/billing-volumes.js
@@ -142,12 +142,12 @@ const updateByBatchId = async (billingBatchId, changes) => {
  * Marks all records as errored by batch ID
  * @param {String} billingBatchId
  */
-const markVolumesAsErrored = async (billingBatchId) => {
+const markVolumesAsErrored = async (billingBatchId, options = {}) => {
   const result = await BillingVolume
     .where('billing_batch_id', billingBatchId)
     .save({
       errored_on: new Date()
-    }, { method: 'update' });
+    }, { method: 'update', ...options });
   return result.toJSON();
 };
 

--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -129,7 +129,7 @@ const onFailedHandler = async (job, err) => {
   if (helpers.isFinalAttempt(job)) {
     try {
       logger.error(`Transaction with id ${transactionId} not generated in CM after ${job.attemptsMade} attempts, marking batch as errored ${batchId}`);
-      await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToPrepareTransactions);
+      await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToCreateCharge);
     } catch (error) {
       logger.error(`Unable to set batch status ${batchId}`, error);
     }

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -155,7 +155,7 @@ const setStatus = (batchId, status) =>
 const setErrorStatus = async (batchId, errorCode) => {
   logger.error(`Batch ${batchId} failed with error code ${errorCode}`);
   return Promise.all([
-    newRepos.billingVolumes.markVolumesAsErrored(batchId),
+    newRepos.billingVolumes.markVolumesAsErrored(batchId, { require: false }),
     newRepos.billingBatches.update(batchId, { status: Batch.BATCH_STATUS.error, errorCode }),
     licencesService.updateIncludeInSupplementaryBillingStatusForUnsentBatch(batchId)
   ]);

--- a/test/lib/connectors/repos/billing-volumes.js
+++ b/test/lib/connectors/repos/billing-volumes.js
@@ -321,7 +321,7 @@ experiment('lib/connectors/repos/billing-volumes', () => {
 
   experiment('.markVolumesAsErrored', () => {
     beforeEach(async () => {
-      await billingVolumes.markVolumesAsErrored('test-batch-id');
+      await billingVolumes.markVolumesAsErrored('test-batch-id', { require: false });
     });
 
     test('calls .where to find only the rows in the relevant batch', async () => {
@@ -335,6 +335,12 @@ experiment('lib/connectors/repos/billing-volumes', () => {
       const [updates] = stub.save.lastCall.args;
       expect(Object.keys(updates)).to.only.include('errored_on');
       expect(updates.errored_on instanceof Date).to.be.true();
+    });
+
+    test('passes in expected options', async () => {
+      const [, options] = stub.save.lastCall.args;
+      expect(options.method).to.equal('update');
+      expect(options.require).to.be.false();
     });
 
     test('calls .toJSON on the collection', async () => {

--- a/test/modules/billing/jobs/create-charge.js
+++ b/test/modules/billing/jobs/create-charge.js
@@ -447,7 +447,7 @@ experiment('modules/billing/jobs/create-charge', () => {
 
       test('the batch is not updated', async () => {
         expect(batchService.setErrorStatus.calledWith(
-          job.data.batchId, BATCH_ERROR_CODE.failedToPrepareTransactions
+          job.data.batchId, BATCH_ERROR_CODE.failedToCreateCharge
         )).to.be.true();
       });
     });

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -520,6 +520,12 @@ experiment('modules/billing/services/batch-service', () => {
       await batchService.setErrorStatus('batch-id', 10);
     });
 
+    test('calls billingVolumes.markVolumesAsErrored() with correct params', async () => {
+      const [id, data] = newRepos.billingVolumes.markVolumesAsErrored.lastCall.args;
+      expect(id).to.equal('batch-id');
+      expect(data).to.equal({ require: false });
+    });
+
     test('calls billingBatches.update() with correct params', async () => {
       const [id, data] = newRepos.billingBatches.update.lastCall.args;
       expect(id).to.equal('batch-id');


### PR DESCRIPTION
WATER-2991

Updates call to billing volumes service when marking batch as errored making the update not required as this throws an error when no rows are updated.