### PR TITLE
Bugfix 1 of many for CMV2 migration

### DIFF
--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -35,7 +35,7 @@ const getAllCmTransactionsForInvoice = async (cmBillRunId, invoiceId) => {
         ...transaction,
         transactionReference: invoice.transactionReference,
         isDeminimis: invoice.deminimisInvoice,
-        licenceNumber: invoice.licences[0].licenceNumber
+        licenceNumber: lic.licenceNumber
       };
     })).flat();
   } catch (error) {


### PR DESCRIPTION
For invoices that encompass multiple licences, transactions do not appear under the correct licences. All transactions are being grouped under one licence.