### PR TITLE
Return not found from licence summary if document header not found

### DIFF
--- a/src/modules/licences/controllers/documents.js
+++ b/src/modules/licences/controllers/documents.js
@@ -238,6 +238,10 @@ const getLicenceSummaryByDocumentId = async (request, h) => {
 
   try {
     const documentHeader = await getDocumentHeader(documentId, includeExpired);
+    if (!documentHeader) {
+      return Boom.notFound(`Document ${documentId} not found`);
+    }
+
     const licence = await getLicence(documentHeader, undefined, companyId);
 
     if (licence) {

--- a/test/modules/licences/controllers/documents.js
+++ b/test/modules/licences/controllers/documents.js
@@ -305,8 +305,8 @@ experiment('modules/licences/controllers/documents', () => {
       permitClient.licences.findMany.resolves(licences());
     });
 
-    test('returns 404 for unknown document id', async () => {
-      documentsClient.findMany.rejects({ statusCode: 404 });
+    test('returns 404 when document not found', async () => {
+      documentsClient.findMany.resolves({ data: [] });
       const response = await controller.getLicenceSummaryByDocumentId(testRequest);
       expect(response.output.statusCode).to.equal(404);
     });


### PR DESCRIPTION
`WATER-3257` licence summary endpoint by document ID should return not found if the CRM v1 document header is not found