### PR TITLE
Fetch due_date when getting returns by format ID

### DIFF
--- a/src/modules/internal-search/lib/search-returns.js
+++ b/src/modules/internal-search/lib/search-returns.js
@@ -108,7 +108,7 @@ const findRecentReturnsByFormatId = async (formatId) => {
   };
   const columns = [
     'return_id', 'licence_ref', 'return_requirement',
-    'end_date', 'metadata', 'status'
+    'end_date', 'metadata', 'status', 'due_date'
   ];
 
   const returns = await returnsService.returns.findAll(filter, sort, columns);


### PR DESCRIPTION
`WATER-3216`

Includes the due date in the returns search results, fixing an issue with the search results