### PR TITLE
Add agreements history processor test cases

### DIFF
--- a/src/modules/billing/services/charge-processor-service/lib/agreements.js
+++ b/src/modules/billing/services/charge-processor-service/lib/agreements.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { compact, groupBy, flatMap } = require('lodash');
+const { compact, groupBy, flatMap, sortBy } = require('lodash');
 const helpers = require('@envage/water-abstraction-helpers');
 const dateHelpers = require('./date-helpers');
 const DateRange = require('../../../../../lib/models/date-range');
@@ -34,6 +34,9 @@ const mapHistoryRow = row => {
   };
 };
 
+const getLicenceAgreementStartDate = licenceAgreement =>
+  licenceAgreement.dateRange.startDate;
+
 /**
  * Gets a history of agreements for the charge period taking into account
  * licence agreements
@@ -41,13 +44,17 @@ const mapHistoryRow = row => {
  * @param {Array<LicenceAgreement>} licenceAgreements
  * @return {Array}
  */
-const getAgreementsHistory = (chargePeriod, licenceAgreements) => {
+const getAgreementsHistory =
+(chargePeriod, licenceAgreements) => {
   // Filter out agreements that are not S127/S130 as they don't affect charging
-  const filtered = licenceAgreements
-    .filter(isBillingAgreement);
+  // And sort by start date
+  const filteredAndSorted = sortBy(
+    licenceAgreements.filter(isBillingAgreement),
+    getLicenceAgreementStartDate
+  );
 
   // Group by agreement type as each has its own timeline
-  const groups = groupBy(filtered, getPropertyKey);
+  const groups = groupBy(filteredAndSorted, getPropertyKey);
 
   // Create a combined history by applying the agreements history in each group
   const history = Object.keys(groups).reduce((acc, key) => {

--- a/test/modules/billing/services/charge-processor-service/lib/agreements.js
+++ b/test/modules/billing/services/charge-processor-service/lib/agreements.js
@@ -1,0 +1,183 @@
+const { expect } = require('@hapi/code');
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+
+const agreements = require('../../../../../../src/modules/billing/services/charge-processor-service/lib/agreements');
+
+const Agreement = require('../../../../../../src/lib/models/agreement');
+const DateRange = require('../../../../../../src/lib/models/date-range');
+const LicenceAgreement = require('../../../../../../src/lib/models/licence-agreement');
+
+experiment('modules/billing/services/charge-processor-service/lib/agreements', () => {
+  const chargePeriod = new DateRange('2020-04-01', '2021-03-31');
+
+  experiment('.getAgreementsHistory', () => {
+    const twoPartTariffAgreement = new Agreement().fromHash({
+      code: 'S127'
+    });
+    const canalAndRiversTrustAgreement = new Agreement().fromHash({
+      code: 'S130T'
+    });
+
+    experiment('when the agreement is in place for the full financial year', () => {
+      const licenceAgreements = [
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('1996-10-30', '2005-09-15'),
+          agreement: twoPartTariffAgreement
+        }),
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('2004-10-01', null),
+          agreement: twoPartTariffAgreement
+        })
+      ];
+
+      test('creates a single history item', async () => {
+        const history = agreements.getAgreementsHistory(chargePeriod, licenceAgreements);
+
+        expect(history).to.be.an.array().length(1);
+        expect(history[0].dateRange.startDate).to.equal(chargePeriod.startDate);
+        expect(history[0].dateRange.endDate).to.equal(chargePeriod.endDate);
+
+        // Check agreements
+        expect(history[0].agreements).to.be.an.array().length(1);
+        expect(history[0].agreements[0].code).to.equal('S127');
+      });
+    });
+
+    experiment('when the agreement ends part-way through the full financial year', () => {
+      let history;
+
+      const licenceAgreements = [
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('1996-10-30', '2005-09-15'),
+          agreement: twoPartTariffAgreement
+        }),
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('2004-10-01', '2021-01-01'),
+          agreement: twoPartTariffAgreement
+        })
+      ];
+
+      beforeEach(async () => {
+        history = agreements.getAgreementsHistory(chargePeriod, licenceAgreements);
+      });
+
+      test('creates 2 history items', async () => {
+        expect(history).to.be.an.array().length(2);
+      });
+
+      test('creates a first history item with TPT agreement', async () => {
+        // Period
+        expect(history[0].dateRange.startDate).to.equal(chargePeriod.startDate);
+        expect(history[0].dateRange.endDate).to.equal('2021-01-01');
+
+        // Check agreements
+        expect(history[0].agreements).to.be.an.array().length(1);
+        expect(history[0].agreements[0].code).to.equal('S127');
+      });
+
+      test('creates a second history item without TPT agreement', async () => {
+        // Period
+        expect(history[1].dateRange.startDate).to.equal('2021-01-02');
+        expect(history[1].dateRange.endDate).to.equal(chargePeriod.endDate);
+
+        // Check agreements
+        expect(history[1].agreements).to.be.an.array().length(0);
+      });
+    });
+
+    experiment('when the agreement starts and ends part-way through the full financial year', () => {
+      let history;
+
+      const licenceAgreements = [
+
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('2020-12-01', '2021-01-01'),
+          agreement: twoPartTariffAgreement
+        })
+      ];
+
+      beforeEach(async () => {
+        history = agreements.getAgreementsHistory(chargePeriod, licenceAgreements);
+      });
+
+      test('creates 3 history items', async () => {
+        expect(history).to.be.an.array().length(3);
+      });
+
+      test('creates a first history item without TPT agreement', async () => {
+        // Period
+        expect(history[0].dateRange.startDate).to.equal(chargePeriod.startDate);
+        expect(history[0].dateRange.endDate).to.equal('2020-11-30');
+
+        // Check agreements
+        expect(history[0].agreements).to.be.an.array().length(0);
+      });
+
+      test('creates a second history item with TPT agreement', async () => {
+        // Period
+        expect(history[1].dateRange.startDate).to.equal('2020-12-01');
+        expect(history[1].dateRange.endDate).to.equal('2021-01-01');
+
+        // Check agreements
+        expect(history[1].agreements).to.be.an.array().length(1);
+        expect(history[1].agreements[0].code).to.equal('S127');
+      });
+
+      test('creates a third history item without TPT agreement', async () => {
+        // Period
+        expect(history[2].dateRange.startDate).to.equal('2021-01-02');
+        expect(history[2].dateRange.endDate).to.equal(chargePeriod.endDate);
+
+        // Check agreements
+        expect(history[2].agreements).to.be.an.array().length(0);
+      });
+    });
+
+    experiment('when multiple agreements end part-way through the full financial year', () => {
+      let history;
+
+      const licenceAgreements = [
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('1996-10-30', '2005-09-15'),
+          agreement: twoPartTariffAgreement
+        }),
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('2004-10-01', '2021-01-01'),
+          agreement: twoPartTariffAgreement
+        }),
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('2004-10-01', '2021-01-01'),
+          agreement: canalAndRiversTrustAgreement
+        })
+      ];
+
+      beforeEach(async () => {
+        history = agreements.getAgreementsHistory(chargePeriod, licenceAgreements);
+      });
+
+      test('creates 2 history items', async () => {
+        expect(history).to.be.an.array().length(2);
+      });
+
+      test('creates a first history item with TPT and CRT agreement', async () => {
+        // Period
+        expect(history[0].dateRange.startDate).to.equal(chargePeriod.startDate);
+        expect(history[0].dateRange.endDate).to.equal('2021-01-01');
+
+        // Check agreements
+        expect(history[0].agreements).to.be.an.array().length(2);
+        expect(history[0].agreements[0].code).to.equal('S127');
+        expect(history[0].agreements[1].code).to.equal('S130T');
+      });
+
+      test('creates a second history item without TPT agreement', async () => {
+        // Period
+        expect(history[1].dateRange.startDate).to.equal('2021-01-02');
+        expect(history[1].dateRange.endDate).to.equal(chargePeriod.endDate);
+
+        // Check agreements
+        expect(history[1].agreements).to.be.an.array().length(0);
+      });
+    });
+  });
+});

