### PR TITLE
Update cm-refresh-service.js

### DIFF
--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -92,7 +92,8 @@ const getTransactionMap = invoice => {
 const mapTransaction = (invoice, transactionMap, cmTransaction) => {
   // Update existing transaction
   if (transactionMap.has(cmTransaction.id)) {
-    const { sourceFactor, seasonFactor, lossFactor, sucFactor, abatementAdjustment, s127Agreement, eiucFactor, eiucSourceFactor } = cmTransaction.calculation.WRLSChargingResponse;
+    const calculation = get(cmTransaction, 'calculation.WRLSChargingResponse', {});
+    const { sourceFactor, seasonFactor, lossFactor, sucFactor, abatementAdjustment, s127Agreement, eiucFactor, eiucSourceFactor } = calculation;
 
     return transactionMap
       .get(cmTransaction.id)


### PR DESCRIPTION
Occasionally, a CM will return a response where `calculation` is not defined. If/when this happens, the service fails as it attempts to destructure an undefined value.

This gets around it by using lodash.get()