### PR TITLE
Move empty batch detection to end of CM refresh

### DIFF
--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -47,22 +47,15 @@ const isClientError = err => inRange(getStatus(err), 400, 500);
 
 const updateBatchState = async batch => {
   const statuses = await batchService.getTransactionStatusCounts(batch.id);
-  const flags = {
-    isReady: get(statuses, Transaction.statuses.candidate, 0) === 0,
-    isEmptyBatch: get(statuses, Transaction.statuses.chargeCreated, 0) === 0
-  };
 
-  if (flags.isReady) {
+  const isReady = get(statuses, Transaction.statuses.candidate, 0) === 0;
+
+  if (isReady) {
     // Clean up batch
     await batchService.cleanup(batch.id);
-
-    // Set batch status to empty for empty batch
-    if (flags.isEmptyBatch) {
-      await batchService.setStatus(batch.id, BATCH_STATUS.empty);
-    }
   }
 
-  return flags;
+  return isReady;
 };
 
 const getTransactionStatus = batch => get(batch, 'invoices[0].invoiceLicences[0].transactions[0].status');
@@ -110,9 +103,9 @@ const onComplete = async (job, queueManager) => {
 
   try {
     const { batchId } = job.data;
-    const { isReady, isEmptyBatch } = job.returnvalue;
+    const isReady = job.returnvalue;
 
-    if (isReady && !isEmptyBatch) {
+    if (isReady) {
       /* the generate() function calls `PATCH /wrls/v2/{bill run}/generate` which tells the charge module
       * to generate the bill run summary
       */

--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -5,7 +5,7 @@ const { get, inRange } = require('lodash');
 const JOB_NAME = 'billing.create-charge';
 
 const batchService = require('../services/batch-service');
-const { BATCH_ERROR_CODE, BATCH_STATUS } = require('../../../lib/models/batch');
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 const batchJob = require('./lib/batch-job');
 const helpers = require('./lib/helpers');
 const transactionsService = require('../services/transactions-service');

--- a/src/modules/billing/jobs/populate-batch-charge-versions.js
+++ b/src/modules/billing/jobs/populate-batch-charge-versions.js
@@ -24,12 +24,8 @@ const handler = async job => {
     const batch = await batchService.getBatchById(batchId);
 
     // Populate water.billing_batch_charge_version_years
-    const billingBatchChargeVersionYears = await chargeVersionService.createForBatch(batch);
-    // If there is nothing to process, mark empty batch
-    if (billingBatchChargeVersionYears.length === 0) {
-      const updatedBatch = await batchService.setStatus(batchId, BATCH_STATUS.empty);
-      return { batch: updatedBatch };
-    }
+    await chargeVersionService.createForBatch(batch);
+
     return { batch };
   } catch (err) {
     await batchJob.logHandlingErrorAndSetBatchStatus(job, err, BATCH_ERROR_CODE.failedToPopulateChargeVersions);
@@ -42,11 +38,6 @@ const onComplete = async (job, queueManager) => {
 
   try {
     const { batch } = job.returnvalue;
-
-    // Don't do any further processing for empty batch
-    if (batch.status === BATCH_STATUS.empty) {
-      return;
-    }
 
     if (batch.type === BATCH_TYPE.annual) {
       await queueManager.add(processChargeVersionsJobName, batch.id);

--- a/src/modules/billing/jobs/populate-batch-charge-versions.js
+++ b/src/modules/billing/jobs/populate-batch-charge-versions.js
@@ -7,7 +7,7 @@ const JOB_NAME = 'billing.populate-batch-charge-versions';
 const batchService = require('../services/batch-service');
 const chargeVersionService = require('../services/charge-version-service');
 
-const { BATCH_ERROR_CODE, BATCH_STATUS, BATCH_TYPE } = require('../../../lib/models/batch');
+const { BATCH_ERROR_CODE, BATCH_TYPE } = require('../../../lib/models/batch');
 const helpers = require('./lib/helpers');
 const batchJob = require('./lib/batch-job');
 

--- a/src/modules/billing/jobs/prepare-transactions.js
+++ b/src/modules/billing/jobs/prepare-transactions.js
@@ -5,7 +5,7 @@ const { get, partial } = require('lodash');
 const JOB_NAME = 'billing.prepare-transactions';
 
 const batchService = require('../services/batch-service');
-const { BATCH_ERROR_CODE, BATCH_STATUS } = require('../../../lib/models/batch');
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 const batchJob = require('./lib/batch-job');
 const helpers = require('./lib/helpers');
 const { jobName: createChargeJobName } = require('./create-charge');

--- a/src/modules/billing/jobs/prepare-transactions.js
+++ b/src/modules/billing/jobs/prepare-transactions.js
@@ -35,13 +35,6 @@ const handler = async job => {
     const transactions = await billingTransactionsRepo.findByBatchId(batch.id);
     const billingTransactionIds = transactions.map(getTransactionId);
 
-    // Set empty batch
-    if (transactions.length === 0) {
-      logger.info(`No transactions produced for batch ${batchId}, finalising batch run`);
-      await batchService.setStatus(batchId, BATCH_STATUS.empty);
-      return { billingTransactionIds };
-    }
-
     return {
       billingTransactionIds
     };

--- a/src/modules/billing/jobs/process-charge-versions.js
+++ b/src/modules/billing/jobs/process-charge-versions.js
@@ -9,6 +9,7 @@ const { BATCH_ERROR_CODE } = require('../../../lib/models/batch');
 const batchJob = require('./lib/batch-job');
 const helpers = require('./lib/helpers');
 const { jobName: processChargeVersionYearJobName } = require('./process-charge-version-year');
+const { jobName: refreshTotalsJobName } = require('./refresh-totals');
 const batchStatus = require('./lib/batch-status');
 const chargeVersionYearService = require('../services/charge-version-year');
 
@@ -47,6 +48,11 @@ const onComplete = async (job, queueManager) => {
   try {
     const batchId = get(job, 'data.batchId');
     const { billingBatchChargeVersionYearIds } = job.returnvalue;
+
+    // If there's nothing to process, skip to cm refresh
+    if (billingBatchChargeVersionYearIds.length === 0) {
+      await queueManager.add(refreshTotalsJobName, batchId);
+    }
 
     // Publish a job to process each charge version year
     for (const billingBatchChargeVersionYearId of billingBatchChargeVersionYearIds) {

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -212,18 +212,6 @@ const getTransactionStatusCounts = async batchId => {
 };
 
 /**
- * If the batch has no more transactions then the batch is set
- * to empty, otherwise it stays the same
- *
- * @param {Batch} batch
- * @returns {Batch} The updated batch if no transactions
- */
-const setStatusToEmptyWhenNoTransactions = async batch => {
-  const count = await newRepos.billingTransactions.countByBatchId(batch.id);
-  return count === 0 ? setStatus(batch.id, BATCH_STATUS.empty) : batch;
-};
-
-/**
  * Cleans up any
  * - billing_invoice_licences with no related billing_transactions
  * - billing_invoices with no related billing_invoice_licences
@@ -363,8 +351,7 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     const invoiceModel = mappers.invoice.dbToModel(invoice);
     await updateInvoiceLicencesForSupplementaryReprocessing(invoiceModel);
 
-    // Mark batch as 'empty' if needed
-    return setStatusToEmptyWhenNoTransactions(batch);
+    return batch;
   } catch (err) {
     await setErrorStatus(batch.id, Batch.BATCH_ERROR_CODE.failedToDeleteInvoice);
     throw err;
@@ -398,22 +385,27 @@ const deleteAllBillingData = async () => {
  * @return {Promise<Batch>} updated batch model
  */
 const updateWithCMSummary = async (batchId, cmResponse) => {
+  // Extract counts/totals from CM bill run response
   const { invoiceCount, creditLineCount: creditNoteCount, invoiceValue, creditLineValue: creditNoteValue, netTotal, status: cmStatus } = cmResponse.billRun;
 
+  // Calculate next batch status
   const cmCompletedStatuses = ['pending', 'billed', 'billing_not_required'];
+  const status = cmCompletedStatuses.includes(cmStatus) ? Batch.BATCH_STATUS.sent : Batch.BATCH_STATUS.ready;
 
-  const status = cmCompletedStatuses.includes(cmStatus)
-    ? Batch.BATCH_STATUS.sent
-    : Batch.BATCH_STATUS.ready;
+  // Get transaction count in local DB
+  // if 0, the batch will be set to "empty" status
+  const count = await newRepos.billingTransactions.countByBatchId(batchId);
 
-  const changes = {
-    status,
-    invoiceCount,
-    creditNoteCount,
-    invoiceValue,
-    creditNoteValue,
-    netTotal
-  };
+  const changes = count === 0
+    ? { status: BATCH_STATUS.empty }
+    : {
+      status,
+      invoiceCount,
+      creditNoteCount,
+      invoiceValue,
+      creditNoteValue,
+      netTotal
+    };
 
   const data = await newRepos.billingBatches.update(batchId, changes);
   return mappers.batch.dbToModel(data);
@@ -432,7 +424,6 @@ exports.saveInvoicesToDB = saveInvoicesToDB;
 exports.setErrorStatus = setErrorStatus;
 exports.setStatus = setStatus;
 exports.setStatusToReview = partialRight(setStatus, Batch.BATCH_STATUS.review);
-exports.setStatusToEmptyWhenNoTransactions = setStatusToEmptyWhenNoTransactions;
 exports.cleanup = cleanup;
 exports.create = create;
 exports.createChargeModuleBillRun = createChargeModuleBillRun;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -329,14 +329,14 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     throw new BatchStatusError(`Cannot delete invoice from batch when status is ${batch.status}`);
   }
 
-  // Set batch status back to 'processing'
-  await setStatus(batch.id, Batch.BATCH_STATUS.processing);
-
   // Load invoice
   const invoice = await newRepos.billingInvoices.findOne(invoiceId);
   if (!invoice) {
     throw new NotFoundError(`Invoice ${invoiceId} not found`);
   }
+
+  // Set batch status back to 'processing'
+  await setStatus(batch.id, Batch.BATCH_STATUS.processing);
 
   try {
     await chargeModuleBillRunConnector.deleteInvoiceFromBillRun(invoice.billingBatch.externalId, invoice.externalId);

--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -225,10 +225,12 @@ const updateBatch = async batchId => {
     return false;
   }
 
-  // Set batch totals
-  batch = await batchService.updateWithCMSummary(batch.id, cmResponse);
   // Update invoices in batch
   await updateInvoices(batch, cmResponse);
+
+  // Set batch totals
+  batch = await batchService.updateWithCMSummary(batch.id, cmResponse);
+
   return true;
 };
 

--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -226,9 +226,11 @@ const updateBatch = async batchId => {
   }
 
   // Update invoices in batch
+  // It is important to update the invoices first so that
+  // for a batch containing only re-billing, there are >0 transactions
+  // in the batch before calculating the new batch status
   await updateInvoices(batch, cmResponse);
 
-  // Set batch totals
   await batchService.updateWithCMSummary(batch.id, cmResponse);
 
   return true;

--- a/src/modules/billing/services/cm-refresh-service.js
+++ b/src/modules/billing/services/cm-refresh-service.js
@@ -213,7 +213,7 @@ const isCMGeneratingSummary = cmResponse => get(cmResponse, 'billRun.status') ==
 
 const updateBatch = async batchId => {
   // Fetch WRLS batch
-  let batch = await batchService.getBatchById(batchId);
+  const batch = await batchService.getBatchById(batchId);
   if (!batch) {
     throw new errors.NotFoundError(`CM refresh failed, batch ${batchId} not found`);
   }
@@ -229,7 +229,7 @@ const updateBatch = async batchId => {
   await updateInvoices(batch, cmResponse);
 
   // Set batch totals
-  batch = await batchService.updateWithCMSummary(batch.id, cmResponse);
+  await batchService.updateWithCMSummary(batch.id, cmResponse);
 
   return true;
 };

--- a/src/modules/billing/services/job-service.js
+++ b/src/modules/billing/services/job-service.js
@@ -22,14 +22,6 @@ const setReadyJob = (eventId, batchId) =>
   setStatuses(eventId, jobStatus.complete, batchId, BATCH_STATUS.ready);
 
 /**
- * Sets the event/job to complete, and the batch to empty
- * @param {String} eventId
- * @param {String} batchId
- */
-const setEmptyBatch = (eventId, batchId) =>
-  setStatuses(eventId, jobStatus.complete, batchId, BATCH_STATUS.empty);
-
-/**
  * Sets the event/job to error, and the batch to error
  * @param {String} eventId
  * @param {String} batchId
@@ -45,7 +37,6 @@ const setFailedJob = (eventId, batchId) =>
 const setReviewJob = (eventId, batchId) =>
   setStatuses(eventId, jobStatus.review, batchId, BATCH_STATUS.review);
 
-exports.setEmptyBatch = setEmptyBatch;
 exports.setFailedJob = setFailedJob;
 exports.setReadyJob = setReadyJob;
 exports.setReviewJob = setReviewJob;

--- a/test/modules/billing/jobs/create-charge.js
+++ b/test/modules/billing/jobs/create-charge.js
@@ -216,11 +216,8 @@ experiment('modules/billing/jobs/create-charge', () => {
         expect(batchService.setStatus.called).to.be.false();
       });
 
-      test('resolves with flags to indicate status', async () => {
-        expect(result).to.equal({
-          isEmptyBatch: false,
-          isReady: true
-        });
+      test('resolves with boolean to indicate if batch ready', async () => {
+        expect(result).to.equal(true);
       });
     });
 
@@ -254,11 +251,8 @@ experiment('modules/billing/jobs/create-charge', () => {
         expect(batchService.setStatus.called).to.be.false();
       });
 
-      test('resolves with flags to indicate status', async () => {
-        expect(result).to.equal({
-          isEmptyBatch: false,
-          isReady: true
-        });
+      test('resolves with boolean to indicate if batch ready', async () => {
+        expect(result).to.equal(true);
       });
     });
 
@@ -277,17 +271,8 @@ experiment('modules/billing/jobs/create-charge', () => {
         )).to.be.true();
       });
 
-      test('the batch status is set to "empty"', async () => {
-        expect(batchService.setStatus.calledWith(
-          batchId, Batch.BATCH_STATUS.empty
-        )).to.be.true();
-      });
-
-      test('resolves with flags to indicate status', async () => {
-        expect(result).to.equal({
-          isEmptyBatch: true,
-          isReady: true
-        });
+      test('resolves with boolean to indicate batch is ready', async () => {
+        expect(result).to.equal(true);
       });
     });
 
@@ -346,9 +331,7 @@ experiment('modules/billing/jobs/create-charge', () => {
           data: {
             batchId
           },
-          returnvalue: {
-            isReady: false
-          }
+          returnvalue: false
         };
         await createChargeJob.onComplete(job, queueManager);
       });
@@ -366,35 +349,13 @@ experiment('modules/billing/jobs/create-charge', () => {
       });
     });
 
-    experiment('when a batch is ready but empty', () => {
+    experiment('when a batch is ready', () => {
       beforeEach(async () => {
         const job = {
           data: {
             batchId
           },
-          returnvalue: {
-            isReady: true,
-            isEmptyBatch: true
-          }
-        };
-        await createChargeJob.onComplete(job, queueManager);
-      });
-
-      test('no further jobs are published', async () => {
-        expect(queueManager.add.called).to.be.false();
-      });
-    });
-
-    experiment('when a batch is ready and not empty', () => {
-      beforeEach(async () => {
-        const job = {
-          data: {
-            batchId
-          },
-          returnvalue: {
-            isReady: true,
-            isEmptyBatch: false
-          }
+          returnvalue: true
         };
         await createChargeJob.onComplete(job, queueManager);
       });

--- a/test/modules/billing/jobs/populate-batch-charge-versions.js
+++ b/test/modules/billing/jobs/populate-batch-charge-versions.js
@@ -149,23 +149,6 @@ experiment('modules/billing/jobs/populate-batch-charge-versions', () => {
   });
 
   experiment('.onComplete', () => {
-    experiment('when the batch is empty', () => {
-      beforeEach(async () => {
-        const job = {
-          returnvalue: {
-            batch: {
-              status: Batch.BATCH_STATUS.empty
-            }
-          }
-        };
-        await populateBatchChargeVersionsJob.onComplete(job, queueManager);
-      });
-
-      test('no further jobs are scheduled', async () => {
-        expect(queueManager.add.called).to.be.false();
-      });
-    });
-
     experiment('when the batch is a processing "annual" batch', () => {
       let job;
 

--- a/test/modules/billing/jobs/process-charge-versions.js
+++ b/test/modules/billing/jobs/process-charge-versions.js
@@ -14,6 +14,7 @@ const processChargeVersionsJob = require('../../../../src/modules/billing/jobs/p
 const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
 const chargeVersionYearService = require('../../../../src/modules/billing/services/charge-version-year');
 const batchService = require('../../../../src/modules/billing/services/batch-service');
+const { logger } = require('../../../../src/logger');
 
 const Batch = require('../../../../src/lib/models/batch');
 
@@ -41,6 +42,8 @@ experiment('modules/billing/jobs/process-charge-versions', () => {
     sandbox.stub(batchJob, 'logHandling');
     sandbox.stub(batchJob, 'logHandlingErrorAndSetBatchStatus');
     sandbox.stub(batchJob, 'logOnCompleteError');
+
+    sandbox.stub(logger, 'info');
 
     queueManager = {
       add: sandbox.stub()
@@ -170,6 +173,20 @@ experiment('modules/billing/jobs/process-charge-versions', () => {
         )).to.be.true();
         expect(queueManager.add.calledWith(
           'billing.process-charge-version-year', batchId, job.returnvalue.billingBatchChargeVersionYearIds[1]
+        )).to.be.true();
+      });
+    });
+
+    experiment('when there are 0 charge version years to process', () => {
+      beforeEach(async () => {
+        job.returnvalue.billingBatchChargeVersionYearIds = [];
+        processChargeVersionsJob.onComplete(job, queueManager);
+      });
+
+      test('a job is published to refresh the totals', async () => {
+        expect(queueManager.add.callCount).to.equal(1);
+        expect(queueManager.add.calledWith(
+          'billing.refresh-totals', batchId
         )).to.be.true();
       });
     });

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -747,6 +747,7 @@ experiment('modules/billing/services/batch-service', () => {
 
     experiment('when the CM batch is not approved for billing', () => {
       beforeEach(async () => {
+        newRepos.billingTransactions.countByBatchId.resolves(5);
         await batchService.updateWithCMSummary(BATCH_ID, cmResponse);
       });
 
@@ -764,6 +765,7 @@ experiment('modules/billing/services/batch-service', () => {
 
     experiment('when the CM batch is showing as "pending"', () => {
       beforeEach(async () => {
+        newRepos.billingTransactions.countByBatchId.resolves(5);
         cmResponse.billRun.status = 'pending';
         await batchService.updateWithCMSummary(BATCH_ID, cmResponse);
       });
@@ -776,6 +778,20 @@ experiment('modules/billing/services/batch-service', () => {
           invoiceValue,
           creditNoteValue,
           netTotal
+        })).to.be.true();
+      });
+    });
+
+    experiment('when there are 0 transactions in the batch', () => {
+      beforeEach(async () => {
+        newRepos.billingTransactions.countByBatchId.resolves(0);
+        cmResponse.billRun.status = 'pending';
+        await batchService.updateWithCMSummary(BATCH_ID, cmResponse);
+      });
+
+      test('the batch is updated correctly with "sent" status', async () => {
+        expect(newRepos.billingBatches.update.calledWith(BATCH_ID, {
+          status: Batch.BATCH_STATUS.empty
         })).to.be.true();
       });
     });

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -802,41 +802,6 @@ experiment('modules/billing/services/batch-service', () => {
     });
   });
 
-  experiment('.setStatusToEmptyWhenNoTransactions', () => {
-    experiment('when the batch has more transactions', () => {
-      test('the status is not updated', async () => {
-        const batch = new Batch(uuid());
-        batch.status = Batch.BATCH_STATUS.ready;
-
-        newRepos.billingTransactions.countByBatchId.resolves(5);
-
-        const result = await batchService.setStatusToEmptyWhenNoTransactions(batch);
-
-        expect(newRepos.billingBatches.update.called).to.equal(false);
-        expect(result.id).to.equal(batch.id);
-        expect(result.status).to.equal(batch.status);
-      });
-    });
-
-    experiment('when the batch has no more transactions', () => {
-      test('the status is updated to empty', async () => {
-        const batch = new Batch(uuid());
-        batch.status = Batch.BATCH_STATUS.ready;
-
-        newRepos.billingTransactions.countByBatchId.resolves(0);
-
-        newRepos.billingBatches.update.resolves({
-          id: batch.id,
-          status: Batch.BATCH_STATUS.empty
-        });
-
-        const result = await batchService.setStatusToEmptyWhenNoTransactions(batch);
-        expect(result.id).to.equal(batch.id);
-        expect(result.status).to.equal(Batch.BATCH_STATUS.empty);
-      });
-    });
-  });
-
   experiment('.cleanup', () => {
     beforeEach(async () => {
       await batchService.cleanup(BATCH_ID);
@@ -1203,12 +1168,6 @@ experiment('modules/billing/services/batch-service', () => {
           expect(from).to.equal('yes');
           expect(to).to.equal('reprocess');
           expect(licenceId).to.equal(licenceId);
-        });
-
-        test('sets status of batch to empty when there are no transactions', () => {
-          expect(newRepos.billingBatches.update.calledWith(
-            batch.id, { status: 'empty' }
-          )).to.be.true();
         });
       });
 

--- a/test/modules/billing/services/invoice-licences-service.js
+++ b/test/modules/billing/services/invoice-licences-service.js
@@ -10,7 +10,6 @@ const sandbox = sinon.createSandbox();
 const uuid = require('uuid/v4');
 
 const invoiceLicencesService = require('../../../../src/modules/billing/services/invoice-licences-service');
-const batchService = require('../../../../src/modules/billing/services/batch-service');
 
 const Invoice = require('../../../../src/lib/models/invoice');
 const InvoiceLicence = require('../../../../src/lib/models/invoice-licence');
@@ -34,8 +33,6 @@ experiment('modules/billing/services/invoice-licences-service', () => {
     });
 
     sandbox.stub(newRepos.licences, 'updateIncludeLicenceInSupplementaryBilling');
-
-    sandbox.stub(batchService, 'setStatusToEmptyWhenNoTransactions').resolves();
   });
 
   afterEach(async () => {

--- a/test/modules/billing/services/job-service.js
+++ b/test/modules/billing/services/job-service.js
@@ -44,24 +44,6 @@ experiment('modules/billing/services/jobService', () => {
     });
   });
 
-  experiment('.setEmptyBatch', () => {
-    beforeEach(async () => {
-      await jobService.setEmptyBatch('test-event-id', 'test-batch-id');
-    });
-
-    test('updates the event status', async () => {
-      const [eventId, status] = eventService.updateStatus.lastCall.args;
-      expect(eventId).to.equal('test-event-id');
-      expect(status).to.equal(jobStatus.complete);
-    });
-
-    test('updates the batch status', async () => {
-      const [batchId, status] = batchService.setStatus.lastCall.args;
-      expect(batchId).to.equal('test-batch-id');
-      expect(status).to.equal(BATCH_STATUS.empty);
-    });
-  });
-
   experiment('.setFailedJob', () => {
     beforeEach(async () => {
       await jobService.setFailedJob('test-event-id', 'test-batch-id');


### PR DESCRIPTION
`WATER-3106`

Previously an empty batch was detected at various points in the billing process, and the process was aborted early.

With re-billing, a supplementary batch can contain re-billed transactions only, and this isn't known until the `refresh-totals` job is finished.  This is at the end of the process.

Therefore all empty batch detection is moved to after this process has completed.