### PR TITLE
Feat/water 3090 rebilling

### DIFF
--- a/config.js
+++ b/config.js
@@ -195,12 +195,16 @@ module.exports = {
   },
 
   redis: {
-    host: process.env.REDIS_HOST || '127.0.0.1',
-    port: process.env.REDIS_PORT || 6379,
-    password: process.env.REDIS_PASSWORD || '',
-    ...(isTlsConnection) && { tls: {} },
-    db: isPermitsTestDatabase ? 4 : 2,
-    lazyConnect: isRedisLazy
+    // Note: this limit needs increasing when further Bull MQ job queues are added
+    maxListenerCount: 23,
+    connection: {
+      host: process.env.REDIS_HOST || '127.0.0.1',
+      port: process.env.REDIS_PORT || 6379,
+      password: process.env.REDIS_PASSWORD || '',
+      ...(isTlsConnection) && { tls: {} },
+      db: isPermitsTestDatabase ? 4 : 2,
+      lazyConnect: isRedisLazy
+    }
   },
 
   featureToggles: {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const server = Hapi.server({
     {
       provider: {
         constructor: CatboxRedis,
-        options: config.redis
+        options: config.redis.connection
       }
     }
   ]

--- a/migrations/20210420163513-rebilling.js
+++ b/migrations/20210420163513-rebilling.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210420163513-rebilling-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210420163513-rebilling-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20210420163513-rebilling-down.sql
+++ b/migrations/sqls/20210420163513-rebilling-down.sql
@@ -1,0 +1,6 @@
+/* Replace with your SQL commands */
+alter table water.billing_invoices
+  drop column original_billing_invoice_id,
+  drop column rebilling_state;
+
+drop type water.rebilling_state;

--- a/migrations/sqls/20210420163513-rebilling-up.sql
+++ b/migrations/sqls/20210420163513-rebilling-up.sql
@@ -1,0 +1,9 @@
+/* Replace with your SQL commands */
+create type water.rebilling_state as enum('rebill', 'reversal');
+
+alter table water.billing_invoices 
+  add column original_billing_invoice_id uuid default null,
+  add column rebilling_state water.rebilling_state default null,
+  add constraint fk_original_billing_invoice_id 
+  foreign key (original_billing_invoice_id) 
+  references water.billing_invoices (billing_invoice_id);

--- a/src/lib/connectors/bookshelf/BillingInvoice.js
+++ b/src/lib/connectors/bookshelf/BillingInvoice.js
@@ -15,5 +15,9 @@ module.exports = bookshelf.model('BillingInvoice', {
 
   billingInvoiceLicences () {
     return this.hasMany('BillingInvoiceLicence', 'billing_invoice_id', 'billing_invoice_id');
+  },
+
+  linkedBillingInvoices () {
+    return this.hasMany('BillingInvoice', 'original_billing_invoice_id', 'original_billing_invoice_id');
   }
 });

--- a/src/lib/connectors/charge-module/bill-runs.js
+++ b/src/lib/connectors/charge-module/bill-runs.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const got = require('./lib/got-cm');
+const { logger } = require('../../../logger');
 
 /**
  * Creates a bill run in the CM for the specified region code
@@ -71,6 +72,10 @@ const getInvoiceTransactions = (billRunId, invoiceId) =>
 const generate = CMBillRunId =>
   got.patch(`v2/wrls/bill-runs/${CMBillRunId}/generate`);
 
+const rebillInvoice = async (billRunId, invoiceId) => {
+  logger.info(`CM rebilling API for ${billRunId} ${invoiceId} not yet implemented`);
+};
+
 exports.addTransaction = addTransaction;
 exports.approve = approve;
 exports.create = create;
@@ -81,3 +86,4 @@ exports.send = send;
 exports.getInvoiceTransactions = getInvoiceTransactions;
 exports.deleteInvoiceFromBillRun = deleteInvoiceFromBillRun;
 exports.generate = generate;
+exports.rebillInvoice = rebillInvoice;

--- a/src/lib/connectors/io-redis.js
+++ b/src/lib/connectors/io-redis.js
@@ -4,7 +4,7 @@ const IORedis = require('ioredis');
 const config = require('../../../config');
 
 // Note: this limit will need increasing if further Bull MQ job queues are added
-const maxListenerCount = 20;
+const maxListenerCount = 23;
 
 exports.createConnection = () => {
   const ioRedis = new IORedis(config.redis);

--- a/src/lib/connectors/io-redis.js
+++ b/src/lib/connectors/io-redis.js
@@ -3,11 +3,8 @@
 const IORedis = require('ioredis');
 const config = require('../../../config');
 
-// Note: this limit will need increasing if further Bull MQ job queues are added
-const maxListenerCount = 23;
-
 exports.createConnection = () => {
-  const ioRedis = new IORedis(config.redis);
-  ioRedis.setMaxListeners(maxListenerCount);
+  const ioRedis = new IORedis(config.redis.connection);
+  ioRedis.setMaxListeners(config.redis.maxListenerCount);
   return ioRedis;
 };

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -116,6 +116,25 @@ const findByIsFlaggedForRebillingAndRegion = regionId =>
 const resetIsFlaggedForRebilling = batchId =>
   raw.multiRow(queries.resetIsFlaggedForRebilling, { batchId });
 
+/**
+ * Finds invoices linked to the supplied invoice ID
+ * Invoices are linked via the original_billing_invoice_id column
+ * @param {String} billingInvoiceId
+ * @param {String} originalBillingInvoiceId
+ * @return {Promise<Array>}
+ */
+const findLinkedInvoices = async (billingInvoiceId, originalBillingInvoiceId) => {
+  const result = await BillingInvoice
+    .forge()
+    .where('originalBillingInvoiceId', originalBillingInvoiceId)
+    .andWhere('billingInvoiceId', '<>', billingInvoiceId)
+    .fetch({
+      require: false
+    });
+
+  return result.toJSON();
+};
+
 exports.upsert = upsert;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
 exports.findOne = findOne;
@@ -126,3 +145,4 @@ exports.update = update;
 exports.findAllForInvoiceAccount = findAllForInvoiceAccount;
 exports.findByIsFlaggedForRebillingAndRegion = findByIsFlaggedForRebillingAndRegion;
 exports.resetIsFlaggedForRebilling = resetIsFlaggedForRebilling;
+exports.findLinkedInvoices = findLinkedInvoices;

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -102,8 +102,19 @@ const findAllForInvoiceAccount = async (invoiceAccountId, page = 1, perPage = 10
  * @param {String} regionId
  * @returns {Promise<Array>}
  */
-const findByFlaggedForRebillingAndRegion = regionId =>
-  raw.multiRow(queries.findByFlaggedForRebillingAndRegion, { regionId });
+const findByIsFlaggedForRebillingAndRegion = regionId =>
+  raw.multiRow(queries.findByIsFlaggedForRebillingAndRegion, { regionId });
+
+/**
+ * Resets rebilling flags for invoices relating to the supplied
+ * batch Id.
+ * Note: the invoices themselves are not in this batch
+ *
+ * @param {String} batchId
+ * @return {Promise}
+ */
+const resetIsFlaggedForRebilling = batchId =>
+  raw.multiRow(queries.resetIsFlaggedForRebilling, { batchId });
 
 exports.upsert = upsert;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
@@ -113,4 +124,5 @@ exports.delete = deleteRecord;
 exports.deleteByBatchId = deleteByBatchId;
 exports.update = update;
 exports.findAllForInvoiceAccount = findAllForInvoiceAccount;
-exports.findByFlaggedForRebillingAndRegion = findByFlaggedForRebillingAndRegion;
+exports.findByIsFlaggedForRebillingAndRegion = findByIsFlaggedForRebillingAndRegion;
+exports.resetIsFlaggedForRebilling = resetIsFlaggedForRebilling;

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { bookshelf, BillingInvoice } = require('../bookshelf');
 const raw = require('./lib/raw');
 const queries = require('./queries/billing-invoices');
@@ -95,6 +97,14 @@ const findAllForInvoiceAccount = async (invoiceAccountId, page = 1, perPage = 10
   return paginationHelper.paginatedEnvelope(result);
 };
 
+/**
+ * Finds invoices flagged for rebilling in the given region
+ * @param {String} regionId
+ * @returns {Promise<Array>}
+ */
+const findByFlaggedForRebillingAndRegion = regionId =>
+  raw.multiRow(queries.findByFlaggedForRebillingAndRegion, { regionId });
+
 exports.upsert = upsert;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
 exports.findOne = findOne;
@@ -103,3 +113,4 @@ exports.delete = deleteRecord;
 exports.deleteByBatchId = deleteByBatchId;
 exports.update = update;
 exports.findAllForInvoiceAccount = findAllForInvoiceAccount;
+exports.findByFlaggedForRebillingAndRegion = findByFlaggedForRebillingAndRegion;

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -37,7 +37,8 @@ const findOne = async id => {
         'billingInvoiceLicences.billingTransactions',
         'billingInvoiceLicences.billingTransactions.billingVolume',
         'billingInvoiceLicences.billingTransactions.chargeElement',
-        'billingInvoiceLicences.billingTransactions.chargeElement.purposeUse'
+        'billingInvoiceLicences.billingTransactions.chargeElement.purposeUse',
+        'linkedBillingInvoices'
       ]
     });
 
@@ -116,25 +117,6 @@ const findByIsFlaggedForRebillingAndRegion = regionId =>
 const resetIsFlaggedForRebilling = batchId =>
   raw.multiRow(queries.resetIsFlaggedForRebilling, { batchId });
 
-/**
- * Finds invoices linked to the supplied invoice ID
- * Invoices are linked via the original_billing_invoice_id column
- * @param {String} billingInvoiceId
- * @param {String} originalBillingInvoiceId
- * @return {Promise<Array>}
- */
-const findLinkedInvoices = async (billingInvoiceId, originalBillingInvoiceId) => {
-  const result = await BillingInvoice
-    .forge()
-    .where('originalBillingInvoiceId', originalBillingInvoiceId)
-    .andWhere('billingInvoiceId', '<>', billingInvoiceId)
-    .fetch({
-      require: false
-    });
-
-  return result.toJSON();
-};
-
 exports.upsert = upsert;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
 exports.findOne = findOne;
@@ -145,4 +127,3 @@ exports.update = update;
 exports.findAllForInvoiceAccount = findAllForInvoiceAccount;
 exports.findByIsFlaggedForRebillingAndRegion = findByIsFlaggedForRebillingAndRegion;
 exports.resetIsFlaggedForRebilling = resetIsFlaggedForRebilling;
-exports.findLinkedInvoices = findLinkedInvoices;

--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -29,9 +29,21 @@ exports.deleteEmptyByBatchId = `delete from water.billing_invoices i
   group by i.billing_invoice_id
   having count(l.billing_invoice_licence_id)=0);`;
 
-exports.findByFlaggedForRebillingAndRegion = `
+exports.findByIsFlaggedForRebillingAndRegion = `
 select * from water.billing_invoices i
 join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
 where i.is_flagged_for_rebilling=true
 and b.region_id=:regionId;
-  `;
+`;
+
+exports.resetIsFlaggedForRebilling = `
+update water.billing_invoices t1
+set is_flagged_for_rebilling=false
+from water.billing_invoices t2
+where 
+  t2.billing_batch_id=:batchId 
+  and t1.billing_batch_id<>t2.billing_batch_id 
+  and t1.billing_invoice_id=t2.original_billing_invoice_id
+  and t2.original_billing_invoice_id is not null
+returning *;
+`;

--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -28,3 +28,10 @@ exports.deleteEmptyByBatchId = `delete from water.billing_invoices i
   where b.billing_batch_id=:batchId
   group by i.billing_invoice_id
   having count(l.billing_invoice_licence_id)=0);`;
+
+exports.findByFlaggedForRebillingAndRegion = `
+select * from water.billing_invoices i
+join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
+where i.is_flagged_for_rebilling=true
+and b.region_id=:regionId;
+  `;

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -24,7 +24,8 @@ const dbToModelMapper = createMapper()
     'externalId',
     'legacyId',
     'metadata',
-    'isFlaggedForRebilling'
+    'isFlaggedForRebilling',
+    'rebillingState'
   )
   .map('netAmount').to('netTotal')
   .map('billingInvoiceId').to('id')
