### PR TITLE
Add job handler to delete errored CM batch

### DIFF
--- a/config.js
+++ b/config.js
@@ -203,7 +203,7 @@ module.exports = {
 
   redis: {
     // Note: this limit needs increasing when further Bull MQ job queues are added
-    maxListenerCount: 29,
+    maxListenerCount: 31,
     connection: {
       host: process.env.REDIS_HOST || '127.0.0.1',
       port: process.env.REDIS_PORT || 6379,

--- a/src/modules/billing/jobs/delete-errored-batch.js
+++ b/src/modules/billing/jobs/delete-errored-batch.js
@@ -40,11 +40,11 @@ const handler = async job => {
 const onFailedHandler = async (job, err) => {
   const batchId = get(job, 'data.batchId');
 
-  // On final attempt, error the batch and log
+  // Log error on final attempt
   if (helpers.isFinalAttempt(job)) {
     logger.error(`Failed to delete charge module bill run for errored batch ${batchId} after ${job.attemptsMade} attempts`);
   } else {
-    // Do normal error logging
+    // Default failed job error logging
     helpers.onFailedHandler(job, err);
   }
 };

--- a/src/modules/billing/jobs/delete-errored-batch.js
+++ b/src/modules/billing/jobs/delete-errored-batch.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { get } = require('lodash');
+
+const JOB_NAME = 'billing.delete-errored-batch';
+
+const batchService = require('../services/batch-service');
+const batchJob = require('./lib/batch-job');
+const helpers = require('./lib/helpers');
+const chargeModuleBillRunConnector = require('../../../lib/connectors/charge-module/bill-runs');
+
+const { logger } = require('../../../logger');
+
+const createMessage = batchId => ([
+  JOB_NAME,
+  {
+    batchId
+  },
+  {
+    jobId: `${JOB_NAME}.${batchId}`,
+    attempts: 6,
+    backoff: {
+      type: 'exponential',
+      delay: 5000
+    }
+  }
+]);
+
+const handler = async job => {
+  batchJob.logHandling(job);
+
+  // Get batch
+  const batchId = get(job, 'data.batchId');
+  const batch = await batchService.getBatchById(batchId);
+
+  // Delete batch in charge module
+  await chargeModuleBillRunConnector.delete(batch.externalId);
+};
+
+const onFailedHandler = async (job, err) => {
+  const batchId = get(job, 'data.batchId');
+
+  // On final attempt, error the batch and log
+  if (helpers.isFinalAttempt(job)) {
+    logger.error(`Failed to delete charge module bill run for errored batch ${batchId} after ${job.attemptsMade} attempts`);
+  } else {
+    // Do normal error logging
+    helpers.onFailedHandler(job, err);
+  }
+};
+
+exports.handler = handler;
+exports.onFailed = onFailedHandler;
+exports.jobName = JOB_NAME;
+exports.createMessage = createMessage;
+exports.hasScheduler = true;

--- a/src/modules/billing/register-subscribers.js
+++ b/src/modules/billing/register-subscribers.js
@@ -12,6 +12,7 @@ const twoPartTariffMatching = require('./jobs/two-part-tariff-matching');
 const updateCustomer = require('./jobs/update-customer');
 const checkForUpdatedInvoiceAccounts = require('./jobs/check-for-updated-invoice-accounts');
 const approveBatch = require('./jobs/approve-batch');
+const deleteErroredBatch = require('./jobs/delete-errored-batch');
 
 module.exports = {
   name: 'billing-jobs',
@@ -29,6 +30,7 @@ module.exports = {
       .register(twoPartTariffMatching)
       .register(updateCustomer)
       .register(checkForUpdatedInvoiceAccounts)
-      .register(approveBatch);
+      .register(approveBatch)
+      .register(deleteErroredBatch);
   }
 };

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -167,7 +167,7 @@ const setErrorStatus = async (batchId, errorCode) => {
   await newRepos.billingBatches.update(batchId, { status: Batch.BATCH_STATUS.error, errorCode });
   if (errorCode !== Batch.BATCH_ERROR_CODE.failedToCreateBillRun) {
     await messageQueue.getQueueManager().add(deleteErroredBatchName, batchId);
-  };
+  }
 
   await licencesService.updateIncludeInSupplementaryBillingStatusForUnsentBatch(batchId);
 };

--- a/test/modules/billing/jobs/delete-errored-batch.js
+++ b/test/modules/billing/jobs/delete-errored-batch.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+const uuid = require('uuid/v4');
+
+const deleteErroredBatchJob = require('../../../../src/modules/billing/jobs/delete-errored-batch');
+
+// Connectors
+const chargeModuleBillRunConnector = require('../../../../src/lib/connectors/charge-module/bill-runs');
+const { logger } = require('../../../../src/logger');
+
+// Services
+const batchService = require('../../../../src/modules/billing/services/batch-service');
+const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job');
+
+// Models
+const Batch = require('../../../../src/lib/models/batch');
+
+experiment('modules/billing/jobs/create-charge', () => {
+  const batchId = uuid();
+  const externalId = uuid();
+  const batch = new Batch(batchId).fromHash({
+    externalId
+  });
+
+  beforeEach(async () => {
+    sandbox.stub(batchJob, 'logHandling');
+
+    sandbox.stub(batchService, 'getBatchById').resolves(batch);
+
+    sandbox.stub(chargeModuleBillRunConnector, 'delete');
+
+    sandbox.stub(logger, 'error');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('exports the expected job name', async () => {
+    expect(deleteErroredBatchJob.jobName).to.equal('billing.delete-errored-batch');
+  });
+
+  experiment('.createMessage', () => {
+    test('creates the expected message array', async () => {
+      const message = deleteErroredBatchJob.createMessage(
+        batchId
+      );
+
+      expect(message).to.equal([
+        'billing.delete-errored-batch',
+        {
+          batchId
+        },
+        {
+          attempts: 6,
+          backoff: {
+            type: 'exponential',
+            delay: 5000
+          },
+          jobId: `billing.delete-errored-batch.${batchId}`
+        }
+      ]);
+    });
+  });
+
+  experiment('.handler', () => {
+    let job;
+
+    beforeEach(async () => {
+      job = {
+        data: {
+          batchId
+        }
+      };
+
+      await deleteErroredBatchJob.handler(job);
+    });
+
+    test('the batch is loaded by id', () => {
+      expect(batchService.getBatchById.calledWith(
+        batchId
+      )).to.be.true();
+    });
+
+    test('the CM batch is deleted by externalId', () => {
+      expect(chargeModuleBillRunConnector.delete.calledWith(
+        externalId
+      )).to.be.true();
+    });
+  });
+
+  experiment('.onFailedHandler', () => {
+    let job;
+    const err = new Error('oops');
+
+    experiment('when deleting the charge module bill run failed and is not the final attempt', () => {
+      beforeEach(async () => {
+        job = {
+          name: deleteErroredBatchJob.jobName,
+          id: 'test-id',
+          data: {
+            batchId
+          },
+          attemptsMade: 5,
+          opts: {
+            attempts: 10
+          }
+        };
+        await deleteErroredBatchJob.onFailed(job, err);
+      });
+
+      test('the job failure error is logged', async () => {
+        expect(logger.error.calledWith(
+          'Job billing.delete-errored-batch test-id failed'
+        )).to.be.true();
+      });
+    });
+
+    experiment('when deleting the charge module bill run failed and is not the final attempt', () => {
+      beforeEach(async () => {
+        job = {
+          data: {
+            batchId
+          },
+          attemptsMade: 10,
+          opts: {
+            attempts: 10
+          }
+        };
+        await deleteErroredBatchJob.onFailed(job, err);
+      });
+
+      test('the final error is logged', async () => {
+        expect(logger.error.calledWith(
+          `Failed to delete charge module bill run for errored batch ${batchId} after ${job.attemptsMade} attempts`
+        )).to.be.true();
+      });
+    });
+  });
+});


### PR DESCRIPTION
`WATER-3246`

* Deletes CM batch on failed batch at WRLS - this allows re-billed invoices to re-billed again
* Creates a new `billing.delete-errored-batch` job to enable the deletion to be retried on failure