### PR TITLE
Respect charge version workflow date_deleted when processing supplementary billing

### DIFF
--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -21,6 +21,11 @@ join (
     and i.is_de_minimis=false
 ) t on t.licence_id=l.licence_id and t.financial_year_ending>= b.from_financial_year_ending and t.financial_year_ending<=b.to_financial_year_ending
 where b.billing_batch_id=:batchId
+and l.licence_id not in (
+  select cvw.licence_id 
+  from water.charge_version_workflows cvw
+  where cvw.date_deleted is null
+)
 order by t.date_created asc
 `;
 

--- a/src/lib/connectors/repos/queries/charge-versions.js
+++ b/src/lib/connectors/repos/queries/charge-versions.js
@@ -24,7 +24,11 @@ from (
     and l.suspend_from_billing = FALSE
     and cv.status='current'
     and (cv.change_reason_id is null or cr.type = 'new_chargeable_charge_version')
-    and l.licence_id not in (select licence_id from water.charge_version_workflows)
+    and l.licence_id not in (
+      select cvw.licence_id 
+      from water.charge_version_workflows cvw
+      where cvw.date_deleted is null
+    )
 ) cv
   left join (
     select la.* from water.licence_agreements la 


### PR DESCRIPTION
Charge version workflows now have a `date_deleted` column for soft deleting.

This PR modifies SQL queries so that deleted charge version workflows are ignored during the billing process, and fixes a bug where they were not accounted for at all in supplementary billing.