@@ -32,7 +33,8 @@ const dbToModelMapper = createMapper()
   .map('invoiceAccountNumber').to('invoiceAccount.accountNumber')
   .map('billingInvoiceLicences').to('invoiceLicences', billingInvoiceLicences => billingInvoiceLicences.map(invoiceLicence.dbToModel))
   .map('billingBatch').to('batch', batchMapper.dbToModel)
-  .map('financialYearEnding').to('financialYear', financialYearEnding => new FinancialYear(financialYearEnding));
+  .map('financialYearEnding').to('financialYear', financialYearEnding => new FinancialYear(financialYearEnding))
+  .map('originalBillingInvoiceId').to('originalInvoiceId');
 
 /**
  * Converts DB representation to a Invoice service model
@@ -64,7 +66,9 @@ const modelToDb = (batch, invoice) => ({
   netAmount: invoice.netTotal,
   invoiceValue: invoice.invoiceValue,
   creditNoteValue: invoice.creditNoteValue,
-  isFlaggedForRebilling: invoice.isFlaggedForRebilling
+  isFlaggedForRebilling: invoice.isFlaggedForRebilling,
+  rebillingState: invoice.rebillingState,
+  originalBillingInvoiceId: invoice.originalInvoiceId
 });
 
 const crmToModel = row => {

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -13,7 +13,7 @@ const batchMapper = require('../../modules/billing/mappers/batch');
 const { createMapper } = require('../object-mapper');
 const { createModel } = require('./lib/helpers');
 
-const mapLinkedInvoices = (linkedBillingInvoices, billingInvoiceId) => linkedBillingInvoices
+const mapLinkedInvoices = (linkedBillingInvoices = [], billingInvoiceId) => linkedBillingInvoices
   .filter(linkedBillingInvoice => linkedBillingInvoice.billingInvoiceId !== billingInvoiceId)
   .map(dbToModel);
 
@@ -39,7 +39,7 @@ const dbToModelMapper = createMapper()
   .map('billingBatch').to('batch', batchMapper.dbToModel)
   .map('financialYearEnding').to('financialYear', financialYearEnding => new FinancialYear(financialYearEnding))
   .map('originalBillingInvoiceId').to('originalInvoiceId')
-  .map('linkedBillingInvoices', 'billingInvoiceId').to('linkedInvoices', mapLinkedInvoices);
+  .map(['linkedBillingInvoices', 'billingInvoiceId']).to('linkedInvoices', mapLinkedInvoices);
 
 /**
  * Converts DB representation to a Invoice service model

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -13,6 +13,10 @@ const batchMapper = require('../../modules/billing/mappers/batch');
 const { createMapper } = require('../object-mapper');
 const { createModel } = require('./lib/helpers');
 
+const mapLinkedInvoices = (linkedBillingInvoices, billingInvoiceId) => linkedBillingInvoices
+  .filter(linkedBillingInvoice => linkedBillingInvoice.billingInvoiceId !== billingInvoiceId)
+  .map(dbToModel);
+
 const dbToModelMapper = createMapper()
   .copy(
     'dateCreated',
@@ -34,7 +38,8 @@ const dbToModelMapper = createMapper()
   .map('billingInvoiceLicences').to('invoiceLicences', billingInvoiceLicences => billingInvoiceLicences.map(invoiceLicence.dbToModel))
   .map('billingBatch').to('batch', batchMapper.dbToModel)
   .map('financialYearEnding').to('financialYear', financialYearEnding => new FinancialYear(financialYearEnding))
-  .map('originalBillingInvoiceId').to('originalInvoiceId');
+  .map('originalBillingInvoiceId').to('originalInvoiceId')
+  .map('linkedBillingInvoices', 'billingInvoiceId').to('linkedInvoices', mapLinkedInvoices);
 
 /**
  * Converts DB representation to a Invoice service model

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -13,7 +13,7 @@ const batchMapper = require('../../modules/billing/mappers/batch');
 const { createMapper } = require('../object-mapper');
 const { createModel } = require('./lib/helpers');
 
-const mapLinkedInvoices = (linkedBillingInvoices = [], billingInvoiceId) => linkedBillingInvoices
+const mapLinkedInvoices = (billingInvoiceId, linkedBillingInvoices = []) => linkedBillingInvoices
   .filter(linkedBillingInvoice => linkedBillingInvoice.billingInvoiceId !== billingInvoiceId)
   .map(dbToModel);
 
@@ -39,7 +39,7 @@ const dbToModelMapper = createMapper()
   .map('billingBatch').to('batch', batchMapper.dbToModel)
   .map('financialYearEnding').to('financialYear', financialYearEnding => new FinancialYear(financialYearEnding))
   .map('originalBillingInvoiceId').to('originalInvoiceId')
-  .map(['linkedBillingInvoices', 'billingInvoiceId']).to('linkedInvoices', mapLinkedInvoices);
+  .map(['billingInvoiceId', 'linkedBillingInvoices']).to('linkedInvoices', mapLinkedInvoices);
 
 /**
  * Converts DB representation to a Invoice service model

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -33,7 +33,8 @@ const BATCH_ERROR_CODE = {
   failedToCreateBillRun: 50,
   failedToDeleteInvoice: 60,
   failedToProcessTwoPartTariff: 70,
-  failedToGetChargeModuleBillRunSummary: 80
+  failedToGetChargeModuleBillRunSummary: 80,
+  failedToProcessRebilling: 90
 };
 
 const BATCH_TYPE = {

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -9,7 +9,9 @@ const {
   assertNullableInteger, assertNullableId,
   assertNullablePositiveOrZeroInteger,
   assertNullableNegativeOrZeroInteger,
-  assertIsNullableBoolean
+  assertIsNullableBoolean,
+  assertEnum,
+  assertNullableEnum
 } = require('./validators');
 
 const Address = require('./address');
@@ -19,6 +21,11 @@ const Company = require('./company');
 const Contact = require('./contact-v2');
 const FinancialYear = require('./financial-year');
 const Totals = require('./totals');
+
+const rebillingState = {
+  rebill: 'rebill',
+  reversal: 'reversal'
+};
 
 class Invoice extends Totals {
   constructor (id) {
@@ -324,6 +331,35 @@ class Invoice extends Totals {
       displayLabel,
       ...super.toJSON()
     };
+  }
+
+  /**
+   * Records whether this invoice is:
+   * - reversal - reverses a previous sent bill for rebilling
+   * - rebill - a fresh copy of the previously sent bill for rebilling
+   *
+   * @param {String} value  - reversal|rebill
+   */
+  set rebillingState (value) {
+    assertNullableEnum(value, Object.values(rebillingState));
+    this._rebillingState = value;
+  }
+
+  get rebillingState () {
+    return this._rebillingState;
+  }
+
+  /**
+   * The ID of the original bill for rebilling
+   * @param {String|Null} id - guid
+   */
+  set originalInvoiceId (id) {
+    assertNullableId(id);
+    this._originalInvoiceId = id;
+  }
+
+  get originalInvoiceId () {
+    return this._originalInvoiceId;
   }
 }
 

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -32,6 +32,7 @@ class Invoice extends Totals {
     super(id);
     this._invoiceLicences = [];
     this.isDeMinimis = false;
+    this._linkedInvoices = [];
   }
 
   /**
@@ -360,6 +361,19 @@ class Invoice extends Totals {
 
   get originalInvoiceId () {
     return this._originalInvoiceId;
+  }
+
+  /**
+   * The ID of the original bill for rebilling
+   * @param {String|Null} id - guid
+   */
+  set linkedInvoices (invoices) {
+    assertIsArrayOfType(invoices, Invoice);
+    this._linkedInvoices = invoices;
+  }
+
+  get linkedInvoices () {
+    return this._linkedInvoices;
   }
 }
 

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -10,7 +10,6 @@ const {
   assertNullablePositiveOrZeroInteger,
   assertNullableNegativeOrZeroInteger,
   assertIsNullableBoolean,
-  assertEnum,
   assertNullableEnum
 } = require('./validators');
 
