### PR TITLE
Feat/water 3157 licence agreement purpose uses

### DIFF
--- a/migrations/20210430141208-licence-agreement-purpose-uses.js
+++ b/migrations/20210430141208-licence-agreement-purpose-uses.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210430141208-licence-agreement-purpose-uses-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210430141208-licence-agreement-purpose-uses-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20210430141208-licence-agreement-purpose-uses-down.sql
+++ b/migrations/sqls/20210430141208-licence-agreement-purpose-uses-down.sql
@@ -2,7 +2,7 @@
 drop table water.licence_agreement_purpose_uses;
 
 alter table water.licence_agreements 
-  drop column legacy_id;
+  drop column external_id;
 
 alter table water.licence_agreements 
   alter column licence_agreement_id type varchar using licence_agreement_id::varchar;

--- a/migrations/sqls/20210430141208-licence-agreement-purpose-uses-down.sql
+++ b/migrations/sqls/20210430141208-licence-agreement-purpose-uses-down.sql
@@ -1,0 +1,10 @@
+/* Replace with your SQL commands */
+drop table water.licence_agreement_purpose_uses;
+
+alter table water.licence_agreements 
+  drop column legacy_id;
+
+alter table water.licence_agreements 
+  alter column licence_agreement_id type varchar using licence_agreement_id::varchar;
+
+  

--- a/migrations/sqls/20210430141208-licence-agreement-purpose-uses-up.sql
+++ b/migrations/sqls/20210430141208-licence-agreement-purpose-uses-up.sql
@@ -1,0 +1,15 @@
+/* Convert primary key to proper UUID column */
+alter table water.licence_agreements
+  alter column licence_agreement_id type uuid using licence_agreement_id::uuid;
+
+/* Add a legacy ID column to track TPT agreements imported from NALD */
+alter table water.licence_agreements 
+  add column legacy_id uuid default null unique;
+
+/* Create a join table to allow purpose uses to be attached to a licence agreement */
+create table water.licence_agreement_purpose_uses (
+  licence_agreement_id uuid not null references water.licence_agreements (licence_agreement_id),
+  purpose_use_id uuid not null references water.purposes_uses (purpose_use_id),
+  primary key(licence_agreement_id, purpose_use_id)
+);
+  

--- a/migrations/sqls/20210430141208-licence-agreement-purpose-uses-up.sql
+++ b/migrations/sqls/20210430141208-licence-agreement-purpose-uses-up.sql
@@ -4,12 +4,13 @@ alter table water.licence_agreements
 
 /* Add a legacy ID column to track TPT agreements imported from NALD */
 alter table water.licence_agreements 
-  add column legacy_id uuid default null unique;
+  add column external_id varchar default null unique;
 
 /* Create a join table to allow purpose uses to be attached to a licence agreement */
 create table water.licence_agreement_purpose_uses (
+  licence_agreement_purpose_use_id uuid not null default public.gen_random_uuid() primary key,
   licence_agreement_id uuid not null references water.licence_agreements (licence_agreement_id),
   purpose_use_id uuid not null references water.purposes_uses (purpose_use_id),
-  primary key(licence_agreement_id, purpose_use_id)
+  unique(licence_agreement_id, purpose_use_id)
 );
   

--- a/src/lib/connectors/bookshelf/LicenceAgreement.js
+++ b/src/lib/connectors/bookshelf/LicenceAgreement.js
@@ -15,5 +15,9 @@ module.exports = bookshelf.model('LicenceAgreement', {
 
   financialAgreementType () {
     return this.hasOne('FinancialAgreementType', 'financial_agreement_type_id', 'financial_agreement_type_id');
+  },
+
+  licenceAgreementPurposeUses () {
+    return this.hasMany('LicenceAgreementPurposeUse', 'licence_agreement_id', 'licence_agreement_id');
   }
 });

--- a/src/lib/connectors/bookshelf/LicenceAgreementPurposeUse.js
+++ b/src/lib/connectors/bookshelf/LicenceAgreementPurposeUse.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { bookshelf } = require('./bookshelf.js');
+
+module.exports = bookshelf.model('LicenceAgreementPurposeUse', {
+  tableName: 'water.licence_agreement_purpose_uses',
+
+  idAttribute: 'licence_agreement_purpose_use_id',
+
+  licenceAgreement () {
+    return this.belongsTo('LicenceAgreement', 'licence_agreement_id', 'licence_agreement_id');
+  },
+
+  purposeUse () {
+    return this.hasOne('PurposeUse', 'purpose_use_id', 'purpose_use_id');
+  }
+});

