### PR TITLE
Set full billable volume only when season matches

### DIFF
--- a/src/lib/models/billing-volume.js
+++ b/src/lib/models/billing-volume.js
@@ -126,14 +126,19 @@ class BillingVolume extends Model {
 
   /**
    * Sets the two part tariff status and billable volume
+   *
+   * When the supplied isSummer flag matches that of this billing volume,
+   * the full billable is set.  Otherwise zero is set.
+   *
    * @param {Number} twoPartTariffStatus
    * @param {Number} billableVolume
+   * @param {Boolean} isSummer
    */
-  setTwoPartTariffStatus (twoPartTariffStatus, billableVolume) {
+  setTwoPartTariffStatus (twoPartTariffStatus, billableVolume, isSummer) {
     this.twoPartTariffStatus = twoPartTariffStatus;
     if (assignBillableStatuses.includes(twoPartTariffStatus)) {
       this.calculatedVolume = null;
-      this.volume = billableVolume;
+      this.volume = isSummer === this.isSummer ? billableVolume : 0;
     }
     if (setErrorFlagStatuses.includes(twoPartTariffStatus)) {
       this.twoPartTariffError = true;

--- a/src/modules/billing/services/volume-matching-service/models/charge-element-container.js
+++ b/src/modules/billing/services/volume-matching-service/models/charge-element-container.js
@@ -225,7 +225,7 @@ class ChargeElementContainer {
   setTwoPartTariffStatus (returnSeason, twoPartTariffStatus) {
     validators.assertEnum(returnSeason, Object.values(RETURN_SEASONS));
     const { volume } = this.chargeElement;
-    this._billingVolumes[returnSeason].setTwoPartTariffStatus(twoPartTariffStatus, volume);
+    this._billingVolumes[returnSeason].setTwoPartTariffStatus(twoPartTariffStatus, volume, this.isSummer);
   }
 
   /**

--- a/test/lib/models/billing-volume.js
+++ b/test/lib/models/billing-volume.js
@@ -284,11 +284,12 @@ experiment('lib/models/billingVolume', () => {
     beforeEach(async () => {
       billingVolume.calculatedVolume = 25;
       billingVolume.volume = 15;
+      billingVolume.isSummer = true;
     });
 
     experiment('when no returns are submitted', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NO_RETURNS_SUBMITTED, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NO_RETURNS_SUBMITTED, 20, true);
       });
 
       test('the volume is set', async () => {
@@ -308,9 +309,31 @@ experiment('lib/models/billingVolume', () => {
       });
     });
 
+    experiment('when no returns are submitted, but the season does not match that supplied', () => {
+      beforeEach(async () => {
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NO_RETURNS_SUBMITTED, 20, false);
+      });
+
+      test('the volume is set to zero', async () => {
+        expect(billingVolume.volume).to.be.equal(0);
+      });
+
+      test('the calculatedVolume is null', async () => {
+        expect(billingVolume.calculatedVolume).to.be.null();
+      });
+
+      test('the error flag is not set', async () => {
+        expect(billingVolume.twoPartTariffError).to.not.be.true();
+      });
+
+      test('the status code is set', async () => {
+        expect(billingVolume.twoPartTariffStatus).to.equal(twoPartTariffStatuses.ERROR_NO_RETURNS_SUBMITTED);
+      });
+    });
+
     experiment('when returns are under query', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_UNDER_QUERY, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_UNDER_QUERY, 20, true);
       });
 
       test('the volume and calculated volume are not changed', async () => {
@@ -329,7 +352,7 @@ experiment('lib/models/billingVolume', () => {
 
     experiment('when returns are received not keyed', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_RECEIVED, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_RECEIVED, 20, true);
       });
 
       test('the volume and calculated volume are not changed', async () => {
@@ -348,7 +371,7 @@ experiment('lib/models/billingVolume', () => {
 
     experiment('when some returns are due', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_SOME_RETURNS_DUE, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_SOME_RETURNS_DUE, 20, true);
       });
 
       test('the volume is set', async () => {
@@ -364,13 +387,13 @@ experiment('lib/models/billingVolume', () => {
       });
 
       test('the status code is set', async () => {
-        expect(billingVolume.twoPartTariffStatus).to.equal(twoPartTariffStatuses.ERROR_SOME_RETURNS_DUE);
+        expect(billingVolume.twoPartTariffStatus).to.equal(twoPartTariffStatuses.ERROR_SOME_RETURNS_DUE, true);
       });
     });
 
     experiment('when returns are received late', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_LATE_RETURNS, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_LATE_RETURNS, 20, true);
       });
 
       test('the volume is set', async () => {
@@ -392,7 +415,7 @@ experiment('lib/models/billingVolume', () => {
 
     experiment('when there is over abstraction', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_OVER_ABSTRACTION, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_OVER_ABSTRACTION, 20, true);
       });
 
       test('the volume and calculated volume are not changed', async () => {
@@ -411,7 +434,7 @@ experiment('lib/models/billingVolume', () => {
 
     experiment('when there are no returns for matching', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NO_RETURNS_FOR_MATCHING, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NO_RETURNS_FOR_MATCHING, 20, true);
       });
 
       test('the volume and calculated volume are not changed', async () => {
@@ -430,7 +453,7 @@ experiment('lib/models/billingVolume', () => {
 
     experiment('when the returns are not due for billing', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NOT_DUE_FOR_BILLING, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_NOT_DUE_FOR_BILLING, 20, true);
       });
 
       test('the volume and calculated volume are not changed', async () => {
@@ -449,7 +472,7 @@ experiment('lib/models/billingVolume', () => {
 
     experiment('when a return line overlaps the charge period start/end dates', () => {
       beforeEach(async () => {
-        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_RETURN_LINE_OVERLAPS_CHARGE_PERIOD, 20);
+        billingVolume.setTwoPartTariffStatus(twoPartTariffStatuses.ERROR_RETURN_LINE_OVERLAPS_CHARGE_PERIOD, 20, true);
       });
 
       test('the volume and calculated volume are not changed', async () => {

--- a/test/lib/models/billing-volume.js
+++ b/test/lib/models/billing-volume.js
@@ -322,8 +322,8 @@ experiment('lib/models/billingVolume', () => {
         expect(billingVolume.calculatedVolume).to.be.null();
       });
 
-      test('the error flag is not set', async () => {
-        expect(billingVolume.twoPartTariffError).to.not.be.true();
+      test('the error flag is set', async () => {
+        expect(billingVolume.twoPartTariffError).to.be.true();
       });
 
       test('the status code is set', async () => {

--- a/test/modules/billing/services/volume-matching-service/matching-service.js
+++ b/test/modules/billing/services/volume-matching-service/matching-service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
 const { expect } = require('@hapi/code');
 
 // Services
@@ -14,6 +14,7 @@ const AbstractionPeriod = require('../../../../../src/lib/models/abstraction-per
 const Return = require('../../../../../src/lib/models/return');
 
 const { twoPartTariffStatuses } = require('../../../../../src/lib/models/billing-volume');
+const { logger } = require('../../../../../src/logger');
 
 const {
   chargePeriod,
@@ -21,6 +22,7 @@ const {
   createChargeElementContainer,
   createPurposeUse
 } = require('./data');
+const sandbox = require('sinon').createSandbox();
 
 const purposeUses = {
   sprayIrrigation: createPurposeUse('sprayIrrigation', true),
@@ -29,6 +31,14 @@ const purposeUses = {
 
 experiment('modules/billing/services/volume-matching-service/matching-service', () => {
   let returnGroup, chargeElementGroup, result;
+
+  beforeEach(async () => {
+    sandbox.stub(logger, 'info');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
 
   experiment('when a return has errors', () => {
     beforeEach(async () => {
@@ -43,7 +53,7 @@ experiment('modules/billing/services/volume-matching-service/matching-service', 
 
     test('the matching is aborted early and error codes assigned', async () => {
       expect(result).to.be.an.array().length(1);
-      expect(result[0].volume).to.equal(chargeElementGroup.chargeElementContainers[0].chargeElement.volume);
+      expect(result[0].volume).to.equal(0);
       expect(result[0].calculatedVolume).to.equal(null);
       expect(result[0].twoPartTariffStatus).to.equal(twoPartTariffStatuses.ERROR_NO_RETURNS_SUBMITTED);
     });


### PR DESCRIPTION
`WATER-3166`

To avoid the risk of double-billing, when automatically setting billing volumes, only set the full billable volume if the billing volume season matches the charge element abstraction period season.