### PR TITLE
Fix issue on licence summary tab caused by events with empty string status

### DIFF
--- a/migrations/20210602132436-empty-event-status.js
+++ b/migrations/20210602132436-empty-event-status.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210602132436-empty-event-status-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210602132436-empty-event-status-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20210602132436-empty-event-status-down.sql
+++ b/migrations/sqls/20210602132436-empty-event-status-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20210602132436-empty-event-status-up.sql
+++ b/migrations/sqls/20210602132436-empty-event-status-up.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+update water.events set status=null where status='';

--- a/src/lib/mappers/event.js
+++ b/src/lib/mappers/event.js
@@ -1,8 +1,11 @@
 'use strict';
 
-const { isNull } = require('lodash');
+const { isNull, isEmpty } = require('lodash');
 
 const Event = require('../models/event');
+
+const mapStatus = status =>
+  isEmpty(status) ? null : status;
 
 /**
  * Creates Event object model from data received from the repo layer
@@ -13,9 +16,12 @@ const dbToModel = data => {
   if (isNull(data)) {
     return null;
   }
-  const { eventId, ...rest } = data;
+  const { eventId, status, ...rest } = data;
   const event = new Event(eventId);
-  return event.fromHash(rest);
+  return event.fromHash({
+    status: mapStatus(status),
+    ...rest
+  });
 };
 
 /**

--- a/test/lib/mappers/event.js
+++ b/test/lib/mappers/event.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const {
+  experiment,
+  test
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const Event = require('../../../src/lib/models/event');
+const eventMapper = require('../../../src/lib/mappers/event');
+
+experiment('src/lib/mappers/event', () => {
+  experiment('.dbToModel', () => {
+    test('returns an Event instance', async () => {
+      const STATUS = 'completed';
+      const result = eventMapper.dbToModel({ status: STATUS });
+      expect(result).to.be.an.instanceOf(Event);
+    });
+
+    test('maps status when it is a string', async () => {
+      const STATUS = 'completed';
+      const result = eventMapper.dbToModel({ status: STATUS });
+      expect(result.status).to.equal(STATUS);
+    });
+
+    test('maps status to null when it is an empty string', async () => {
+      const result = eventMapper.dbToModel({ status: '' });
+      expect(result.status).to.be.null();
+    });
+
+    test('maps status to null when it is null', async () => {
+      const result = eventMapper.dbToModel({ status: null });
+      expect(result.status).to.be.null();
+    });
+  });
+});


### PR DESCRIPTION
`WATER-3214`

Fixes an issue where some events have an empty string as their status, which caused a validation error when mapped to the service model.

This appears to only be present for some very old events (e.g. circa 2018).

* Existing records in the DB are migrated
* Mapper is tweaked to map empty string to null