--- a/src/lib/connectors/bookshelf/index.js
+++ b/src/lib/connectors/bookshelf/index.js
@@ -14,6 +14,7 @@ exports.Event = require('./Event');
 exports.FinancialAgreementType = require('./FinancialAgreementType');
 exports.Licence = require('./Licence');
 exports.LicenceAgreement = require('./LicenceAgreement');
+exports.LicenceAgreementPurposeUse = require('./LicenceAgreementPurposeUse');
 exports.LicenceVersion = require('./LicenceVersion');
 exports.LicenceVersionPurpose = require('./LicenceVersionPurpose');
 exports.Region = require('./Region');

--- a/src/lib/connectors/repos/licence-agreements.js
+++ b/src/lib/connectors/repos/licence-agreements.js
@@ -23,7 +23,11 @@ const findByLicenceRef = async (licenceRef, agreementTypes = []) => {
   licenceAgreements = await licenceAgreements
     .orderBy('start_date', 'asc')
     .fetchAll({
-      withRelated: ['financialAgreementType']
+      withRelated: [
+        'financialAgreementType',
+        'licenceAgreementPurposeUses',
+        'licenceAgreementPurposeUses.purposeUse'
+      ]
     });
 
   return licenceAgreements.toJSON();

--- a/src/lib/mappers/licence-agreement-purpose-use.js
+++ b/src/lib/mappers/licence-agreement-purpose-use.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { createMapper } = require('../object-mapper');
+const { createModel } = require('./lib/helpers');
+const LicenceAgreementPurposeUse = require('../models/licence-agreement-purpose-use');
+
+const purposeUseMapper = require('./purpose-use');
+
+const dbToModelMapper = createMapper()
+  .map('licenceAgreementPurposeUseId').to('id')
+  .map('purposeUse').to('purposeUse', purposeUseMapper.dbToModel);
+
+const dbToModel = row => createModel(LicenceAgreementPurposeUse, row, dbToModelMapper);
+
+exports.dbToModel = dbToModel;

--- a/src/lib/mappers/licence-agreement.js
+++ b/src/lib/mappers/licence-agreement.js
@@ -6,13 +6,15 @@ const DateRange = require('../models/date-range');
 const LicenceAgreement = require('../models/licence-agreement');
 
 const agreementMapper = require('./agreement');
+const licenceAgreementPurposeUseMapper = require('./licence-agreement-purpose-use');
 
 const dbToModelMapper = createMapper()
   .map('licenceAgreementId').to('id')
   .map('licenceRef').to('licenceNumber')
   .map(['startDate', 'endDate']).to('dateRange', (startDate, endDate) => new DateRange(startDate, endDate))
   .map('financialAgreementType').to('agreement', agreementMapper.dbToModel)
-  .map('dateSigned').to('dateSigned');
+  .map('dateSigned').to('dateSigned')
+  .map('licenceAgreementPurposeUses').to('licenceAgreementPurposeUses', arr => arr.map(licenceAgreementPurposeUseMapper.dbToModel));
 
 const dbToModel = row => createModel(LicenceAgreement, row, dbToModelMapper);
 

--- a/src/lib/models/licence-agreement-purpose-use.js
+++ b/src/lib/models/licence-agreement-purpose-use.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const validators = require('./validators');
+
+const Model = require('./model');
+const PurposeUse = require('./purpose-use');
+
+class LicenceAgreementPurposeUse extends Model {
+  /**
+   * An instance of PurposeUse for the tertiary/use purpose
+   * @param {PurposeUse}
+   */
+  set purposeUse (purposeUse) {
+    validators.assertIsInstanceOf(purposeUse, PurposeUse);
+    this._purposeUse = purposeUse;
+  }
+
+  get purposeUse () {
+    return this._purposeUse;
+  }
+}
+
+module.exports = LicenceAgreementPurposeUse;

--- a/src/lib/models/licence-agreement.js
+++ b/src/lib/models/licence-agreement.js
@@ -2,6 +2,7 @@
 
 const DateRange = require('./date-range');
 const Agreement = require('./agreement');
+const LicenceAgreementPurposeUse = require('./licence-agreement-purpose-use');
 
 const validators = require('./validators');
 
@@ -51,6 +52,20 @@ class LicenceAgreement extends Model {
 
   set dateSigned (dateSigned) {
     this._dateSigned = this.getDateTimeFromValue(dateSigned);
+  }
+
+  /**
+   * Licence agreement purpose use
+   * @return {LicenceAgreementPurposeUse}
+   */
+  get licenceAgreementPurposeUses () {
+    return this._licenceAgreementPurposeUses;
+  }
+
+  set licenceAgreementPurposeUses (licenceAgreementPurposeUses) {
+    console.log(licenceAgreementPurposeUses);
+    validators.assertIsArrayOfType(licenceAgreementPurposeUses, LicenceAgreementPurposeUse);
+    this._licenceAgreementPurposeUses = licenceAgreementPurposeUses;
   }
 }
 

--- a/test/lib/connectors/bookshelf/LicenceAgreement.js
+++ b/test/lib/connectors/bookshelf/LicenceAgreement.js
@@ -18,6 +18,7 @@ experiment('lib/connectors/bookshelf/LicenceAgreement', () => {
     instance = LicenceAgreement.forge();
     sandbox.stub(instance, 'belongsTo');
     sandbox.stub(instance, 'hasOne');
+    sandbox.stub(instance, 'hasMany');
   });
 
   afterEach(async () => {
@@ -67,6 +68,23 @@ experiment('lib/connectors/bookshelf/LicenceAgreement', () => {
       expect(model).to.equal('FinancialAgreementType');
       expect(foreignKey).to.equal('financial_agreement_type_id');
       expect(foreignKeyTarget).to.equal('financial_agreement_type_id');
+    });
+  });
+
+  experiment('the .licenceAgreementPurposeUses() relation', () => {
+    beforeEach(async () => {
+      instance.licenceAgreementPurposeUses();
+    });
+
+    test('is a function', async () => {
+      expect(instance.licenceAgreementPurposeUses).to.be.a.function();
+    });
+
+    test('calls .hasMany with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
+      expect(model).to.equal('LicenceAgreementPurposeUse');
+      expect(foreignKey).to.equal('licence_agreement_id');
+      expect(foreignKeyTarget).to.equal('licence_agreement_id');
     });
   });
 });

