### PR TITLE
Fix: Makes approving billing volumes not required

### DIFF
--- a/src/lib/connectors/repos/billing-volumes.js
+++ b/src/lib/connectors/repos/billing-volumes.js
@@ -131,10 +131,10 @@ const deleteByBatchIdAndLicenceId = (billingBatchId, licenceId) =>
  * @param {String} billingBatchId
  * @param {Object} changes
  */
-const updateByBatchId = async (billingBatchId, changes, options = {}) => {
+const updateByBatchId = async (billingBatchId, changes) => {
   const result = await BillingVolume
     .where('billing_batch_id', billingBatchId)
-    .save(changes, { method: 'update', ...options });
+    .save(changes, { method: 'update', require: false });
   return result.toJSON();
 };
 

--- a/src/lib/connectors/repos/billing-volumes.js
+++ b/src/lib/connectors/repos/billing-volumes.js
@@ -131,10 +131,10 @@ const deleteByBatchIdAndLicenceId = (billingBatchId, licenceId) =>
  * @param {String} billingBatchId
  * @param {Object} changes
  */
-const updateByBatchId = async (billingBatchId, changes) => {
+const updateByBatchId = async (billingBatchId, changes, options = {}) => {
   const result = await BillingVolume
     .where('billing_batch_id', billingBatchId)
-    .save(changes, { method: 'update' });
+    .save(changes, { method: 'update', ...options });
   return result.toJSON();
 };
 

--- a/src/modules/billing/services/billing-volumes-service.js
+++ b/src/modules/billing/services/billing-volumes-service.js
@@ -80,7 +80,7 @@ const assertNoBillingVolumesWithTwoPartError = async batch => {
  */
 const approveVolumesForBatch = async batch => {
   await assertNoBillingVolumesWithTwoPartError(batch);
-  return billingVolumesRepo.updateByBatchId(batch.id, { isApproved: true });
+  return billingVolumesRepo.updateByBatchId(batch.id, { isApproved: true }, { require: false });
 };
 
 /**

--- a/test/lib/connectors/repos/billing-volumes.js
+++ b/test/lib/connectors/repos/billing-volumes.js
@@ -301,7 +301,7 @@ experiment('lib/connectors/repos/billing-volumes', () => {
     };
 
     beforeEach(async () => {
-      await billingVolumes.updateByBatchId('test-batch-id', changes);
+      await billingVolumes.updateByBatchId('test-batch-id', changes, { require: false });
     });
 
     test('calls .where to find only the rows in the relevant batch', async () => {
@@ -312,6 +312,12 @@ experiment('lib/connectors/repos/billing-volumes', () => {
 
     test('saves the changes', async () => {
       expect(stub.save.calledWith(changes)).to.be.true();
+    });
+
+    test('passes in expected options', async () => {
+      const [, options] = stub.save.lastCall.args;
+      expect(options.method).to.equal('update');
+      expect(options.require).to.be.false();
     });
 
     test('calls .toJSON on the collection', async () => {

--- a/test/lib/connectors/repos/billing-volumes.js
+++ b/test/lib/connectors/repos/billing-volumes.js
@@ -301,7 +301,7 @@ experiment('lib/connectors/repos/billing-volumes', () => {
     };
 
     beforeEach(async () => {
-      await billingVolumes.updateByBatchId('test-batch-id', changes, { require: false });
+      await billingVolumes.updateByBatchId('test-batch-id', changes);
     });
 
     test('calls .where to find only the rows in the relevant batch', async () => {


### PR DESCRIPTION
WATER-3069

* If all billing volumes are removed in Review stage, will not throw error