### PR TITLE
bugfix-water-3295 - creating credits for licences that has been removed from the batch

### DIFF
--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -26,6 +26,8 @@ and l.licence_id not in (
   from water.charge_version_workflows cvw
   where cvw.date_deleted is null
 )
+and t.licence_ref IN (select licence_ref from water.billing_invoice_licences il join water.billing_invoices i ON il.billing_invoice_id = i.billing_invoice_id
+  join water.billing_batches b ON i.billing_batch_id = b.billing_batch_id where b.billing_batch_id=:batchId)
 order by t.date_created asc
 `;
 


### PR DESCRIPTION
bugfix/water-3295
-- sql updated to only select historic transactions for licences
with an invoice that was created and still in the batch