--- a/test/lib/connectors/bookshelf/LicenceAgreementPurposeUse.js
+++ b/test/lib/connectors/bookshelf/LicenceAgreementPurposeUse.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+
+const LicenceAgreementPurposeUse = require('../../../../src/lib/connectors/bookshelf/LicenceAgreementPurposeUse');
+
+experiment('lib/connectors/bookshelf/LicenceAgreementPurposeUse', () => {
+  let instance;
+
+  beforeEach(async () => {
+    instance = LicenceAgreementPurposeUse.forge();
+    sandbox.stub(instance, 'belongsTo');
+    sandbox.stub(instance, 'hasOne');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('uses the water.licence_agreement_purpose_uses table', async () => {
+    expect(instance.tableName).to.equal('water.licence_agreement_purpose_uses');
+  });
+
+  test('uses the correct ID attribute', async () => {
+    expect(instance.idAttribute).to.equal('licence_agreement_purpose_use_id');
+  });
+
+  experiment('the .licenceAgreement() relation', () => {
+    beforeEach(async () => {
+      instance.licenceAgreement();
+    });
+
+    test('is a function', async () => {
+      expect(instance.licenceAgreement).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.belongsTo.lastCall.args;
+      expect(model).to.equal('LicenceAgreement');
+      expect(foreignKey).to.equal('licence_agreement_id');
+      expect(foreignKeyTarget).to.equal('licence_agreement_id');
+    });
+  });
+
+  experiment('the .purposeUse() relation', () => {
+    beforeEach(async () => {
+      instance.purposeUse();
+    });
+
+    test('is a function', async () => {
+      expect(instance.purposeUse).to.be.a.function();
+    });
+
+    test('calls .hasOne with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasOne.lastCall.args;
+      expect(model).to.equal('PurposeUse');
+      expect(foreignKey).to.equal('purpose_use_id');
+      expect(foreignKeyTarget).to.equal('purpose_use_id');
+    });
+  });
+});

--- a/test/lib/connectors/repos/licence-agreements.js
+++ b/test/lib/connectors/repos/licence-agreements.js
@@ -66,7 +66,13 @@ experiment('lib/connectors/repos/licence-agreements', () => {
       });
 
       test('calls .fetchAll() to retrieve all matching records', async () => {
-        expect(stub.fetchAll.called).to.be.true();
+        expect(stub.fetchAll.calledWith({
+          withRelated: [
+            'financialAgreementType',
+            'licenceAgreementPurposeUses',
+            'licenceAgreementPurposeUses.purposeUse'
+          ]
+        })).to.be.true();
       });
 
       test('calls .toJSON() on the collection', async () => {

--- a/test/lib/mappers/licence-agreement-purpose-use.js
+++ b/test/lib/mappers/licence-agreement-purpose-use.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const uuid = require('uuid/v4');
+
+const LicenceAgreementPurposeUse = require('../../../src/lib/models/licence-agreement-purpose-use');
+const PurposeUse = require('../../../src/lib/models/purpose-use');
+
+const licenceAgreementPurposeUseMapper = require('../../../src/lib/mappers/licence-agreement-purpose-use');
+
+const dbRow = {
+  licenceAgreementPurposeUseId: uuid(),
+  purposeUse: {
+    legacyId: '123',
+    dateCreated: '2020-05-06 15:00:04.942199',
+    dateUpdated: '2020-06-17 10:50:09.260824',
+    description: 'Water slides',
+    purposeUseId: 'e2bee7e5-923b-4f67-b163-38bc51f623c1',
+    lossFactor: 'high',
+    isTwoPartTariff: true
+  }
+};
+
+experiment('modules/billing/mappers/licence-agreement-purpose-use', () => {
+  experiment('.dbToModel', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = licenceAgreementPurposeUseMapper.dbToModel(dbRow);
+    });
+
+    test('returns a LicenceAgreementPurposeUse instance with correct ID', async () => {
+      expect(result instanceof LicenceAgreementPurposeUse).to.be.true();
+      expect(result.id).to.equal(dbRow.licenceAgreementPurposeUseId);
+    });
+
+    test('has a purposeUse property', async () => {
+      const { purposeUse } = result;
+      expect(purposeUse instanceof PurposeUse).to.be.true();
+    });
+  });
+});

