### PR TITLE
WATER-3191 - licence links broken in internal returns flows

### DIFF
--- a/src/lib/connectors/repos/licences.js
+++ b/src/lib/connectors/repos/licences.js
@@ -3,6 +3,7 @@
 const raw = require('./lib/raw');
 const { Licence, bookshelf } = require('../bookshelf');
 const queries = require('./queries/licences');
+const helpers = require('./lib/helpers');
 
 const deleteTest = () => Licence
   .forge()
@@ -30,16 +31,9 @@ const findOne = async licenceId => {
   return model ? model.toJSON() : null;
 };
 
-const findOneByLicenceRef = async licenceRef => {
-  const model = await Licence
-    .forge()
-    .where({ licence_ref: licenceRef })
-    .fetchAll({
-      withRelated: ['region']
-    });
-
-  return model.toJSON();
-};
+const findOneByLicenceRef = licenceNumber => helpers.findOne(
+  Licence, 'licence_ref', licenceNumber, ['region']
+);
 
 /**
  * Finds many licences by licence ref array

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -30,12 +30,9 @@ const getLicenceById = async licenceId =>
  * legacy regions
  *
  * @param {String} licenceRef
- * @param {Number} regionCode
  */
-const getLicenceByLicenceRef = async (licenceRef, regionCode) => {
-  const licences = await repos.licences.findOneByLicenceRef(licenceRef);
-  const licence = licences.find(licence => licence.region.naldRegionId === +regionCode);
-
+const getLicenceByLicenceRef = async licenceRef => {
+  const licence = await repos.licences.findOneByLicenceRef(licenceRef);
   return licence ? licenceMapper.dbToModel(licence) : null;
 };
 

--- a/src/modules/licences/controllers/documents.js
+++ b/src/modules/licences/controllers/documents.js
@@ -137,7 +137,7 @@ const getLicenceByDocumentId = async (request, h) => {
     const permitLicence = await getLicence(documentId, includeExpired, companyId);
 
     if (permitLicence) {
-      const waterLicence = await licencesService.getLicenceByLicenceRef(permitLicence.licence_ref, permitLicence.licence_data_value.FGAC_REGION_CODE);
+      const waterLicence = await licencesService.getLicenceByLicenceRef(permitLicence.licence_ref);
       const licence = {
         ...permitLicence,
         id: waterLicence.id
@@ -246,7 +246,7 @@ const getLicenceSummaryByDocumentId = async (request, h) => {
       // add the service layer model to the data object to allow the shift
       // towards using the licence model for viewing licences over the use
       // of the document entity from the CRM.
-      data.waterLicence = await licencesService.getLicenceByLicenceRef(data.licenceNumber, data.regionCode);
+      data.waterLicence = await licencesService.getLicenceByLicenceRef(data.licenceNumber);
 
       data.contacts = mapContacts(licence);
       return { error: null, data };

--- a/src/modules/licences/controllers/licences.js
+++ b/src/modules/licences/controllers/licences.js
@@ -9,6 +9,9 @@ const crmDocumentsConnector = require('../../../lib/connectors/crm/documents');
 const getLicence = async request =>
   controller.getEntity(request.params.licenceId, licencesService.getLicenceById);
 
+const getLicenceByLicenceNumber = async request =>
+  controller.getEntity(request.query.licenceNumber, licencesService.getLicenceByLicenceRef);
+
 const getLicenceVersions = async request =>
   licencesService.getLicenceVersions(request.params.licenceId);
 
@@ -68,3 +71,4 @@ exports.getLicenceDocument = getLicenceDocument;
 exports.getValidLicenceDocumentByDate = getValidLicenceDocumentByDate;
 exports.getLicenceReturns = getLicenceReturns;
 exports.getLicenceNotifications = getLicenceNotifications;
+exports.getLicenceByLicenceNumber = getLicenceByLicenceNumber;

--- a/src/modules/licences/routes/licences.js
+++ b/src/modules/licences/routes/licences.js
@@ -22,6 +22,20 @@ module.exports = {
     }
   },
 
+  getLicenceByLicenceNumber: {
+    method: 'GET',
+    path: `/water/${version}/licences`,
+    handler: controller.getLicenceByLicenceNumber,
+    config: {
+      description: 'Gets licence by licence number',
+      validate: {
+        query: Joi.object({
+          licenceNumber: Joi.string().required()
+        })
+      }
+    }
+  },
+
   getLicenceVersions: {
     method: 'GET',
     path: `${pathPrefix}{licenceId}/versions`,

--- a/test/lib/connectors/repos/licences.js
+++ b/test/lib/connectors/repos/licences.js
@@ -14,6 +14,7 @@ const licenceQueries = require('../../../../src/lib/connectors/repos/queries/lic
 const licencesRepo = require('../../../../src/lib/connectors/repos/licences');
 const { Licence, bookshelf } = require('../../../../src/lib/connectors/bookshelf');
 const raw = require('../../../../src/lib/connectors/repos/lib/raw');
+const helpers = require('../../../../src/lib/connectors/repos/lib/helpers');
 
 experiment('lib/connectors/repos/licences.js', () => {
   let model, stub;
@@ -37,6 +38,7 @@ experiment('lib/connectors/repos/licences.js', () => {
     sandbox.stub(Licence, 'forge').returns(stub);
     sandbox.stub(bookshelf.knex, 'raw');
     sandbox.stub(raw, 'multiRow');
+    sandbox.stub(helpers, 'findOne');
   });
 
   afterEach(async () => {
@@ -83,27 +85,14 @@ experiment('lib/connectors/repos/licences.js', () => {
   });
 
   experiment('.findOneByLicenceRef', () => {
-    let result;
-
     beforeEach(async () => {
-      result = await licencesRepo.findOneByLicenceRef('test-ref');
+      await licencesRepo.findOneByLicenceRef('test-ref');
     });
 
-    test('calls where with correct id', async () => {
-      const [params] = stub.where.lastCall.args;
-      expect(params).to.equal({ licence_ref: 'test-ref' });
-    });
-
-    test('calls fetchAll() with related models', async () => {
-      const [params] = stub.fetchAll.lastCall.args;
-      expect(params.withRelated).to.equal(['region']);
-    });
-
-    test('returns the result of the toJSON() call', async () => {
-      expect(result).to.equal([
-        { foo: 'bar' },
-        { foo: 'baz' }
-      ]);
+    test('calls findOne helper', async () => {
+      expect(helpers.findOne.calledWith(
+        Licence, 'licence_ref', 'test-ref', ['region']
+      )).to.be.true();
     });
   });
 

--- a/test/lib/services/licences.js
+++ b/test/lib/services/licences.js
@@ -122,26 +122,10 @@ experiment('src/lib/services/licences', () => {
 
     experiment('when the licence is not found', () => {
       beforeEach(async () => {
-        repos.licences.findOneByLicenceRef.resolves([]);
+        repos.licences.findOneByLicenceRef.resolves(null);
 
         result = await licencesService.getLicenceByLicenceRef(
-          data.dbRow.licenceRef,
-          data.dbRow.region.naldRegionId
-        );
-      });
-
-      test('resolves with null', async () => {
-        expect(result).to.equal(null);
-      });
-    });
-
-    experiment('when the licence is not found for the region', () => {
-      beforeEach(async () => {
-        repos.licences.findOneByLicenceRef.resolves([data.dbRow]);
-
-        result = await licencesService.getLicenceByLicenceRef(
-          data.dbRow.licenceRef,
-          '00000000-0000-0000-0000-000000001111'
+          data.dbRow.licenceRef
         );
       });
 

--- a/test/modules/licences/controllers/documents.js
+++ b/test/modules/licences/controllers/documents.js
@@ -338,10 +338,9 @@ experiment('modules/licences/controllers/documents', () => {
     test('adds the licence model to the waterService property', async () => {
       const response = await controller.getLicenceSummaryByDocumentId(testRequest);
 
-      const [licenceNumber, regionCode] = licencesService.getLicenceByLicenceRef.lastCall.args;
+      const [licenceNumber] = licencesService.getLicenceByLicenceRef.lastCall.args;
 
       expect(licenceNumber).to.equal('12/34/56/78');
-      expect(regionCode).to.equal('1');
 
       expect(response.data.waterLicence.id).to.equal('test-licence-id');
     });

--- a/test/modules/licences/controllers/licences.js
+++ b/test/modules/licences/controllers/licences.js
@@ -18,6 +18,7 @@ const sandbox = require('sinon').createSandbox();
 experiment('modules/licences/controllers/licences.js', () => {
   beforeEach(async () => {
     sandbox.stub(licencesService, 'getLicenceById');
+    sandbox.stub(licencesService, 'getLicenceByLicenceRef');
     sandbox.stub(licencesService, 'getLicenceVersions');
     sandbox.stub(licencesService, 'getLicenceAccountsByRefAndDate');
     sandbox.stub(licencesService, 'getReturnsByLicenceId');
@@ -342,6 +343,47 @@ experiment('modules/licences/controllers/licences.js', () => {
 
       test('resolves with the service method response', async () => {
         expect(result).to.equal(serviceResponse);
+      });
+    });
+  });
+
+  experiment('.getLicenceByLicenceNumber', () => {
+    let request, result;
+
+    const licenceNumber = '01/123/ABC';
+
+    beforeEach(async () => {
+      request = {
+        query: {
+          licenceNumber
+        }
+      };
+    });
+
+    experiment('when the licence exists', () => {
+      beforeEach(async () => {
+        licencesService.getLicenceByLicenceRef.resolves(new Licence());
+        result = await controller.getLicenceByLicenceNumber(request);
+      });
+
+      test('the licence number is passed to the service', async () => {
+        expect(licencesService.getLicenceByLicenceRef.calledWith(licenceNumber)).to.be.true();
+      });
+
+      test('resolves with a licence model', async () => {
+        expect(result instanceof Licence).to.be.true();
+      });
+    });
+
+    experiment('when the licence does not exist', () => {
+      beforeEach(async () => {
+        licencesService.getLicenceByLicenceRef.resolves(null);
+        result = await controller.getLicenceByLicenceNumber(request);
+      });
+
+      test('resolves with a Boom 404', async () => {
+        expect(result.isBoom).to.be.true();
+        expect(result.output.statusCode).to.equal(404);
       });
     });
   });


### PR DESCRIPTION
`WATER-3191`
* Adds new endpoint to get licence model by licence number
* Refactors repo method to use helper
* Refactors service method to not require region code as argument, since licence numbers are globally unique