### PR TITLE
Bugfix/min charge cm transactions

### DIFF
--- a/src/modules/billing/mappers/transaction.js
+++ b/src/modules/billing/mappers/transaction.js
@@ -240,7 +240,7 @@ const modelToChargeModule = (batch, invoice, invoiceLicence, transaction) => {
     authorisedDays: transaction.authorisedDays,
     volume: transaction.volume,
     twoPartTariff: transaction.isTwoPartTariffSupplementary,
-    compensationCharge: transaction.isCompensationCharge,
+    compensationCharge: transaction.isCompensationCharge === 'true', // TODO remove this once CM have fixed the issue. https://defra-digital.slack.com/archives/G01927WKA77/p1617281188003900
     ...mapAgreementsToChargeModule(transaction),
     customerReference: invoice.invoiceAccount.accountNumber,
     lineDescription: transaction.description,
@@ -248,7 +248,7 @@ const modelToChargeModule = (batch, invoice, invoiceLicence, transaction) => {
     batchNumber: batch.id,
     ...mapChargeElementToChargeModuleTransaction(transaction.chargeElement),
     ...mapLicenceToChargeElementTransaction(invoiceLicence.licence),
-    newLicence: transaction.isNewLicence
+    subjectToMinimumCharge: transaction.isNewLicence
   };
 };
 
@@ -270,10 +270,10 @@ const cmToModelMapper = createMapper()
   .map('chargeValue').to('value')
   .map('credit').to('isCredit')
   .map('lineDescription').to('description')
-  .map('compensationCharge').to('isCompensationCharge')
+  .map('compensationCharge').to('isCompensationCharge', val => ['true', true].includes(val)) // TODO remove this once CM have fixed the issue. https://defra-digital.slack.com/archives/G01927WKA77/p1617281188003900
   .map('minimumChargeAdjustment').to('isMinimumCharge')
   .map('deminimis').to('isDeMinimis')
-  .map('newLicence').to('isNewLicence')
+  .map('subjectToMinimumCharge').to('isNewLicence')
   .map('twoPartTariff').to('isTwoPartTariffSupplementary', mapIsTwoPartTariffSupplementary)
   .map('transactionStatus').to('status', mapCMTransactionStatus)
   .map('calculation.WRLSChargingResponse.sourceFactor').to('calcSourceFactor')

--- a/src/modules/billing/mappers/transaction.js
+++ b/src/modules/billing/mappers/transaction.js
@@ -240,7 +240,7 @@ const modelToChargeModule = (batch, invoice, invoiceLicence, transaction) => {
     authorisedDays: transaction.authorisedDays,
     volume: transaction.volume,
     twoPartTariff: transaction.isTwoPartTariffSupplementary,
-    compensationCharge: transaction.isCompensationCharge === 'true', // TODO remove this once CM have fixed the issue. https://defra-digital.slack.com/archives/G01927WKA77/p1617281188003900
+    compensationCharge: ['true', true].includes(transaction.isCompensationCharge), // TODO remove this once CM have fixed the issue. https://defra-digital.slack.com/archives/G01927WKA77/p1617281188003900
     ...mapAgreementsToChargeModule(transaction),
     customerReference: invoice.invoiceAccount.accountNumber,
     lineDescription: transaction.description,

--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -110,7 +110,7 @@ const mapTransaction = (invoice, transactionMap, cmTransaction) => {
       });
   } else {
     // Create a new min charge model and add to heirarchy
-    const newTransaction = transactionMapper.cmToModel(cmTransaction);
+    const newTransaction = transactionMapper.cmToModel({ ...cmTransaction, twoPartTariff: false });
     invoice
       .getInvoiceLicenceByLicenceNumber(cmTransaction.licenceNumber)
       .transactions

--- a/test/modules/billing/mappers/transaction.js
+++ b/test/modules/billing/mappers/transaction.js
@@ -452,7 +452,7 @@ experiment('modules/billing/mappers/transaction', () => {
             licenceNumber: '01/123/ABC',
             region: 'A',
             areaCode: 'ARCA',
-            newLicence: false
+            subjectToMinimumCharge: false
           });
         });
 
@@ -537,7 +537,7 @@ experiment('modules/billing/mappers/transaction', () => {
       compensationCharge: false,
       minimumChargeAdjustment: true,
       deminimis: false,
-      newLicence: false
+      subjectToMinimumCharge: false
     };
 
     beforeEach(async () => {
@@ -556,7 +556,7 @@ experiment('modules/billing/mappers/transaction', () => {
       expect(result.isCompensationCharge).to.equal(cmData.compensationCharge);
       expect(result.isMinimumCharge).to.equal(cmData.minimumChargeAdjustment);
       expect(result.isDeMinimis).to.equal(cmData.deminimis);
-      expect(result.isNewLicence).to.equal(cmData.newLicence);
+      expect(result.isNewLicence).to.equal(cmData.subjectToMinimumCharge);
     });
   });
 });


### PR DESCRIPTION
Deals with the change of the new licence flag on the CM side.

It used to be 'newLicence'.

It is now 'subjectToMinimumCharge'.