--- a/test/lib/models/licence-agreement-purpose-use.js
+++ b/test/lib/models/licence-agreement-purpose-use.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const LicenceAgreementPurposeUse = require('../../../src/lib/models/licence-agreement-purpose-use');
+const PurposeUse = require('../../../src/lib/models/purpose-use');
+class TestModel {};
+
+const TEST_GUID = 'add1cf3b-7296-4817-b013-fea75a928580';
+
+experiment('lib/models/licence-agreement-purpose', () => {
+  let licenceAgreementPurposeUse;
+
+  beforeEach(async () => {
+    licenceAgreementPurposeUse = new LicenceAgreementPurposeUse();
+  });
+
+  experiment('.id', () => {
+    test('can be set to a guid string', async () => {
+      licenceAgreementPurposeUse.id = TEST_GUID;
+      expect(licenceAgreementPurposeUse.id).to.equal(TEST_GUID);
+    });
+
+    test('throws an error if set to a non-guid string', async () => {
+      const func = () => {
+        licenceAgreementPurposeUse.id = 'hey';
+      };
+      expect(func).to.throw();
+    });
+  });
+
+  experiment('.purposeUse', () => {
+    test('can be set to a PurposeUse instance', async () => {
+      const purposeUse = new PurposeUse();
+      licenceAgreementPurposeUse.purposeUse = purposeUse;
+      expect(licenceAgreementPurposeUse.purposeUse).to.equal(purposeUse);
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        licenceAgreementPurposeUse.purposeUse = new TestModel();
+      };
+      expect(func).to.throw();
+    });
+
+    test('throws an error if set to null', async () => {
+      const func = () => {
+        licenceAgreementPurposeUse.purposeUse = null;
+      };
+      expect(func).to.throw();
+    });
+  });
+});

--- a/test/lib/models/licence-agreement.js
+++ b/test/lib/models/licence-agreement.js
@@ -5,6 +5,7 @@ const { expect } = require('@hapi/code');
 const moment = require('moment');
 
 const LicenceAgreement = require('../../../src/lib/models/licence-agreement');
+const LicenceAgreementPurposeUse = require('../../../src/lib/models/licence-agreement-purpose-use');
 const DateRange = require('../../../src/lib/models/date-range');
 const Agreement = require('../../../src/lib/models/agreement');
 class TestModel {};
@@ -95,6 +96,22 @@ experiment('lib/models/licence-agreement', () => {
     test('allows null', async () => {
       licenceAgreement.dateSigned = null;
       expect(licenceAgreement.dateSigned).to.be.null();
+    });
+  });
+
+  experiment('.licenceAgreementPurposeUses', () => {
+    test('can be set to an array of LicenceAgreementPurposeUses', async () => {
+      const licenceAgreementPurposeUses = [new LicenceAgreementPurposeUse()];
+      licenceAgreement.licenceAgreementPurposeUses = licenceAgreementPurposeUses;
+      expect(licenceAgreement.licenceAgreementPurposeUses).to.equal(licenceAgreementPurposeUses);
+    });
+
+    test('throws an error if set to a different model type', async () => {
+      const func = () => {
+        const notLicenceAgreementPurposeUses = [new TestModel()];
+        licenceAgreement.licenceAgreementPurposeUses = notLicenceAgreementPurposeUses;
+      };
+      expect(func).to.throw();
     });
   });
 });


### PR DESCRIPTION
`WATER-3157`

Adds a new `licence_agreement_purpose_uses` table along with associated model and mapping code so that:

* the DB is ready to accept the data from the import module
* the purpose uses related to a licence agreement are included in the relevant API endpoint.