### PR TITLE
bugfix - Charge element model annual quantity set to not nullable

### DIFF
--- a/src/lib/models/charge-element.js
+++ b/src/lib/models/charge-element.js
@@ -89,7 +89,7 @@ class ChargeElement extends Model {
   }
 
   set authorisedAnnualQuantity (quantity) {
-    validators.assertNullableQuantity(quantity);
+    validators.assertQuantity(quantity);
     this._authorisedAnnualQuantity = parseFloat(quantity);
   }
 


### PR DESCRIPTION
bugfix/ce-annual-qty
-- reverts CE model annual quantity to not nullable