### PR TITLE
Fix issue with invoice net total validation/mapping

### DIFF
--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { uniq, get, flatMap } = require('lodash');
+const { uniq, get, flatMap, isNull } = require('lodash');
 
 const {
   assertIsInstanceOf, assertIsArrayOfType,
@@ -8,7 +8,8 @@ const {
   assertNullableString, assertNullableObject,
   assertNullableInteger, assertNullableId,
   assertNullablePositiveOrZeroInteger,
-  assertNullableNegativeOrZeroInteger
+  assertNullableNegativeOrZeroInteger,
+  assertIsNullableBoolean
 } = require('./validators');
 
 const Address = require('./address');
@@ -198,7 +199,7 @@ class Invoice extends Totals {
    */
   set netTotal (netTotal) {
     assertNullableInteger(netTotal);
-    this._netTotal = netTotal;
+    this._netTotal = isNull(netTotal) ? null : parseInt(netTotal);
   }
 
   get netTotal () {
@@ -210,7 +211,7 @@ class Invoice extends Totals {
    * @param {Boolean} isCredit
    */
   set isCredit (isCredit) {
-    assertIsBoolean(isCredit);
+    assertIsNullableBoolean(isCredit);
     this._isCredit = isCredit;
   }
 

--- a/src/modules/billing/mappers/invoice.js
+++ b/src/modules/billing/mappers/invoice.js
@@ -25,7 +25,7 @@ const dbToModelMapper = createMapper()
     'legacyId',
     'metadata'
   )
-  .map('netAmount').to('netTotal', netAmount => parseInt(netAmount))
+  .map('netAmount').to('netTotal')
   .map('billingInvoiceId').to('id')
   .map('invoiceAccountId').to('invoiceAccount', invoiceAccountId => new InvoiceAccount(invoiceAccountId))
   .map('invoiceAccountNumber').to('invoiceAccount.accountNumber')

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -223,7 +223,12 @@ experiment('lib/models/invoice', () => {
 
     test('can be set to an integer string', async () => {
       invoice.netTotal = '12345';
-      expect(invoice.netTotal).to.equal('12345');
+      expect(invoice.netTotal).to.equal(12345);
+    });
+
+    test('can be set to null', async () => {
+      invoice.netTotal = null;
+      expect(invoice.netTotal).to.be.null();
     });
 
     test('throws an error if set to a non-integer', async () => {


### PR DESCRIPTION
Fixes an issue where validation added to `netTotal` property of invoice model could not cope with `null` which is allowed in the DB.