@@ -378,3 +377,4 @@ class Invoice extends Totals {
 }
 
 module.exports = Invoice;
+module.exports.rebillingState = rebillingState;

--- a/src/lib/services/invoice-service.js
+++ b/src/lib/services/invoice-service.js
@@ -208,7 +208,7 @@ const updateInvoice = async (invoiceAccountId, changes) => {
 };
 
 const getInvoicesFlaggedForRebilling = async regionId => {
-  const data = await repos.billingInvoices.findByFlaggedForRebillingAndRegion(regionId);
+  const data = await repos.billingInvoices.findByIsFlaggedForRebillingAndRegion(regionId);
   return data.map(mappers.invoice.dbToModel);
 };
 
@@ -233,10 +233,20 @@ const rebillInvoice = async (batch, invoice) => {
   // Set the "originalBillingInvoiceId" to this invoice ID.  This allows an invoice
   // to be linked with the reversal and recharge invoices which will be created by the CM
   const updatedRow = await repos.billingInvoices.update(invoice.id, {
-    originalBillingInvoiceId: invoice.id
+    originalBillingInvoiceId: invoice.id,
+    rebillingState: null
   });
   return mappers.invoice.dbToModel(updatedRow);
 };
+
+/**
+ * Resets invoices originally flagged for rebilling which have now been re-billed
+ * in the current batch
+ *
+ * @param {String} batchId - current batch ID
+ * @returns {Promise}
+ */
+const resetIsFlaggedForRebilling = batchId => repos.billingInvoices.resetIsFlaggedForRebilling(batchId);
 
 exports.getInvoicesForBatch = getInvoicesForBatch;
 exports.getInvoiceForBatch = getInvoiceForBatch;
