### PR TITLE
Skip request to CM unless transaction in "candidate" status.  

### DIFF
--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -50,7 +50,7 @@ const isClientError = err => inRange(getStatus(err), 400, 500);
  * @param {Error} err
  * @return {Boolean}
  */
-const isConflictError = err => getStatus(err) === 409;
+// const isConflictError = err => getStatus(err) === 409;
 
 const updateBatchState = async batch => {
   const statuses = await batchService.getTransactionStatusCounts(batch.id);
@@ -72,6 +72,8 @@ const updateBatchState = async batch => {
   return flags;
 };
 
+const getTransactionStatus = batch => get(batch, 'invoices[0].invoiceLicences[0].transactions[0].status');
+
 const handler = async job => {
   batchJob.logHandling(job);
   const transactionId = get(job, 'data.billingBatchTransactionId');
@@ -80,6 +82,12 @@ const handler = async job => {
   const batch = await transactionsService.getById(transactionId);
 
   try {
+    // Skip CM call if transaction is already processed
+    const status = getTransactionStatus(batch);
+    if (status !== Transaction.statuses.candidate) {
+      return await updateBatchState(batch);
+    }
+
     // Map data to charge module transaction
     const [cmTransaction] = batchMapper.modelToChargeModule(batch);
 
@@ -95,11 +103,16 @@ const handler = async job => {
     batchJob.logHandlingError(job, err);
 
     // if the charge was created in the CM
+    /*
+    // Note: this has been temporarily removed as it is not supported
+    // by CM v2 currently
     if (isConflictError(err)) {
       await transactionsService.updateWithChargeModuleResponse(transactionId, err.response.body);
       return updateBatchState(batch);
     }
-    // if error code >= 400 and < 500 set transacti on status to error and continue
+    */
+
+    // if error code >= 400 and < 500 set transaction status to error and continue
     if (isClientError(err)) {
       await transactionsService.setErrorStatus(transactionId);
       return updateBatchState(batch);

--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -45,13 +45,6 @@ const getStatus = err => get(err, 'statusCode', 0);
  */
 const isClientError = err => inRange(getStatus(err), 400, 500);
 
-/**
- * Checks if error is HTTP 409 - conflict
- * @param {Error} err
- * @return {Boolean}
- */
-// const isConflictError = err => getStatus(err) === 409;
-
 const updateBatchState = async batch => {
   const statuses = await batchService.getTransactionStatusCounts(batch.id);
   const flags = {
@@ -101,16 +94,6 @@ const handler = async job => {
     return await updateBatchState(batch);
   } catch (err) {
     batchJob.logHandlingError(job, err);
-
-    // if the charge was created in the CM
-    /*
-    // Note: this has been temporarily removed as it is not supported
-    // by CM v2 currently
-    if (isConflictError(err)) {
-      await transactionsService.updateWithChargeModuleResponse(transactionId, err.response.body);
-      return updateBatchState(batch);
-    }
-    */
 
     // if error code >= 400 and < 500 set transaction status to error and continue
     if (isClientError(err)) {

--- a/test/modules/billing/jobs/create-charge.js
+++ b/test/modules/billing/jobs/create-charge.js
@@ -316,42 +316,6 @@ experiment('modules/billing/jobs/create-charge', () => {
       });
     });
 
-    /*
-    // Note: this has been temporarily removed as it is not supported
-    // by CM v2 currently
-    experiment('when there is 409 error in the charge module', () => {
-      const err = new Error('Test error');
-      err.statusCode = 409;
-      err.response = {
-        body: {
-          id: '7205bd26-8064-4bf3-beb7-b4c4df7e29d4',
-          clientId: '548f5338-3dcf-4235-a3ba-4a3024a3710f'
-        }
-      };
-
-      beforeEach(async () => {
-        chargeModuleBillRunConnector.addTransaction.rejects(err);
-        await createChargeJob.handler(job);
-      });
-
-      test('the error is logged', async () => {
-        expect(batchJob.logHandlingError.calledWith(
-          job, err
-        )).to.be.true();
-      });
-
-      test('the transaction is updated with the charge module response', async () => {
-        const [id, response] = transactionService.updateWithChargeModuleResponse.lastCall.args;
-        expect(id).to.equal(transactionId);
-        expect(response).to.equal(err.response.body);
-      });
-
-      test('the batch status is not set to "error"', async () => {
-        expect(batchService.setErrorStatus.called).to.be.false();
-      });
-    });
-    */
-
     experiment('when there is a 5xx error', () => {
       const err = new Error('Test error');
       err.statusCode = 500;


### PR DESCRIPTION
`WATER-3150`
* Due to recent changes in the CM API responses, removes 409 handling (as the transaction ID is not present the invoked code cannot correctly process the response payload)
* Ensures the transaction is in "candidate" status before creating the tx in the CM

We may still need to:
* Get CM team to re-implement transaction ID in 409 response payload
* Re-introduce the 409 handling removed here