### PR TITLE
WATER - 3105 Water service process to safely delete rebilling invoices

### DIFF
--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -117,6 +117,14 @@ const findByIsFlaggedForRebillingAndRegion = regionId =>
 const resetIsFlaggedForRebilling = batchId =>
   raw.multiRow(queries.resetIsFlaggedForRebilling, { batchId });
 
+/**
+ * Deletes rebilled invoices by originalInvoiceId
+ * @param {String} originalBillingInvoiceId
+ */
+const deleteInvoicesByOriginalInvoiceId = originalBillingInvoiceId =>
+  bookshelf.knex.raw(queries.deleteByOriginalInvoiceId, { originalBillingInvoiceId });
+
+exports.deleteInvoicesByOriginalInvoiceId = deleteInvoicesByOriginalInvoiceId;
 exports.upsert = upsert;
 exports.deleteEmptyByBatchId = deleteEmptyByBatchId;
 exports.findOne = findOne;

--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -47,3 +47,7 @@ where
   and t2.original_billing_invoice_id is not null
 returning *;
 `;
+
+exports.deleteByOriginalBillingInvoiceId = `
+delete from water.billing_invoices 
+where original_billing_invoice_id = :originalBillingInvoiceId`;

--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -50,4 +50,4 @@ returning *;
 
 exports.deleteByOriginalBillingInvoiceId = `
 delete from water.billing_invoices 
-where original_billing_invoice_id = :originalBillingInvoiceId`;
+where original_billing_invoice_id = :originalBillingInvoiceId;`;

--- a/src/lib/services/invoice-service.js
+++ b/src/lib/services/invoice-service.js
@@ -240,6 +240,14 @@ const rebillInvoice = async (batch, invoice) => {
 };
 
 /**
+ * Deletes all new rebilled invoices where it matches the original invoiceId
+ * @param {string} originalBillingInvoiceId
+ * @returns {promise}
+ */
+const deleteByOriginalBillingInvoiceId = originalBillingInvoiceId =>
+  repos.billingInvoices.deleteInvoicesByOriginalInvoiceId(originalBillingInvoiceId);
+
+/**
  * Resets invoices originally flagged for rebilling which have now been re-billed
  * in the current batch
  *
@@ -248,6 +256,7 @@ const rebillInvoice = async (batch, invoice) => {
  */
 const resetIsFlaggedForRebilling = batchId => repos.billingInvoices.resetIsFlaggedForRebilling(batchId);
 
+exports.deleteByOriginalBillingInvoiceId = deleteByOriginalBillingInvoiceId;
 exports.getInvoicesForBatch = getInvoicesForBatch;
 exports.getInvoiceForBatch = getInvoiceForBatch;
 exports.getInvoicesTransactionsForBatch = getInvoicesTransactionsForBatch;

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -321,6 +321,19 @@ const updateInvoiceLicencesForSupplementaryReprocessing = invoice => {
 };
 
 /**
+ * Deletes all rebilled invoices that is grouped by the original invoice id and
+ * resets the rebilling state and original invoice id flags to null for the original invoice
+ * @param {*} originalBillingInvoideId - the original invoice
+ * @return {promise}
+ */
+const deleteRebillingInvoices = async originalBillingInvoideId => {
+  // update the original invoice rebilling state to null and originalIncoideId to null
+  await invoiceService.update(originalBillingInvoideId, { isFlaggedForBilling: false, originalBillingInvoideId: null, rebillingState: null });
+  // delete all the invoices where the original_billing_invoice_id = originalInvoiceId
+  await invoiceService.deleteByOriginalBillingInvoiceId(originalBillingInvoideId);
+};
+
+/**
  * Deletes an individual invoice from the batch.  Also deletes CM transactions
  * @param {Batch} batch
  * @param {String} invoiceId
@@ -348,7 +361,14 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     await newRepos.billingVolumes.deleteByBatchAndInvoiceId(batch.id, invoiceId);
     await newRepos.billingTransactions.deleteByInvoiceId(invoiceId);
     await newRepos.billingInvoiceLicences.deleteByInvoiceId(invoiceId);
-    await newRepos.billingInvoices.delete(invoiceId);
+
+    // Delete the invoice if the rebilling state is null otherwise
+    // reset the original invoice and delete the rebilled invoices.
+    if (invoice.rebillingState === null) {
+      await newRepos.billingInvoices.delete(invoiceId);
+    } else {
+      await deleteRebillingInvoices(invoice);
+    }
 
     // update the include in supplementary billing status
     const invoiceModel = mappers.invoice.dbToModel(invoice);

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -326,11 +326,11 @@ const updateInvoiceLicencesForSupplementaryReprocessing = invoice => {
  * @param {*} originalBillingInvoideId - the original invoice
  * @return {promise}
  */
