### PR TITLE
WATER-3245 - alter re-billing logic

### DIFF
--- a/migrations/20210810160000-add-rebilling-state.js
+++ b/migrations/20210810160000-add-rebilling-state.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210810160000-add-rebilling-state-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210810160000-add-rebilling-state-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20210810160000-add-rebilling-state-down.sql
+++ b/migrations/sqls/20210810160000-add-rebilling-state-down.sql
@@ -1,0 +1,13 @@
+/* Replace with your SQL commands */
+alter type water.rebilling_state
+ rename to rebilling_state_old;
+
+create type water.rebilling_state as enum('rebill', 'reversal');
+
+update water.billing_invoices set rebilling_state = 'rebill' where original_billing_invoice_id is not null and rebilling_state = 'rebilled';
+update water.billing_invoices set rebilling_state = null where original_billing_invoice_id is null and rebilling_state = 'rebilled';
+
+alter table water.billing_invoices
+  alter column rebilling_state type water.rebilling_state using rebilling_state::text::water.rebilling_state;
+
+drop type water.rebilling_state_old;

--- a/migrations/sqls/20210810160000-add-rebilling-state-up.sql
+++ b/migrations/sqls/20210810160000-add-rebilling-state-up.sql
@@ -1,0 +1,9 @@
+alter type water.rebilling_state
+ rename to rebilling_state_old;
+
+create type water.rebilling_state as enum('rebill', 'reversal', 'rebilled');
+
+alter table water.billing_invoices
+  alter column rebilling_state type water.rebilling_state using rebilling_state::text::water.rebilling_state;
+
+drop type water.rebilling_state_old;

--- a/src/lib/connectors/bookshelf/BillingInvoice.js
+++ b/src/lib/connectors/bookshelf/BillingInvoice.js
@@ -19,5 +19,9 @@ module.exports = bookshelf.model('BillingInvoice', {
 
   linkedBillingInvoices () {
     return this.hasMany('BillingInvoice', 'original_billing_invoice_id', 'original_billing_invoice_id');
+  },
+
+  originalBillingInvoice () {
+    return this.hasOne('BillingInvoice', 'billing_invoice_id', 'original_billing_invoice_id');
   }
 });

--- a/src/lib/connectors/repos/billing-invoices.js
+++ b/src/lib/connectors/repos/billing-invoices.js
@@ -38,7 +38,8 @@ const findOne = async id => {
         'billingInvoiceLicences.billingTransactions.billingVolume',
         'billingInvoiceLicences.billingTransactions.chargeElement',
         'billingInvoiceLicences.billingTransactions.chargeElement.purposeUse',
-        'linkedBillingInvoices'
+        'linkedBillingInvoices',
+        'originalBillingInvoice'
       ]
     });
 

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -18,6 +18,7 @@ const mapLinkedInvoices = (billingInvoiceId, linkedBillingInvoices = [], origina
   const invoices = linkedBillingInvoices
     .filter(linkedBillingInvoice => linkedBillingInvoice.billingInvoiceId !== billingInvoiceId)
     .map(dbToModel);
+
   if (!(isEmpty(originalBillingInvoice))) {
     invoices.push(dbToModel(originalBillingInvoice));
   }

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -23,7 +23,8 @@ const Totals = require('./totals');
 
 const rebillingState = {
   rebill: 'rebill',
-  reversal: 'reversal'
+  reversal: 'reversal',
+  rebilled: 'rebilled'
 };
 
 class Invoice extends Totals {

--- a/src/modules/billing/jobs/rebilling.js
+++ b/src/modules/billing/jobs/rebilling.js
@@ -52,6 +52,7 @@ const handler = async job => {
   // Process each invoice that needs rebilling
   for (const invoice of invoices) {
     await rebillingService.rebillInvoice(batch, invoice.id);
+    await invoiceService.updateInvoice(invoice.id, { rebillingState: 'rebilled' });
   }
 };
 

--- a/test/lib/connectors/bookshelf/BillingInvoice.js
+++ b/test/lib/connectors/bookshelf/BillingInvoice.js
@@ -18,6 +18,7 @@ experiment('lib/connectors/bookshelf/BillingInvoice', () => {
     instance = BillingInvoice.forge();
     sandbox.stub(instance, 'belongsTo');
     sandbox.stub(instance, 'hasMany');
+    sandbox.stub(instance, 'hasOne');
   });
 
   afterEach(async () => {
@@ -83,6 +84,23 @@ experiment('lib/connectors/bookshelf/BillingInvoice', () => {
       const [model, foreignKey, foreignKeyTarget] = instance.hasMany.lastCall.args;
       expect(model).to.equal('BillingInvoice');
       expect(foreignKey).to.equal('original_billing_invoice_id');
+      expect(foreignKeyTarget).to.equal('original_billing_invoice_id');
+    });
+  });
+
+  experiment('the .originalBillingInvoice() relation', () => {
+    beforeEach(async () => {
+      instance.originalBillingInvoice();
+    });
+
+    test('is a function', async () => {
+      expect(instance.originalBillingInvoice).to.be.a.function();
+    });
+
+    test('calls .belongsTo with correct params', async () => {
+      const [model, foreignKey, foreignKeyTarget] = instance.hasOne.lastCall.args;
+      expect(model).to.equal('BillingInvoice');
+      expect(foreignKey).to.equal('billing_invoice_id');
       expect(foreignKeyTarget).to.equal('original_billing_invoice_id');
     });
   });

--- a/test/lib/connectors/repos/billing-invoices.js
+++ b/test/lib/connectors/repos/billing-invoices.js
@@ -116,7 +116,8 @@ experiment('lib/connectors/repos/billing-invoices', () => {
         'billingInvoiceLicences.billingTransactions.billingVolume',
         'billingInvoiceLicences.billingTransactions.chargeElement',
         'billingInvoiceLicences.billingTransactions.chargeElement.purposeUse',
-        'linkedBillingInvoices'
+        'linkedBillingInvoices',
+        'originalBillingInvoice'
       ]);
     });
 

