### PR TITLE
Feat/water 3011 return kpis

### DIFF
--- a/src/lib/connectors/repos/queries/events.js
+++ b/src/lib/connectors/repos/queries/events.js
@@ -21,7 +21,12 @@ from (
     date_part('month', date.ts) as month,
     date_part('year', date.ts) as year
   from ( 
-    select * from generate_series('2018-10-31', now(), '1 month') as ts
+    select * from generate_series(
+      '2018-10-31', 
+      -- last day of current month
+      (date_trunc('month', now()::date) + interval '1 month' - interval '1 day')::date,
+      '1 month'
+    ) as ts
   ) as date
 ) as m
 left join (

--- a/src/lib/connectors/repos/queries/events.js
+++ b/src/lib/connectors/repos/queries/events.js
@@ -8,20 +8,55 @@ SELECT * FROM water.scheduled_notification
     `;
 
 exports.getKPIReturnsMonthlyData = `
-SELECT date_part('month', created)::integer AS month, 
-date_part('year', created)::integer AS year,
-SUM(CASE 
-  WHEN subtype = 'pdf.return_form' THEN 1
-  WHEN subtype = 'paperReturnForms' THEN jsonb_array_length(licences)
-  ELSE 0
-END)::integer AS request,
-SUM(CASE WHEN "type" = 'return' and subtype <> 'pdf.return_form' THEN 1 ELSE 0 END)::integer AS return, 
-CASE WHEN date_part('year', created)::integer = date_part('year', CURRENT_DATE) THEN true ELSE false END AS current_year
-FROM water.events 
-WHERE "type" = 'return' OR subtype IN ('pdf.return_form', 'paperReturnForms')      
-AND date_part('year', created) = date_part('year', CURRENT_DATE)  
-GROUP BY  current_year, month
-ORDER BY current_year asc, month desc;`;
+select 
+  m.month, 
+  m.year, 
+  coalesce(sum(e.is_return), 0)::integer as return_count, 
+  coalesce(sum(e.is_paper_form), 0)::integer as paper_form_count,
+  coalesce(sum(e.sent_notification_count), 0)::integer as sent_notification_count,
+  m.year = date_part('year', NOW()) as current_year
+from (
+  -- Gets a series of months beginning when WRLS began collecting returns
+  select 
+    date_part('month', date.ts) as month,
+    date_part('year', date.ts) as year
+  from ( 
+    select * from generate_series('2018-10-31', now(), '1 month') as ts
+  ) as date
+) as m
+left join (
+  -- Gets list of returns/return PDF form events with month and year  
+  select
+    e.event_id,
+    date_part('year', e.created) as year,
+    date_part('month', e.created) as month,
+    case
+      when e.type='return' then 1 else 0 end
+      as is_return,
+    case
+      when e.subtype in ('pdf.return_form', 'paperReturnForms') then 1 else 0 end
+      as is_paper_form,
+    sn.sent_notification_count
+  from water.events e 
+  left join (
+    -- Gets successfully sent notification count by event ID 
+    select sn.event_id, count(id) as sent_notification_count 
+      from water.scheduled_notification sn
+      where 
+        sn.notify_id is not null
+        and sn.notify_status in ('accepted', 'delivered', 'sending', 'accepted', 'received')
+        and sn.event_id is not null
+        group by sn.event_id
+  ) sn on e.event_id=sn.event_id
+  where 
+    (
+      e.type='return'
+      or e.subtype in ('pdf.return_form', 'paperReturnForms')
+    )
+    and e.status in ('sent', 'completed')
+  ) e on m.month=e.month and m.year=e.year
+  group by m.year, m.month
+`;
 
 exports.getKPILicenceNamesData = `
 SELECT date_part('month', created)::integer AS month, 

--- a/src/lib/connectors/returns.js
+++ b/src/lib/connectors/returns.js
@@ -4,7 +4,6 @@ const helpers = require('@envage/water-abstraction-helpers');
 const urlJoin = require('url-join');
 const { URL } = require('url');
 const { chunk, flatMap } = require('lodash');
-const querystring = require('querystring');
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 

--- a/src/lib/connectors/returns.js
+++ b/src/lib/connectors/returns.js
@@ -126,19 +126,6 @@ const getLinesForReturn = async ret => {
 };
 
 /**
- * Gets the returns KPI data by cycle within the specified parameters
- * @param {Date} startDate
- * @param {Date} endDate
- * @param {Boolean} isSummer
- * @returns Object
- */
-const getKPIReturnsByCycle = async (startDate, endDate, isSummer) => {
-  const qs = querystring.stringify({ startDate, endDate, isSummer });
-  const url = urlJoin(config.services.returns, `/kpi/licencesBySeason?${qs}`);
-  return helpers.serviceRequest.get(url);
-};
-
-/**
  * Gets a report of return cycles with data on number of returns in each status
  *
  * @return {Promise<Object>}
@@ -183,7 +170,6 @@ exports.getCurrentDueReturns = getCurrentDueReturns;
 exports.getServiceVersion = getServiceVersion;
 exports.getReturnsForLicence = getReturnsForLicence;
 exports.getLinesForReturn = getLinesForReturn;
-exports.getKPIReturnsByCycle = getKPIReturnsByCycle;
 
 if (config.isAcceptanceTestTarget) {
   exports.deleteAcceptanceTestData = deleteAcceptanceTestData;

--- a/src/modules/kpi-reporting/controller.js
+++ b/src/modules/kpi-reporting/controller.js
@@ -1,18 +1,11 @@
 'use-strict';
 
-const helpers = require('@envage/water-abstraction-helpers');
 const dataService = require('./services/data-service');
 
 const mappers = require('./lib/mappers');
 
-const getReturnCycles = async () => {
-// get the last 2 returns cycles parameters
-  return helpers.returns.date.createReturnCycles().slice(-2);
-};
-
 const collectKpiData = async () => {
-  const returnCycles = await getReturnCycles();
-  const [registrations, delegatedAccess, returnsMonthly, returnsCycle1, returnsCycle2, licenceNames] = await Promise.allSettled([
+  const [registrations, delegatedAccess, returnsMonthly, returnCycles, licenceNames] = await Promise.allSettled([
     // Registrations data from IDM
     dataService.getIDMRegistrationsData(),
     // Delegated access - CRM 1.0
@@ -20,14 +13,13 @@ const collectKpiData = async () => {
     // Returns Monthly data - events table
     dataService.getReturnsDataByMonth(),
     // Returns by cycle for last 2 cycles
-    dataService.getReturnsDataByCycle(returnCycles[1].startDate, returnCycles[1].endDate, returnCycles[1].isSummer),
-    dataService.getReturnsDataByCycle(returnCycles[0].startDate, returnCycles[0].endDate, returnCycles[0].isSummer),
+    dataService.getReturnCycles(),
     dataService.getLicenceNamesData()
   ]).then(responses => {
     return responses.map(response => response.status === 'fulfilled' ? response.value : null);
   });
 
-  return { returnCycles, registrations, delegatedAccess, returnsMonthly, returnsCycle1, returnsCycle2, licenceNames };
+  return { returnCycles, registrations, delegatedAccess, returnsMonthly, licenceNames };
 };
 
 /**
@@ -43,17 +35,10 @@ const getKpiData = async (request) => {
       registrations: dataOrEmpty(kpiData.registrations),
       delegatedAccess: dataOrEmpty(kpiData.delegatedAccess),
       returnsMonthly: dataOrEmpty(kpiData.returnsMonthly, mappers.mapReturnsDataMonthly),
-      returnsCycle1: getReturnsCycleData(kpiData.returnsCycle1, kpiData.returnCycles[1], {}),
-      returnsCycle2: getReturnsCycleData(kpiData.returnsCycle2, kpiData.returnCycles[0], {}),
+      returnsCycles: kpiData.returnCycles,
       licenceNames: dataOrEmpty(kpiData.licenceNames, mappers.mapLicenceNamesData)
     }
   };
-};
-
-const getReturnsCycleData = (data, returnCycle) => {
-  return data
-    ? mappers.mapReturnsDataByCycle(data, returnCycle)
-    : {};
 };
 
 const getEmptyResponse = () => ({ totals: { allTime: 0, ytd: 0 }, monthly: [] });

--- a/src/modules/kpi-reporting/controller.js
+++ b/src/modules/kpi-reporting/controller.js
@@ -35,7 +35,7 @@ const getKpiData = async (request) => {
       registrations: dataOrEmpty(kpiData.registrations),
       delegatedAccess: dataOrEmpty(kpiData.delegatedAccess),
       returnsMonthly: dataOrEmpty(kpiData.returnsMonthly, mappers.mapReturnsDataMonthly),
-      returnsCycles: kpiData.returnCycles || [],
+      returnCycles: kpiData.returnCycles || [],
       licenceNames: dataOrEmpty(kpiData.licenceNames, mappers.mapLicenceNamesData)
     }
   };

--- a/src/modules/kpi-reporting/controller.js
+++ b/src/modules/kpi-reporting/controller.js
@@ -35,7 +35,7 @@ const getKpiData = async (request) => {
       registrations: dataOrEmpty(kpiData.registrations),
       delegatedAccess: dataOrEmpty(kpiData.delegatedAccess),
       returnsMonthly: dataOrEmpty(kpiData.returnsMonthly, mappers.mapReturnsDataMonthly),
-      returnsCycles: kpiData.returnCycles,
+      returnsCycles: kpiData.returnCycles || [],
       licenceNames: dataOrEmpty(kpiData.licenceNames, mappers.mapLicenceNamesData)
     }
   };

--- a/src/modules/kpi-reporting/lib/mappers.js
+++ b/src/modules/kpi-reporting/lib/mappers.js
@@ -13,9 +13,10 @@ const mapReturnsDataByCycle = (data, returnCycle) => {
 
 const mapReturnsDataMonthly = data => {
   return data.reduce((acc, row) => {
-    acc.totals.allTime = acc.totals.allTime + row.returnCount;
-    acc.totals.ytd = acc.totals.ytd + (row.currentYear ? row.returnCount : 0);
-    if (row.currentYear) { // row.month - 1 to mamtch the string array of months starting with index of 0
+    acc.totals.allTime += row.returnCount;
+    if (row.currentYear) {
+      acc.totals.ytd += row.returnCount;
+      // row.month - 1 to mamtch the string array of months starting with index of 0
       acc.monthly.push({ ...row, month: months[(row.month - 1)], currentYear: row.year });
     }
     return acc;

--- a/src/modules/kpi-reporting/lib/mappers.js
+++ b/src/modules/kpi-reporting/lib/mappers.js
@@ -13,8 +13,8 @@ const mapReturnsDataByCycle = (data, returnCycle) => {
 
 const mapReturnsDataMonthly = data => {
   return data.reduce((acc, row) => {
-    acc.totals.allTime = acc.totals.allTime + row.return;
-    acc.totals.ytd = acc.totals.ytd + (row.currentYear ? row.return : 0);
+    acc.totals.allTime = acc.totals.allTime + row.returnCount;
+    acc.totals.ytd = acc.totals.ytd + (row.currentYear ? row.returnCount : 0);
     if (row.currentYear) { // row.month - 1 to mamtch the string array of months starting with index of 0
       acc.monthly.push({ ...row, month: months[(row.month - 1)], currentYear: row.year });
     }

--- a/src/modules/kpi-reporting/services/data-service.js
+++ b/src/modules/kpi-reporting/services/data-service.js
@@ -41,8 +41,15 @@ const getReturnsDataByMonth = async () => {
  */
 const getReturnCycles = async refDate => {
   const startDate = moment(refDate).subtract(729, 'day').format('YYYY-MM-DD');
-  const { data } = await returns.getReturnsCyclesReport(startDate);
-  return data.slice(0, 2);
+  try {
+    const { data } = await returns.getReturnsCyclesReport(startDate);
+    return data.slice(0, 2);
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return null;
+    }
+    throw err;
+  }
 };
 
 module.exports.getCRMDelegatedAccessData = getCRMDelegatedAccessData;

--- a/src/modules/kpi-reporting/services/data-service.js
+++ b/src/modules/kpi-reporting/services/data-service.js
@@ -1,3 +1,6 @@
+'use strict';
+
+const moment = require('moment');
 
 const crm = require('../../../lib/connectors/crm/kpi-reporting');
 const idm = require('../../../lib/connectors/idm/kpi-reporting');
@@ -31,20 +34,19 @@ const getReturnsDataByMonth = async () => {
   return data;
 };
 
-const getReturnsDataByCycle = async (startDate, endDate, isSummer) => {
-  try {
-    const { data: [data] } = await returns.getKPIReturnsByCycle(startDate, endDate, isSummer);
-    return data;
-  } catch (err) {
-    if (err.statusCode === 404) {
-      return null;
-    }
-    return err;
-  }
+/**
+ * Get last 2 return cycles
+ * @param {String} [refDate] - reference date, defaults to current date
+ * @returns
+ */
+const getReturnCycles = async refDate => {
+  const startDate = moment(refDate).subtract(729, 'day').format('YYYY-MM-DD');
+  const { data } = await returns.getReturnsCyclesReport(startDate);
+  return data.slice(0, 2);
 };
 
 module.exports.getCRMDelegatedAccessData = getCRMDelegatedAccessData;
 module.exports.getIDMRegistrationsData = getIDMRegistrationsData;
 module.exports.getReturnsDataByMonth = getReturnsDataByMonth;
-module.exports.getReturnsDataByCycle = getReturnsDataByCycle;
 module.exports.getLicenceNamesData = getLicenceNamesData;
+module.exports.getReturnCycles = getReturnCycles;

--- a/test/lib/connectors/returns.js
+++ b/test/lib/connectors/returns.js
@@ -238,20 +238,6 @@ experiment('connectors/returns', () => {
     });
   });
 
-  experiment('.getKPIReturnsByCycle', () => {
-    beforeEach(async () => {
-      await returns.getKPIReturnsByCycle('2001-01-01', '2001-01-01', true);
-    });
-
-    afterEach(async => { sandbox.restore(); });
-
-    test('makes a request to the expected URL', async () => {
-      const testUrl = 'http://test.defra/returns/1.0/kpi/licencesBySeason?startDate=2001-01-01&endDate=2001-01-01&isSummer=true';
-      const [url] = helpers.serviceRequest.get.lastCall.args;
-      expect(url).to.equal(testUrl);
-    });
-  });
-
   experiment('.getReturnsCyclesReport', () => {
     const startDate = '2020-01-01';
 

--- a/test/modules/kpi-reporting/controller.js
+++ b/test/modules/kpi-reporting/controller.js
@@ -64,7 +64,7 @@ experiment('./modules/kpi-reporting/controller', () => {
           registrations: emptyResponse,
           delegatedAccess: emptyResponse,
           returnsMonthly: emptyResponse,
-          returnsCycles: [],
+          returnCycles: [],
           licenceNames: emptyResponse
         }
       };
@@ -122,7 +122,7 @@ experiment('./modules/kpi-reporting/controller', () => {
 
     test('Last 2 return cycles data are returned in the expected shape', async () => {
       const { data } = await controller.getKpiData();
-      expect(data.returnsCycles).to.equal(returnCycles);
+      expect(data.returnCycles).to.equal(returnCycles);
     });
   });
 });

--- a/test/modules/kpi-reporting/lib/mappers.js
+++ b/test/modules/kpi-reporting/lib/mappers.js
@@ -46,9 +46,9 @@ experiment('./modules/kpi-reporting/lib/mappers', () => {
 
   experiment('.mapReturnsDataMonthly', () => {
     const returnsDataMonthly = [
-      { currentYear: true, month: 2, request: 2, return: 2, year: 2020 },
-      { currentYear: true, month: 1, request: 3, return: 3, year: 2020 },
-      { currentYear: false, month: 12, request: 1, return: 1, year: 2020 }
+      { currentYear: true, month: 2, paperFormCount: 2, returnCount: 2, year: 2020 },
+      { currentYear: true, month: 1, paperFormCount: 3, returnCount: 3, year: 2020 },
+      { currentYear: false, month: 12, paperFormCount: 1, returnCount: 1, year: 2020 }
     ];
 
     test('the returns data by cycle is mapped correctly', async () => {
@@ -56,12 +56,12 @@ experiment('./modules/kpi-reporting/lib/mappers', () => {
       expect(mappedData.totals).to.be.equal({ allTime: 6, ytd: 5 });
       expect(mappedData.monthly.length).to.equal(2);
       expect(mappedData.monthly[0].month).to.equal('February');
-      expect(mappedData.monthly[0].request).to.equal(2);
-      expect(mappedData.monthly[0].return).to.equal(2);
+      expect(mappedData.monthly[0].paperFormCount).to.equal(2);
+      expect(mappedData.monthly[0].returnCount).to.equal(2);
       expect(mappedData.monthly[0].currentYear).to.equal(2020);
       expect(mappedData.monthly[1].month).to.equal('January');
-      expect(mappedData.monthly[1].request).to.equal(3);
-      expect(mappedData.monthly[1].return).to.equal(3);
+      expect(mappedData.monthly[1].paperFormCount).to.equal(3);
+      expect(mappedData.monthly[1].returnCount).to.equal(3);
       expect(mappedData.monthly[1].currentYear).to.equal(2020);
     });
   });


### PR DESCRIPTION
`WATER-3011` 
- Modifies KPI API endpoint to use return cycles endpoint.  
- Removes connector code for original returns KPI implementation.