### PR TITLE
Bugfix/water 3185 tltd agreement single day

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,9 +194,9 @@
       }
     },
     "@envage/water-abstraction-helpers": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.3.8.tgz",
-      "integrity": "sha512-ERxxoPxMkyVZds5ef56cApBj+UXA7oKnD49KBy/LCun5Xcy5JYCU8KqDPvlrT42qdNQgUW+rsG7dz+bWi6FWxQ==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.3.9.tgz",
+      "integrity": "sha512-/ETK7E6qGkr50rSxTlE2xBkgyjQquq0K20Ax+50nXYnpsFcShFBBIIBUlNP9RoqCT0VvYsdXWqUJm/77TU8zGA==",
       "requires": {
         "@hapi/joi": "^15.1.1",
         "airbrake-js": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^5.0.0",
-    "@envage/water-abstraction-helpers": "^4.3.8",
+    "@envage/water-abstraction-helpers": "^4.3.9",
     "@hapi/boom": "^7.4.11",
     "@hapi/catbox-redis": "^6.0.1",
     "@hapi/good": "^8.2.4",

--- a/src/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/src/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -99,20 +99,6 @@ const doesMinimumChargeApply = (chargePeriod, chargeVersion) => {
 };
 
 /**
- * Gets the intersecting date range between the supplied ranges
- * @todo replace with implementation from helpers project
- * @param {Array} ranges - e.g. [[startDate, endDate], []...]
- * @returns {Array|null}
- */
-const getIntersection = ranges => {
-  const startDate = ranges.map(range => range[0]).sort().pop();
-  const endDate = ranges.map(range => range[1]).sort()[0];
-  return moment(startDate).isAfter(endDate, 'day')
-    ? null
-    : [startDate, endDate];
-};
-
-/**
  * Gets the charge period for the element, taking into account the time-limited
  * dates.  If the time limit does not overlap with the supplied period, returns null
  * @param {Object} period
@@ -128,7 +114,7 @@ const getElementChargePeriod = (period, chargeElement) => {
     return new DateRange(period.startDate, period.endDate);
   }
 
-  const intersection = getIntersection([
+  const intersection = helpers.charging.getIntersection([
     [period.startDate, period.endDate],
     [timeLimitedPeriod.startDate, timeLimitedPeriod.endDate]
   ]);

--- a/src/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/src/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -99,6 +99,20 @@ const doesMinimumChargeApply = (chargePeriod, chargeVersion) => {
 };
 
 /**
+ * Gets the intersecting date range between the supplied ranges
+ * @todo replace with implementation from helpers project
+ * @param {Array} ranges - e.g. [[startDate, endDate], []...]
+ * @returns {Array|null}
+ */
+const getIntersection = ranges => {
+  const startDate = ranges.map(range => range[0]).sort().pop();
+  const endDate = ranges.map(range => range[1]).sort()[0];
+  return moment(startDate).isAfter(endDate, 'day')
+    ? null
+    : [startDate, endDate];
+};
+
+/**
  * Gets the charge period for the element, taking into account the time-limited
  * dates.  If the time limit does not overlap with the supplied period, returns null
  * @param {Object} period
@@ -114,19 +128,12 @@ const getElementChargePeriod = (period, chargeElement) => {
     return new DateRange(period.startDate, period.endDate);
   }
 
-  const rangeA = moment.range(period.startDate, period.endDate);
-  const rangeB = moment.range(timeLimitedPeriod.startDate, timeLimitedPeriod.endDate);
+  const intersection = getIntersection([
+    [period.startDate, period.endDate],
+    [timeLimitedPeriod.startDate, timeLimitedPeriod.endDate]
+  ]);
 
-  const intersection = rangeA.intersect(rangeB);
-
-  if (!intersection) {
-    return null;
-  }
-
-  const startDate = intersection.start.format(DATE_FORMAT);
-  const endDate = intersection.end.format(DATE_FORMAT);
-
-  return new DateRange(startDate, endDate);
+  return intersection ? new DateRange(...intersection) : null;
 };
 
 /**

--- a/test/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/test/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -458,6 +458,33 @@ experiment('modules/billing/services/charge-processor-service/transactions-proce
           expect(transactions[0].billableDays).to.equal(32);
         });
       });
+
+      experiment('when a time-limited element ends on the first day of the financial year', () => {
+        beforeEach(async () => {
+          chargeVersion = data.createChargeVersion();
+          chargeVersion.licence = data.createLicence();
+          chargeVersion.chargeElements = [
+            data.createChargeElement({ timeLimitedStartDate: '2015-01-01', timeLimitedEndDate: '2019-04-01' })
+          ];
+          chargeVersionYear = data.createChargeVersionYear(batch, chargeVersion, financialYear);
+          const billingVolumes = chargeVersion.chargeElements.map(data.createBillingVolume);
+          transactions = transactionsProcessor.createTransactions(chargeVersionYear, billingVolumes);
+        });
+
+        test('there is a single transaction', async () => {
+          expect(transactions).to.be.an.array().length(2);
+        });
+
+        test('the transaction charge period starts and ends on the first day of the financial year', async () => {
+          expect(transactions[0].chargePeriod.startDate).to.equal('2019-04-01');
+          expect(transactions[0].chargePeriod.endDate).to.equal('2019-04-01');
+        });
+
+        test('the transaction has the correct number of billable days', async () => {
+          expect(transactions[0].authorisedDays).to.equal(366);
+          expect(transactions[0].billableDays).to.equal(1);
+        });
+      });
     });
 
     experiment('compensation charges', () => {

--- a/test/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/test/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -485,6 +485,33 @@ experiment('modules/billing/services/charge-processor-service/transactions-proce
           expect(transactions[0].billableDays).to.equal(1);
         });
       });
+
+      experiment('when a time-limited element starts on the last day of the financial year', () => {
+        beforeEach(async () => {
+          chargeVersion = data.createChargeVersion();
+          chargeVersion.licence = data.createLicence();
+          chargeVersion.chargeElements = [
+            data.createChargeElement({ timeLimitedStartDate: '2020-03-31', timeLimitedEndDate: '2030-01-01' })
+          ];
+          chargeVersionYear = data.createChargeVersionYear(batch, chargeVersion, financialYear);
+          const billingVolumes = chargeVersion.chargeElements.map(data.createBillingVolume);
+          transactions = transactionsProcessor.createTransactions(chargeVersionYear, billingVolumes);
+        });
+
+        test('there is a single transaction', async () => {
+          expect(transactions).to.be.an.array().length(2);
+        });
+
+        test('the transaction charge period starts and ends on the last day of the financial year', async () => {
+          expect(transactions[0].chargePeriod.startDate).to.equal('2020-03-31');
+          expect(transactions[0].chargePeriod.endDate).to.equal('2020-03-31');
+        });
+
+        test('the transaction has the correct number of billable days', async () => {
+          expect(transactions[0].authorisedDays).to.equal(366);
+          expect(transactions[0].billableDays).to.equal(1);
+        });
+      });
     });
 
     experiment('compensation charges', () => {


### PR DESCRIPTION
`WATER-3185`

Fixes an issue where if a time-limited element only overlapped the charge period by 1 day, the element was not included in the bill.
* Replaces intersection method of `moment-range` with own version