--- a/test/lib/mappers/invoice.js
+++ b/test/lib/mappers/invoice.js
@@ -17,7 +17,6 @@ const FinancialYear = require('../../../src/lib/models/financial-year');
 const InvoiceAccount = require('../../../src/lib/models/invoice-account');
 
 const invoiceMapper = require('../../../src/lib/mappers/invoice');
-const instance = require('../../../src/lib/connectors/charge-module/lib/got-cm');
 
 const invoiceRow = {
   billingInvoiceId: '5a1577d7-8dc9-4d67-aadc-37d7ea85abca',

--- a/test/lib/mappers/invoice.js
+++ b/test/lib/mappers/invoice.js
@@ -17,6 +17,7 @@ const FinancialYear = require('../../../src/lib/models/financial-year');
 const InvoiceAccount = require('../../../src/lib/models/invoice-account');
 
 const invoiceMapper = require('../../../src/lib/mappers/invoice');
+const instance = require('../../../src/lib/connectors/charge-module/lib/got-cm');
 
 const invoiceRow = {
   billingInvoiceId: '5a1577d7-8dc9-4d67-aadc-37d7ea85abca',
@@ -35,7 +36,11 @@ const invoiceRow = {
   },
   {
     billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e866'
-  }]
+  }],
+  originalBillingInvoice: {
+    billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899'
+  },
+  originalBillingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899'
 };
 
 experiment('lib/mappers/invoice', () => {
@@ -90,8 +95,9 @@ experiment('lib/mappers/invoice', () => {
 
     test('maps the linked billing invoices for re-billing, excluding the current invoice', () => {
       const { linkedInvoices } = result;
-      expect(linkedInvoices).to.be.an.array().length(1);
+      expect(linkedInvoices).to.be.an.array().length(2);
       expect(linkedInvoices[0].id).to.equal(invoiceRow.linkedBillingInvoices[1].billingInvoiceId);
+      expect(linkedInvoices[1].id).to.equal(invoiceRow.originalBillingInvoiceId);
     });
   });
 

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -483,6 +483,11 @@ experiment('lib/models/invoice', () => {
       expect(invoice.rebillingState).to.equal('reversal');
     });
 
+    test('can be set to "reversal"', async () => {
+      invoice.rebillingState = 'rebilled';
+      expect(invoice.rebillingState).to.equal('rebilled');
+    });
+
     test('can be set to null', async () => {
       invoice.rebillingState = null;
       expect(invoice.rebillingState).to.equal(null);

--- a/test/modules/billing/jobs/rebilling.js
+++ b/test/modules/billing/jobs/rebilling.js
@@ -57,6 +57,7 @@ experiment('modules/billing/jobs/rebilling', () => {
     sandbox.stub(batchService, 'setErrorStatus');
 
     sandbox.stub(invoiceService, 'getInvoicesFlaggedForRebilling');
+    sandbox.stub(invoiceService, 'updateInvoice').resolves();
 
     sandbox.stub(rebillingService, 'rebillInvoice');
 

--- a/test/modules/billing/jobs/rebilling.js
+++ b/test/modules/billing/jobs/rebilling.js
@@ -137,6 +137,14 @@ experiment('modules/billing/jobs/rebilling', () => {
           batch, invoice.id
         )).to.be.true();
       });
+
+      test('calls the .invoice service method for each invoice retrieved', async () => {
+        expect(invoiceService.updateInvoice.callCount).to.equal(1);
+        expect(invoiceService.updateInvoice.calledWith(
+          invoice.id,
+          { rebillingState: 'rebilled' }
+        )).to.be.true();
+      });
     });
 
     experiment('when the batch status is not "processing"', () => {


### PR DESCRIPTION
feat/water-3245
-- rebilling process tweaked to allow rebilling only where
rebill status = rebill or null
-- invoice model now includes original invoice in
linked invoices for the UI
-- rebilling job updated to update the source invoice to status rebilled
-- migration to add new rebill status rebilled