-const deleteRebillingInvoices = async originalBillingInvoideId => {
+const deleteRebillingInvoices = async originalBillingInvoiceId => {
   // update the original invoice rebilling state to null and originalIncoideId to null
-  await invoiceService.update(originalBillingInvoideId, { isFlaggedForBilling: false, originalBillingInvoideId: null, rebillingState: null });
+  await invoiceService.updateInvoice(originalBillingInvoiceId, { isFlaggedForRebilling: false, originalBillingInvoiceId: null, rebillingState: null });
   // delete all the invoices where the original_billing_invoice_id = originalInvoiceId
-  await invoiceService.deleteByOriginalBillingInvoiceId(originalBillingInvoideId);
+  await invoiceService.deleteByOriginalBillingInvoiceId(originalBillingInvoiceId);
 };
 
 /**
@@ -367,7 +367,7 @@ const deleteBatchInvoice = async (batch, invoiceId) => {
     if (invoice.rebillingState === null) {
       await newRepos.billingInvoices.delete(invoiceId);
     } else {
-      await deleteRebillingInvoices(invoice);
+      await deleteRebillingInvoices(invoice.originalBillingInvoiceId);
     }
 
     // update the include in supplementary billing status

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -265,4 +265,18 @@ experiment('lib/connectors/repos/billing-invoices', () => {
       ));
     });
   });
+
+  experiment('.deleteInvoicesByOriginalInvoiceId', () => {
+    const originalInvoiceId = uuid();
+
+    beforeEach(async () => {
+      await billingInvoices.deleteInvoicesByOriginalInvoiceId(originalInvoiceId);
+    });
+
+    test('calls raw.multiRow with the correct query', async () => {
+      expect(raw.multiRow.calledWith(
+        queries.deleteByOriginalInvoiceId, { originalInvoiceId }
+      ));
+    });
+  });
 });

--- a/test/lib/services/invoice-service.js
+++ b/test/lib/services/invoice-service.js
@@ -232,6 +232,7 @@ experiment('modules/billing/services/invoiceService', () => {
     sandbox.stub(repos.billingInvoices, 'findAllForInvoiceAccount').resolves();
     sandbox.stub(repos.billingInvoices, 'findByIsFlaggedForRebillingAndRegion').resolves();
     sandbox.stub(repos.billingInvoices, 'resetIsFlaggedForRebilling').resolves();
+    sandbox.stub(repos.billingInvoices, 'deleteInvoicesByOriginalInvoiceId').resolves();
 
     sandbox.stub(invoiceAccountsConnector, 'getInvoiceAccountsByIds').resolves(crmData);
 
@@ -819,6 +820,14 @@ experiment('modules/billing/services/invoiceService', () => {
         await expect(func()).to.reject();
         expect(logger.error.called).to.be.true();
       });
+    });
+  });
+
+  experiment('.deleteByOriginalBillingInvoiceId', () => {
+    test('the original invoice is passed to the repos connector', async () => {
+      const id = uuid();
+      await invoiceService.deleteByOriginalBillingInvoiceId(id);
+      expect(repos.billingInvoices.deleteInvoicesByOriginalInvoiceId.calledWith(id)).to.be.true();
     });
   });
 });


### PR DESCRIPTION
Feat/water 3105
-- new delete invoice by original invoice id repo method added to billing invoices
-- delete invoice batch service method updated to revert changes to rebilling invoices, update original invoice by resetting rebillling flags, delete new rebilled invoices.