### PR TITLE
Add missing await in CM refresh service

### DIFF
--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -190,7 +190,7 @@ const updateInvoices = async (batch, cmResponse) => {
 
     // Note: for now we don't need to expect invoices not in our DB
     // this will likely change when the CM implements rebilling
-    updateInvoice(batch, invoiceMap.get(key), cmInvoiceSummary, cmTransactions);
+    await updateInvoice(batch, invoiceMap.get(key), cmInvoiceSummary, cmTransactions);
   }
 };
 


### PR DESCRIPTION
Adds a missing await to ensure CM refresh processing is complete when batch is marked as `ready`