### PR TITLE
Update charge-elements.js

### DIFF
--- a/src/lib/services/charge-elements.js
+++ b/src/lib/services/charge-elements.js
@@ -51,7 +51,7 @@ const getChargeElementsFromLicenceVersion = licenceVersion => {
     chargeElement.loss = licenceVersionPurpose.purposeUse.lossFactor;
     chargeElement.abstractionPeriod = licenceVersionPurpose.abstractionPeriod;
     chargeElement.authorisedAnnualQuantity = toFixed(
-      unitConversion.cubicMetresToMegalitres(licenceVersionPurpose.annualQuantity), 6
+      unitConversion.cubicMetresToMegalitres(licenceVersionPurpose.annualQuantity || 0), 6
     );
     chargeElement.billableAnnualQuantity = null;
     chargeElement.purposePrimary = licenceVersionPurpose.purposePrimary;

--- a/test/lib/services/charge-elements.js
+++ b/test/lib/services/charge-elements.js
@@ -101,6 +101,22 @@ experiment('lib/services/charge-elements', () => {
       expect(element.authorisedAnnualQuantity).to.equal(0.100123);
     });
 
+    experiment('when the annual quantity is zero', () => {
+      beforeEach(() => {
+        licenceVersionPurpose.annualQuantity = 0;
+
+        licenceVersion = new LicenceVersion();
+        licenceVersion.licenceVersionPurposes = [licenceVersionPurpose];
+
+        setElements();
+      });
+
+      afterEach(() => sandbox.restore());
+      test('the season is set to winter', async () => {
+        expect(element.authorisedAnnualQuantity).to.equal(0);
+      });
+    });
+
     test('the billable annual quanity is set to null', async () => {
       expect(element.billableAnnualQuantity).to.equal(null);
     });


### PR DESCRIPTION
World's smallest PR.

What does it do: When no authorised volume has been defined, it will default to zero.

Original ticket: https://eaflood.atlassian.net/browse/WATER-3118