--- a/test/modules/billing/services/charge-processor-service/lib/agreements.js
+++ b/test/modules/billing/services/charge-processor-service/lib/agreements.js
@@ -43,6 +43,31 @@ experiment('modules/billing/services/charge-processor-service/lib/agreements', (
       });
     });
 
+    experiment('when the agreement is in place for the full financial year and the agreements are not in chronological order', () => {
+      const licenceAgreements = [
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('2004-10-01', null),
+          agreement: twoPartTariffAgreement
+        }),
+        new LicenceAgreement().fromHash({
+          dateRange: new DateRange('1996-10-30', '2005-09-15'),
+          agreement: twoPartTariffAgreement
+        })
+      ];
+
+      test('creates a single history item', async () => {
+        const history = agreements.getAgreementsHistory(chargePeriod, licenceAgreements);
+
+        expect(history).to.be.an.array().length(1);
+        expect(history[0].dateRange.startDate).to.equal(chargePeriod.startDate);
+        expect(history[0].dateRange.endDate).to.equal(chargePeriod.endDate);
+
+        // Check agreements
+        expect(history[0].agreements).to.be.an.array().length(1);
+        expect(history[0].agreements[0].code).to.equal('S127');
+      });
+    });
+
     experiment('when the agreement ends part-way through the full financial year', () => {
       let history;
 


### PR DESCRIPTION
`WATER-3186`

Fixes issue in charge processor where agreement history not correctly computed if agreements supplied out of chronological order.