### PR TITLE
Feat: Auth and Billable days set to 0 for TPT supplementary transactions

### DIFF
--- a/src/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/src/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -32,6 +32,11 @@ const agreementAppliesToTransaction = (agreement, purpose) => {
   return isCanalApplied || isTwoPartTariffApplied(agreement, purpose);
 };
 
+const getBillableDays = (absPeriod, startDate, endDate, isTwoPartTariffSupplementary) =>
+  isTwoPartTariffSupplementary
+    ? 0
+    : helpers.charging.getBillableDays(absPeriod, startDate, endDate);
+
 /**
  * Creates a Transaction model
  * @param {DateRange} chargePeriod - charge period for this charge element - taking time-limits into account
@@ -48,13 +53,12 @@ const createTransaction = (chargePeriod, chargeElement, agreements, financialYea
   const absPeriod = chargeElement.abstractionPeriod.toJSON();
   const transaction = new Transaction();
   transaction.fromHash({
-    ...omit(flags, 'isMinimumCharge'),
     chargeElement,
-    agreements: agreements.filter(agreement => agreementAppliesToTransaction(agreement, chargeElement.purposeUse)),
     chargePeriod,
+    agreements: agreements.filter(agreement => agreementAppliesToTransaction(agreement, chargeElement.purposeUse)),
     status: Transaction.statuses.candidate,
-    authorisedDays: helpers.charging.getBillableDays(absPeriod, financialYear.start.format(DATE_FORMAT), financialYear.end.format(DATE_FORMAT)),
-    billableDays: helpers.charging.getBillableDays(absPeriod, chargePeriod.startDate, chargePeriod.endDate),
+    authorisedDays: getBillableDays(absPeriod, financialYear.start.format(DATE_FORMAT), financialYear.end.format(DATE_FORMAT), flags.isTwoPartTariffSupplementary),
+    billableDays: getBillableDays(absPeriod, chargePeriod.startDate, chargePeriod.endDate, flags.isTwoPartTariffSupplementary),
     volume: billingVolume ? billingVolume.volume : chargeElement.volume,
     isTwoPartTariffSupplementary: flags.isTwoPartTariffSupplementary || false,
     isCompensationCharge: flags.isCompensationCharge || false,

--- a/src/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/src/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { flatMap, get, omit } = require('lodash');
+const { flatMap, get } = require('lodash');
 
 const MomentRange = require('moment-range');
 const moment = MomentRange.extendMoment(require('moment'));

--- a/test/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/test/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -91,6 +91,11 @@ experiment('modules/billing/services/charge-processor-service/transactions-proce
         expect(transactions[0].isTwoPartTariffSupplementary).to.equal(true);
         expect(transactions[0].description).to.equal('Second Part Spray Irrigation Direct Charge at Test Description');
       });
+
+      test('authorised and billable days are set to 0', () => {
+        expect(transactions[0].authorisedDays).to.equal(0);
+        expect(transactions[0].billableDays).to.equal(0);
+      });
     });
 
     experiment('transaction charge periods', () => {


### PR DESCRIPTION
WATER-3099

* Updates calculation for authorised and billable days when creating a transaction