@@ -248,3 +258,4 @@ exports.getInvoiceById = getInvoiceById;
 exports.updateInvoice = updateInvoice;
 exports.getInvoicesFlaggedForRebilling = getInvoicesFlaggedForRebilling;
 exports.rebillInvoice = rebillInvoice;
+exports.resetIsFlaggedForRebilling = resetIsFlaggedForRebilling;

--- a/src/modules/billing/controllers/invoices.js
+++ b/src/modules/billing/controllers/invoices.js
@@ -8,12 +8,18 @@ const invoiceIsPartOfSentBatch = invoice => {
   return billingBatch.status === BATCH_STATUS.sent;
 };
 
+const invoiceIsRebill = invoice =>
+  invoice.rebillingState !== null;
+
 const patchInvoice = async request => {
   try {
     const { invoiceId } = request.params;
     const invoice = await invoiceService.getInvoiceById(invoiceId);
     if (!invoiceIsPartOfSentBatch(invoice)) {
       return Boom.conflict('Cannot update invoice that is not part of a sent batch');
+    }
+    if (invoiceIsRebill(invoice)) {
+      return Boom.conflict('Cannot update invoice that is itself a rebill');
     }
     return invoiceService.updateInvoice(invoiceId, request.payload);
   } catch (err) {

--- a/src/modules/billing/jobs/rebilling.js
+++ b/src/modules/billing/jobs/rebilling.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { get } = require('lodash');
+
+const JOB_NAME = 'billing.rebilling';
+
+const { logger } = require('../../../logger');
+const batchJob = require('./lib/batch-job');
+const helpers = require('./lib/helpers');
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
+
+// Services
+const invoiceService = require('../../../lib/services/invoice-service');
+const batchService = require('../services/batch-service');
+
+const { jobName: populateBatchChargeVersionJobName } = require('./populate-batch-charge-versions');
+
+const createMessage = batchId => ([
+  JOB_NAME,
+  {
+    batchId
+  },
+  {
+    jobId: `${JOB_NAME}.${batchId}`,
+    attempts: 6,
+    backoff: {
+      type: 'exponential',
+      delay: 5000
+    }
+  }
+]);
+
+const handler = async job => {
+  batchJob.logHandling(job);
+
+  // Get batch
+  const batchId = get(job, 'data.batchId');
+  const batch = await batchService.getBatchById(batchId);
+
+  // Get invoices that are flagged for rebilling in the batch region
+  const invoices = await invoiceService.getInvoicesFlaggedForRebilling(batch.region.id);
+
+  // Process each invoice that needs rebilling
+  for (const invoice of invoices) {
+    await invoiceService.rebillInvoice(batch, invoice);
+  }
+};
+
+const onComplete = async (job, queueManager) => {
+  batchJob.logOnComplete(job);
+
+  try {
+    // Publish next job in process
+    const batchId = get(job, 'data.batchId');
+    await queueManager.add(populateBatchChargeVersionJobName, batchId);
+  } catch (err) {
+    batchJob.logOnCompleteError(job, err);
+  }
+};
+
+const onFailedHandler = async (job, err) => {
+  const batchId = get(job, 'data.batchId');
+
+  // On final attempt, error the batch and log
+  if (helpers.isFinalAttempt(job)) {
+    try {
+      logger.error(`Rebilling failed ${batchId}`);
+      await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToProcessRebilling);
+    } catch (error) {
+      logger.error(`Unable to set batch status ${batchId}`, error);
+    }
+  } else {
+    // Do normal error logging
+    helpers.onFailedHandler(job, err);
+  }
+};
+
+exports.jobName = JOB_NAME;
+exports.createMessage = createMessage;
+exports.handler = handler;
+exports.onComplete = onComplete;
+exports.onFailed = onFailedHandler;
+exports.hasScheduler = true;

--- a/src/modules/billing/jobs/rebilling.js
+++ b/src/modules/billing/jobs/rebilling.js
@@ -7,6 +7,8 @@ const JOB_NAME = 'billing.rebilling';
 const { logger } = require('../../../logger');
 const batchJob = require('./lib/batch-job');
 const helpers = require('./lib/helpers');
+const batchStatus = require('./lib/batch-status');
+
 const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 
 // Services
@@ -38,6 +40,9 @@ const handler = async job => {
   // Get batch
   const batchId = getBatchId(job);
   const batch = await batchService.getBatchById(batchId);
+
+  // Check batch in "processing" status
+  batchStatus.assertBatchIsProcessing(batch);
 
   // Get invoices that are flagged for rebilling in the batch region
   const invoices = await invoiceService.getInvoicesFlaggedForRebilling(batch.region.id);

--- a/src/modules/billing/jobs/rebilling.js
+++ b/src/modules/billing/jobs/rebilling.js
@@ -30,11 +30,13 @@ const createMessage = batchId => ([
   }
 ]);
 
+const getBatchId = job => get(job, 'data.batchId');
+
 const handler = async job => {
   batchJob.logHandling(job);
 
   // Get batch
-  const batchId = get(job, 'data.batchId');
+  const batchId = getBatchId(job);
   const batch = await batchService.getBatchById(batchId);
 
   // Get invoices that are flagged for rebilling in the batch region
@@ -51,7 +53,7 @@ const onComplete = async (job, queueManager) => {
 
   try {
     // Publish next job in process
-    const batchId = get(job, 'data.batchId');
+    const batchId = getBatchId(job);
     await queueManager.add(populateBatchChargeVersionJobName, batchId);
   } catch (err) {
     batchJob.logOnCompleteError(job, err);
@@ -59,7 +61,7 @@ const onComplete = async (job, queueManager) => {
 };
 
 const onFailedHandler = async (job, err) => {
-  const batchId = get(job, 'data.batchId');
+  const batchId = getBatchId(job);
 
   // On final attempt, error the batch and log
   if (helpers.isFinalAttempt(job)) {

--- a/src/modules/billing/register-subscribers.js
+++ b/src/modules/billing/register-subscribers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createBillRun = require('./jobs/create-bill-run');
+const rebilling = require('./jobs/rebilling');
 const createCharge = require('./jobs/create-charge');
 const populateBatchChargeVersions = require('./jobs/populate-batch-charge-versions');
 const prepareTransactions = require('./jobs/prepare-transactions');
@@ -16,6 +17,7 @@ module.exports = {
   register: async server => {
     server.queueManager
       .register(createBillRun)
+      .register(rebilling)
       .register(createCharge)
       .register(populateBatchChargeVersions)
       .register(prepareTransactions)

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -166,6 +166,7 @@ const approveBatch = async (batch, internalCallingUser) => {
     await saveEvent('billing-batch:approve', 'sent', internalCallingUser, batch);
 
     await licencesService.updateIncludeInSupplementaryBillingStatusForSentBatch(batch.id);
+    await invoiceService.resetIsFlaggedForRebilling(batch.id);
 
     return setStatus(batch.id, BATCH_STATUS.processing);
   } catch (err) {

--- a/test/lib/connectors/bookshelf/Agreement.js
+++ b/test/lib/connectors/bookshelf/Agreement.js
@@ -9,46 +9,81 @@ const {
 const { expect } = require('@hapi/code');
 const sandbox = require('sinon').createSandbox();
 
-const Agreement = require('../../../../src/lib/connectors/bookshelf/Agreement');
+const BillingInvoice = require('../../../../src/lib/connectors/bookshelf/BillingInvoice');
 
-experiment('lib/connectors/bookshelf/Agreement', () => {
+experiment('lib/connectors/bookshelf/BillingInvoice', () => {
   let instance;
 
   beforeEach(async () => {
-    instance = Agreement.forge();
+    instance = BillingInvoice.forge();
     sandbox.stub(instance, 'belongsTo');
+    sandbox.stub(instance, 'hasMany');
   });
 
   afterEach(async () => {
     sandbox.restore();
   });
 
-  test('uses the water.financial_agreement_types table', async () => {
-    expect(instance.tableName).to.equal('water.financial_agreement_types');
+  test('uses the water.billing_invoices table', async () => {
+    expect(instance.tableName).to.equal('water.billing_invoices');
   });
 
   test('uses the correct ID attribute', async () => {
-    expect(instance.idAttribute).to.equal('id');
+    expect(instance.idAttribute).to.equal('billing_invoice_id');
   });
 
   test('has the expected timestamp fields', async () => {
     expect(instance.hasTimestamps).to.equal(['date_created', 'date_updated']);
   });
 
-  experiment('the .licenceAgreement() relation', () => {
+  experiment('the .billingBatch() relation', () => {
     beforeEach(async () => {
-      instance.licenceAgreement();
+      instance.billingBatch();
     });
 
     test('is a function', async () => {
-      expect(instance.licenceAgreement).to.be.a.function();
+      expect(instance.billingBatch).to.be.a.function();
     });
 
     test('calls .belongsTo with correct params', async () => {
       const [model, foreignKey, foreignKeyTarget] = instance.belongsTo.lastCall.args;
-      expect(model).to.equal('LicenceAgreement');
-      expect(foreignKey).to.equal('id');
-      expect(foreignKeyTarget).to.equal('financial_agreement_type_id');
+      expect(model).to.equal('BillingBatch');
+      expect(foreignKey).to.equal('billing_batch_id');
+      expect(foreignKeyTarget).to.equal('billing_batch_id');
+    });
+  });
+
+  experiment('the .billingInvoiceLicences() relation', () => {
+    beforeEach(async () => {
+      instance.billingInvoiceLicences();
+    });
+
+    test('is a function', async () => {
+      expect(instance.billingInvoiceLicences).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
+      expect(model).to.equal('BillingInvoiceLicence');
+      expect(foreignKey).to.equal('billing_invoice_id');
+      expect(foreignKeyTarget).to.equal('billing_invoice_id');
+    });
+  });
+
+  experiment('the .linkedBillingInvoices() relation', () => {
+    beforeEach(async () => {
+      instance.linkedBillingInvoices();
+    });
+
+    test('is a function', async () => {
+      expect(instance.linkedBillingInvoices).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
+      expect(model).to.equal('BillingInvoice');
+      expect(foreignKey).to.equal('original_billing_invoice_id');
+      expect(foreignKeyTarget).to.equal('original_billing_invoice_id');
     });
   });
 });

--- a/test/lib/connectors/bookshelf/Agreement.js
+++ b/test/lib/connectors/bookshelf/Agreement.js
@@ -9,81 +9,46 @@ const {
 const { expect } = require('@hapi/code');
 const sandbox = require('sinon').createSandbox();
 
-const BillingInvoice = require('../../../../src/lib/connectors/bookshelf/BillingInvoice');
+const Agreement = require('../../../../src/lib/connectors/bookshelf/Agreement');
 
-experiment('lib/connectors/bookshelf/BillingInvoice', () => {
+experiment('lib/connectors/bookshelf/Agreement', () => {
   let instance;
 
   beforeEach(async () => {
-    instance = BillingInvoice.forge();
+    instance = Agreement.forge();
     sandbox.stub(instance, 'belongsTo');
-    sandbox.stub(instance, 'hasMany');
   });
 
   afterEach(async () => {
     sandbox.restore();
   });
 
-  test('uses the water.billing_invoices table', async () => {
-    expect(instance.tableName).to.equal('water.billing_invoices');
+  test('uses the water.financial_agreement_types table', async () => {
+    expect(instance.tableName).to.equal('water.financial_agreement_types');
   });
 
   test('uses the correct ID attribute', async () => {
-    expect(instance.idAttribute).to.equal('billing_invoice_id');
+    expect(instance.idAttribute).to.equal('id');
   });
 
   test('has the expected timestamp fields', async () => {
     expect(instance.hasTimestamps).to.equal(['date_created', 'date_updated']);
   });
 
-  experiment('the .billingBatch() relation', () => {
+  experiment('the .licenceAgreement() relation', () => {
     beforeEach(async () => {
-      instance.billingBatch();
+      instance.licenceAgreement();
     });
 
     test('is a function', async () => {
-      expect(instance.billingBatch).to.be.a.function();
+      expect(instance.licenceAgreement).to.be.a.function();
     });
 
     test('calls .belongsTo with correct params', async () => {
       const [model, foreignKey, foreignKeyTarget] = instance.belongsTo.lastCall.args;
-      expect(model).to.equal('BillingBatch');
-      expect(foreignKey).to.equal('billing_batch_id');
-      expect(foreignKeyTarget).to.equal('billing_batch_id');
-    });
-  });
-
-  experiment('the .billingInvoiceLicences() relation', () => {
-    beforeEach(async () => {
-      instance.billingInvoiceLicences();
-    });
-
-    test('is a function', async () => {
-      expect(instance.billingInvoiceLicences).to.be.a.function();
-    });
-
-    test('calls .belongsTo with correct params', async () => {
-      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
-      expect(model).to.equal('BillingInvoiceLicence');
-      expect(foreignKey).to.equal('billing_invoice_id');
-      expect(foreignKeyTarget).to.equal('billing_invoice_id');
-    });
-  });
-
-  experiment('the .linkedBillingInvoices() relation', () => {
-    beforeEach(async () => {
-      instance.linkedBillingInvoices();
-    });
-
-    test('is a function', async () => {
-      expect(instance.linkedBillingInvoices).to.be.a.function();
-    });
-
-    test('calls .belongsTo with correct params', async () => {
-      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
-      expect(model).to.equal('BillingInvoice');
-      expect(foreignKey).to.equal('original_billing_invoice_id');
-      expect(foreignKeyTarget).to.equal('original_billing_invoice_id');
+      expect(model).to.equal('LicenceAgreement');
+      expect(foreignKey).to.equal('id');
+      expect(foreignKeyTarget).to.equal('financial_agreement_type_id');
     });
   });
 });

--- a/test/lib/connectors/bookshelf/BillingInvoice.js
+++ b/test/lib/connectors/bookshelf/BillingInvoice.js
@@ -9,46 +9,81 @@ const {
 const { expect } = require('@hapi/code');
 const sandbox = require('sinon').createSandbox();
 
-const Agreement = require('../../../../src/lib/connectors/bookshelf/Agreement');
+const BillingInvoice = require('../../../../src/lib/connectors/bookshelf/BillingInvoice');
 
-experiment('lib/connectors/bookshelf/Agreement', () => {
+experiment('lib/connectors/bookshelf/BillingInvoice', () => {
   let instance;
 
   beforeEach(async () => {
-    instance = Agreement.forge();
+    instance = BillingInvoice.forge();
     sandbox.stub(instance, 'belongsTo');
+    sandbox.stub(instance, 'hasMany');
   });
 
   afterEach(async () => {
     sandbox.restore();
   });
 
-  test('uses the water.financial_agreement_types table', async () => {
-    expect(instance.tableName).to.equal('water.financial_agreement_types');
+  test('uses the water.billing_invoices table', async () => {
+    expect(instance.tableName).to.equal('water.billing_invoices');
   });
 
   test('uses the correct ID attribute', async () => {
-    expect(instance.idAttribute).to.equal('id');
+    expect(instance.idAttribute).to.equal('billing_invoice_id');
   });
 
   test('has the expected timestamp fields', async () => {
     expect(instance.hasTimestamps).to.equal(['date_created', 'date_updated']);
   });
 
-  experiment('the .licenceAgreement() relation', () => {
+  experiment('the .billingBatch() relation', () => {
     beforeEach(async () => {
-      instance.licenceAgreement();
+      instance.billingBatch();
     });
 
     test('is a function', async () => {
-      expect(instance.licenceAgreement).to.be.a.function();
+      expect(instance.billingBatch).to.be.a.function();
     });
 
     test('calls .belongsTo with correct params', async () => {
       const [model, foreignKey, foreignKeyTarget] = instance.belongsTo.lastCall.args;
-      expect(model).to.equal('LicenceAgreement');
-      expect(foreignKey).to.equal('id');
-      expect(foreignKeyTarget).to.equal('financial_agreement_type_id');
+      expect(model).to.equal('BillingBatch');
+      expect(foreignKey).to.equal('billing_batch_id');
+      expect(foreignKeyTarget).to.equal('billing_batch_id');
+    });
+  });
+
+  experiment('the .billingInvoiceLicences() relation', () => {
+    beforeEach(async () => {
+      instance.billingInvoiceLicences();
+    });
+
+    test('is a function', async () => {
+      expect(instance.billingInvoiceLicences).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
+      expect(model).to.equal('BillingInvoiceLicence');
+      expect(foreignKey).to.equal('billing_invoice_id');
+      expect(foreignKeyTarget).to.equal('billing_invoice_id');
+    });
+  });
+
+  experiment('the .linkedBillingInvoices() relation', () => {
+    beforeEach(async () => {
+      instance.linkedBillingInvoices();
+    });
+
+    test('is a function', async () => {
+      expect(instance.linkedBillingInvoices).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
+      expect(model).to.equal('BillingInvoice');
+      expect(foreignKey).to.equal('original_billing_invoice_id');
+      expect(foreignKeyTarget).to.equal('original_billing_invoice_id');
     });
   });
 });

--- a/test/lib/connectors/bookshelf/BillingInvoice.js
+++ b/test/lib/connectors/bookshelf/BillingInvoice.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const Agreement = require('../../../../src/lib/connectors/bookshelf/Agreement');
+
+experiment('lib/connectors/bookshelf/Agreement', () => {
+  let instance;
+
+  beforeEach(async () => {
+    instance = Agreement.forge();
+    sandbox.stub(instance, 'belongsTo');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('uses the water.financial_agreement_types table', async () => {
+    expect(instance.tableName).to.equal('water.financial_agreement_types');
+  });
+
+  test('uses the correct ID attribute', async () => {
+    expect(instance.idAttribute).to.equal('id');
+  });
+
+  test('has the expected timestamp fields', async () => {
+    expect(instance.hasTimestamps).to.equal(['date_created', 'date_updated']);
+  });
+
+  experiment('the .licenceAgreement() relation', () => {
+    beforeEach(async () => {
+      instance.licenceAgreement();
+    });
+
+    test('is a function', async () => {
+      expect(instance.licenceAgreement).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.belongsTo.lastCall.args;
+      expect(model).to.equal('LicenceAgreement');
+      expect(foreignKey).to.equal('id');
+      expect(foreignKeyTarget).to.equal('financial_agreement_type_id');
+    });
+  });
+});

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -112,7 +112,8 @@ experiment('lib/connectors/repos/billing-invoices', () => {
         'billingInvoiceLicences.billingTransactions',
         'billingInvoiceLicences.billingTransactions.billingVolume',
         'billingInvoiceLicences.billingTransactions.chargeElement',
-        'billingInvoiceLicences.billingTransactions.chargeElement.purposeUse'
+        'billingInvoiceLicences.billingTransactions.chargeElement.purposeUse',
+        'linkedBillingInvoices'
       ]);
     });
 

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -238,7 +238,7 @@ experiment('lib/connectors/repos/billing-invoices', () => {
     });
   });
 
-  experiment('.findByIsFlaggedForRebillingAndRegion', async () => {
+  experiment('.findByIsFlaggedForRebillingAndRegion', () => {
     const regionId = uuid();
 
     beforeEach(async () => {
@@ -252,7 +252,7 @@ experiment('lib/connectors/repos/billing-invoices', () => {
     });
   });
 
-  experiment('.resetIsFlaggedForRebilling', async () => {
+  experiment('.resetIsFlaggedForRebilling', () => {
     const batchId = uuid();
 
     beforeEach(async () => {

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -14,6 +14,7 @@ const queries = require('../../../../src/lib/connectors/repos/queries/billing-in
 
 const billingInvoices = require('../../../../src/lib/connectors/repos/billing-invoices');
 const paginationHelper = require('../../../../src/lib/connectors/repos/lib/envelope');
+const raw = require('../../../../src/lib/connectors/repos/lib/raw');
 
 const result = {
   rows: [{
@@ -43,6 +44,8 @@ experiment('lib/connectors/repos/billing-invoices', () => {
     };
 
     sandbox.stub(BillingInvoice, 'forge').returns(stub);
+
+    sandbox.stub(raw, 'multiRow');
   });
 
   afterEach(async () => {
@@ -232,6 +235,34 @@ experiment('lib/connectors/repos/billing-invoices', () => {
 
     test('returns the result of the paginationHelper.paginatedEnvelope call', async () => {
       expect(result).to.equal({ data: [{ foo: 'bar' }], pagination: { page: 1, perPage: 10 } });
+    });
+  });
+
+  experiment('.findByIsFlaggedForRebillingAndRegion', async () => {
+    const regionId = uuid();
+
+    beforeEach(async () => {
+      await billingInvoices.findByIsFlaggedForRebillingAndRegion(regionId);
+    });
+
+    test('calls raw.multiRow with the correct query', async () => {
+      expect(raw.multiRow.calledWith(
+        queries.findByIsFlaggedForRebillingAndRegion, { regionId }
+      ));
+    });
+  });
+
+  experiment('.resetIsFlaggedForRebilling', async () => {
+    const batchId = uuid();
+
+    beforeEach(async () => {
+      await billingInvoices.resetIsFlaggedForRebilling(batchId);
+    });
+
+    test('calls raw.multiRow with the correct query', async () => {
+      expect(raw.multiRow.calledWith(
+        queries.resetIsFlaggedForRebilling, { batchId }
+      ));
     });
   });
 });

--- a/test/lib/mappers/invoice.js
+++ b/test/lib/mappers/invoice.js
@@ -30,7 +30,13 @@ const invoiceRow = {
   creditNoteValue: -77,
   legacyId: '12345:678',
   metadata: { foo: 'bar' },
-  isFlaggedForRebilling: true
+  isFlaggedForRebilling: true,
+  linkedBillingInvoices: [{
+    billingInvoiceId: '5a1577d7-8dc9-4d67-aadc-37d7ea85abca'
+  },
+  {
+    billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e866'
+  }]
 };
 
 experiment('lib/mappers/invoice', () => {
@@ -81,6 +87,12 @@ experiment('lib/mappers/invoice', () => {
 
     test('maps the is flagged for rebilling', () => {
       expect(result.isFlaggedForRebilling).to.equal(invoiceRow.isFlaggedForRebilling);
+    });
+
+    test('maps the linked billing invoices for re-billing, excluding the current invoice', () => {
+      const { linkedInvoices } = result;
+      expect(linkedInvoices).to.be.an.array().length(1);
+      expect(linkedInvoices[0].id).to.equal(invoiceRow.linkedBillingInvoices[1].billingInvoiceId);
     });
   });
 

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -471,4 +471,70 @@ experiment('lib/models/invoice', () => {
       });
     });
   });
+
+  experiment('.rebillingState', () => {
+    test('can be set to "rebill"', async () => {
+      invoice.rebillingState = 'rebill';
+      expect(invoice.rebillingState).to.equal('rebill');
+    });
+
+    test('can be set to "reversal"', async () => {
+      invoice.rebillingState = 'reversal';
+      expect(invoice.rebillingState).to.equal('reversal');
+    });
+
+    test('can be set to null', async () => {
+      invoice.rebillingState = null;
+      expect(invoice.rebillingState).to.equal(null);
+    });
+
+    test('throws an error if set to another string', async () => {
+      const func = () => {
+        invoice.isFlaggedForRebilling = 'invalid-state';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.originalInvoiceId', () => {
+    test('can be set to guid', async () => {
+      const id = uuid();
+      invoice.originalInvoiceId = id;
+      expect(invoice.originalInvoiceId).to.equal(id);
+    });
+
+    test('can be set to null', async () => {
+      invoice.originalInvoiceId = null;
+      expect(invoice.originalInvoiceId).to.equal(null);
+    });
+
+    test('throws an error if not a guid', async () => {
+      const func = () => {
+        invoice.originalInvoiceId = 'invalid-state';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.linkedInvoices', () => {
+    test('can be set to an array of invoice instances', async () => {
+      const arr = [
+        new Invoice(uuid()),
+        new Invoice(uuid())
+      ];
+      invoice.linkedInvoices = arr;
+      expect(invoice.linkedInvoices).to.equal(arr);
+    });
+
+    test('throws an error if not Invoice models', async () => {
+      const func = () => {
+        const arr = [
+          new Invoice(uuid()),
+          new InvoiceAccount(uuid())
+        ];
+        invoice.linkedInvoices = arr;
+      };
+      expect(func).to.throw();
+    });
+  });
 });

--- a/test/modules/billing/jobs/rebilling.js
+++ b/test/modules/billing/jobs/rebilling.js
@@ -1,0 +1,234 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+const uuid = require('uuid/v4');
+
+const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
+const rebillingJob = require('../../../../src/modules/billing/jobs/rebilling');
+
+// Connectors
+const { logger } = require('../../../../src/logger');
+
+// Services
+const batchService = require('../../../../src/modules/billing/services/batch-service');
+const invoiceService = require('../../../../src/lib/services/invoice-service');
+
+// Models
+const Batch = require('../../../../src/lib/models/batch');
+const Region = require('../../../../src/lib/models/region');
+const Invoice = require('../../../../src/lib/models/invoice');
+
+const transactionId = uuid();
+const batchId = uuid();
+const regionId = uuid();
+const invoiceId = uuid();
+
+const createBatch = () => new Batch()
+  .fromHash({
+    id: batchId,
+    region: new Region(regionId),
+    status: Batch.BATCH_STATUS.processing
+  });
+
+const createInvoice = () =>
+  new Invoice(invoiceId);
+
+experiment('modules/billing/jobs/rebilling', () => {
+  let batch, queueManager, invoice;
+
+  beforeEach(async () => {
+    batch = createBatch();
+    invoice = createInvoice();
+
+    sandbox.stub(batchJob, 'logHandling');
+    sandbox.stub(batchJob, 'logOnComplete');
+    sandbox.stub(batchJob, 'logOnCompleteError');
+
+    sandbox.stub(batchService, 'getBatchById');
+    sandbox.stub(batchService, 'setErrorStatus');
+
+    sandbox.stub(invoiceService, 'getInvoicesFlaggedForRebilling');
+    sandbox.stub(invoiceService, 'rebillInvoice');
+
+    queueManager = {
+      add: sandbox.stub()
+    };
+
+    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'error');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('exports the expected job name', async () => {
+    expect(rebillingJob.jobName).to.equal('billing.rebilling');
+  });
+
+  experiment('.createMessage', () => {
+    test('creates the expected message array', async () => {
+      const message = rebillingJob.createMessage(
+        batchId,
+        transactionId
+      );
+
+      expect(message).to.equal([
+        'billing.rebilling',
+        {
+          batchId
+        },
+        {
+          attempts: 6,
+          backoff: {
+            type: 'exponential',
+            delay: 5000
+          },
+          jobId: `billing.rebilling.${batchId}`
+        }
+      ]);
+    });
+  });
+
+  experiment('.handler', () => {
+    let job;
+
+    beforeEach(async () => {
+      job = {
+        data: {
+          batchId
+        }
+      };
+      invoiceService.getInvoicesFlaggedForRebilling.resolves([
+        invoice
+      ]);
+    });
+
+    experiment('when the batch status is "processing"', () => {
+      beforeEach(async () => {
+        batchService.getBatchById.resolves(batch);
+        await rebillingJob.handler(job);
+      });
+
+      test('gets the batch', async () => {
+        expect(batchService.getBatchById.calledWith(batchId)).to.be.true();
+      });
+
+      test('gets the invoices flagged for rebilling in the batch region', async () => {
+        expect(invoiceService.getInvoicesFlaggedForRebilling.calledWith(
+          regionId
+        )).to.be.true();
+      });
+
+      test('calls the .rebillInvoice service method for each invoice retrieved', async () => {
+        expect(invoiceService.rebillInvoice.callCount).to.equal(1);
+        expect(invoiceService.rebillInvoice.calledWith(
+          batch, invoice
+        )).to.be.true();
+      });
+    });
+
+    experiment('when the batch status is not "processing"', () => {
+      beforeEach(async () => {
+        batch.status = Batch.BATCH_STATUS.error;
+        batchService.getBatchById.resolves(batch);
+      });
+
+      test('the handler rejects with an error', async () => {
+        const func = () => rebillingJob.handler(job);
+        expect(func()).to.reject();
+      });
+    });
+  });
+
+  experiment('.onComplete', () => {
+    let job;
+    beforeEach(async () => {
+      job = {
+        data: {
+          batchId
+        }
+      };
+    });
+
+    experiment('when there are no errors', () => {
+      beforeEach(async () => {
+        rebillingJob.onComplete(job, queueManager);
+      });
+
+      test('a job is published for each charge version year', async () => {
+        expect(queueManager.add.callCount).to.equal(1);
+        expect(queueManager.add.calledWith(
+          'billing.populate-batch-charge-versions', batchId
+        )).to.be.true();
+      });
+    });
+
+    experiment('when there is an error', () => {
+      let err;
+
+      beforeEach(async () => {
+        err = new Error('oops');
+        queueManager.add.rejects(err);
+        await rebillingJob.onComplete(job, queueManager);
+      });
+
+      test('a message is logged', async () => {
+        expect(batchJob.logOnCompleteError.calledWith(job, err)).to.be.true();
+      });
+    });
+  });
+
+  experiment('.onFailedHandler', () => {
+    let job;
+    const err = new Error('oops');
+
+    experiment('for a non-final attempt to process rebilling', () => {
+      beforeEach(async () => {
+        job = {
+          data: {
+            batchId
+          },
+          attemptsMade: 5,
+          opts: {
+            attempts: 10
+          }
+        };
+        await rebillingJob.onFailed(job, err);
+      });
+
+      test('the batch is not updated', async () => {
+        expect(batchService.setErrorStatus.called).to.be.false();
+      });
+    });
+
+    experiment('for a non-final attempt to process rebilling', () => {
+      beforeEach(async () => {
+        job = {
+          data: {
+            batchId
+          },
+          attemptsMade: 10,
+          opts: {
+            attempts: 10
+          }
+        };
+        await rebillingJob.onFailed(job, err);
+      });
+
+      test('the batch is updated', async () => {
+        expect(batchService.setErrorStatus.calledWith(
+          job.data.batchId, Batch.BATCH_ERROR_CODE.failedToProcessRebilling
+        )).to.be.true();
+      });
+    });
+  });
+});

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -106,6 +106,8 @@ experiment('modules/billing/services/batch-service', () => {
     sandbox.stub(invoiceLicencesService, 'saveInvoiceLicenceToDB');
 
     sandbox.stub(invoiceService, 'saveInvoiceToDB');
+    sandbox.stub(invoiceService, 'resetIsFlaggedForRebilling');
+
     sandbox.stub(invoiceAccountsService, 'getByInvoiceAccountId');
 
     sandbox.stub(licencesService, 'updateIncludeInSupplementaryBillingStatus').resolves();
@@ -470,6 +472,12 @@ experiment('modules/billing/services/batch-service', () => {
       test('updates the include in supplementary billing status for the batch licences', async () => {
         const [batchId] = licencesService.updateIncludeInSupplementaryBillingStatusForSentBatch.lastCall.args;
         expect(batchId).to.equal(batch.id);
+      });
+
+      test('resets the invoice rebilling flags', async () => {
+        expect(invoiceService.resetIsFlaggedForRebilling.calledWith(
+          batch.id
+        )).to.be.true();
       });
 
       test('sets the status of the batch to processing', async () => {


### PR DESCRIPTION
`WATER-3090`

* Adds migration to add new fields needed for re-billing processing
* Adds re-billing Bull MQ job for supplementary runs only to process re-billed invoices
* Resets re-billing flags when bill run is sent
* Includes linked bills in API response