### PR TITLE
Include charge period in billing volume endpoint response

### DIFF
--- a/src/modules/billing/controllers/two-part-tariff-review.js
+++ b/src/modules/billing/controllers/two-part-tariff-review.js
@@ -66,8 +66,15 @@ const deleteBatchLicence = async (request, h) => {
  */
 const getBillingVolume = async request => {
   try {
-    const data = await billingVolumesService.getBillingVolumeById(request.params.billingVolumeId);
-    return data;
+    const { billingVolumeId } = request.params;
+
+    const billingVolume = await billingVolumesService.getBillingVolumeById(billingVolumeId);
+
+    // Get charge period
+    billingVolume.chargePeriod = await billingVolumesService.getBillingVolumeChargePeriod(billingVolume);
+
+    // Include the charge period in the payload response
+    return billingVolume;
   } catch (err) {
     return mapErrorResponse(err);
   }

--- a/src/modules/billing/services/billing-volumes-service.js
+++ b/src/modules/billing/services/billing-volumes-service.js
@@ -4,6 +4,9 @@ const billingVolumesRepo = require('../../../lib/connectors/repos/billing-volume
 const mappers = require('../mappers');
 const { NotFoundError } = require('../../../lib/errors');
 const { BillingVolumeStatusError } = require('../lib/errors');
+const { get } = require('lodash');
+const chargeVersionService = require('../../../lib/services/charge-versions');
+const chargePeriod = require('../lib/charge-period');
 
 /**
  * Filter charge elements for matching season
@@ -142,6 +145,21 @@ const getBillingVolumesByChargeVersion = async (chargeVersionId, financialYear, 
   return data.map(mappers.billingVolume.dbToModel);
 };
 
+/**
+ * Gets the charge period for the supplied billing volume ID
+ * This is to support the UI need to display the charge period
+ * during TPT review, when transactions have not yet been
+ * generated
+ *
+ * @param {BillingVolume} billingVolume
+ * @return {Promise<DateRange>}
+ */
+const getBillingVolumeChargePeriod = async billingVolume => {
+  const chargeVersionId = get(billingVolume, 'chargeElement.chargeVersionId');
+  const chargeVersion = await chargeVersionService.getByChargeVersionId(chargeVersionId);
+  return chargePeriod.getChargePeriod(billingVolume.financialYear, chargeVersion);
+};
+
 exports.updateBillingVolume = updateBillingVolume;
 exports.getUnapprovedVolumesForBatchCount = getUnapprovedVolumesForBatchCount;
 exports.getVolumesForBatch = getVolumesForBatch;
@@ -151,3 +169,4 @@ exports.getLicenceBillingVolumes = getLicenceBillingVolumes;
 exports.getBillingVolumeById = getBillingVolumeById;
 exports.getVolumesForChargeElements = getVolumesForChargeElements;
 exports.getBillingVolumesByChargeVersion = getBillingVolumesByChargeVersion;
+exports.getBillingVolumeChargePeriod = getBillingVolumeChargePeriod;

--- a/test/modules/billing/services/billing-volumes-service.js
+++ b/test/modules/billing/services/billing-volumes-service.js
@@ -5,12 +5,16 @@ const sandbox = require('sinon').createSandbox();
 const uuid = require('uuid/v4');
 
 const billingVolumesService = require('../../../../src/modules/billing/services/billing-volumes-service');
+const chargeVersionService = require('../../../../src/lib/services/charge-versions');
 
+const Batch = require('../../../../src/lib/models/batch');
 const BillingVolume = require('../../../../src/lib/models/billing-volume');
 const FinancialYear = require('../../../../src/lib/models/financial-year');
-const Batch = require('../../../../src/lib/models/batch');
+const ChargeElement = require('../../../../src/lib/models/charge-element');
+const ChargeVersion = require('../../../../src/lib/models/charge-version');
 
 const billingVolumesRepo = require('../../../../src/lib/connectors/repos/billing-volumes');
+const chargePeriod = require('../../../../src/modules/billing/lib/charge-period');
 const { NotFoundError } = require('../../../../src/lib/errors');
 const { BillingVolumeStatusError } = require('../../../../src/modules/billing/lib/errors');
 const { createUser, createBatch, createFinancialYear } = require('../test-data/test-billing-data');
@@ -36,6 +40,10 @@ experiment('modules/billing/services/billing-volumes-service', () => {
     sandbox.stub(billingVolumesRepo, 'findByIds').resolves([]);
     sandbox.stub(billingVolumesRepo, 'findByBatchIdAndLicenceId').resolves();
     sandbox.stub(billingVolumesRepo, 'findByChargeVersionFinancialYearAndSeason').resolves([]);
+
+    sandbox.stub(chargeVersionService, 'getByChargeVersionId');
+
+    sandbox.stub(chargePeriod, 'getChargePeriod');
   });
 
   afterEach(async () => sandbox.restore());
@@ -309,6 +317,35 @@ experiment('modules/billing/services/billing-volumes-service', () => {
       expect(billingVolumesRepo.findByIds.calledWith([
         'test-id-1', 'test-id-2'
       ])).to.be.true();
+    });
+  });
+
+  experiment('.getBillingVolumeChargePeriod', () => {
+    const chargeVersionId = uuid();
+    const financialYear = new FinancialYear(2021);
+    const billingVolume = new BillingVolume().fromHash({
+      financialYear
+    });
+    billingVolume.chargeElement = new ChargeElement().fromHash({
+      chargeVersionId
+    });
+    const chargeVersion = new ChargeVersion(chargeVersionId);
+
+    beforeEach(async () => {
+      chargeVersionService.getByChargeVersionId.resolves(chargeVersion);
+      await billingVolumesService.getBillingVolumeChargePeriod(billingVolume);
+    });
+
+    test('gets the charge version linked to this billing volume', async () => {
+      expect(chargeVersionService.getByChargeVersionId.calledWith(
+        chargeVersionId
+      )).to.be.true();
+    });
+
+    test('gets the charge period', async () => {
+      expect(chargePeriod.getChargePeriod.calledWith(
+        financialYear, chargeVersion
+      )).to.be.true();
     });
   });
 });


### PR DESCRIPTION
`WATER-3167`

Include charge period in billing volume API response, so that the charge period can be displayed during TPT review