### PR TITLE
WATER - 3089 - added rebilling state label to invoice model

### DIFF
--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -56,8 +56,32 @@ const dbToModelMapper = createMapper()
  * @param {Object} row
  * @return {Invoice}
  */
-const dbToModel = row =>
-  createModel(Invoice, row, dbToModelMapper);
+const dbToModel = row => {
+  const invoice = createModel(Invoice, row, dbToModelMapper);
+  return getRebillingStateLabels(invoice);
+};
+
+/**
+ * Corrects the rebilling state label when a rebilled invoice has been rebilled again
+ * @param {Invoice} invoice the invoice service model
+ * @returns Invoice service model with corrected rebilling state labels for the UI
+ */
+const getRebillingStateLabels = (invoice) => {
+  if (invoice.rebillingState === 'rebilled' && invoice.originalInvoiceId === invoice.id) {
+    invoice.rebillingStateLabel = 'original';
+    return invoice;
+  }
+  if (invoice.linkedInvoices.length > 0) {
+    if (invoice.linkedInvoices[0].rebillingStateLabel === 'rebilled' && invoice.linkedInvoices[0].originalInvoiceId === invoice.id) {
+      invoice.linkedInvoices[0].rebillingStateLabel = 'original';
+      return invoice;
+    } else {
+      invoice.linkedInvoices[1].rebillingStateLabel = 'original';
+      return invoice;
+    }
+  }
+  return invoice;
+};
 
 const mapAddress = invoice =>
   invoice.address ? omit(invoice.address.toJSON(), 'id') : {};

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -48,6 +48,7 @@ const dbToModelMapper = createMapper()
   .map('billingBatch').to('batch', batchMapper.dbToModel)
   .map('financialYearEnding').to('financialYear', financialYearEnding => new FinancialYear(financialYearEnding))
   .map('originalBillingInvoiceId').to('originalInvoiceId')
+  .map('rebillingState').to('rebillingStateLabel')
   .map(['billingInvoiceId', 'linkedBillingInvoices', 'originalBillingInvoice']).to('linkedInvoices', mapLinkedInvoices);
 
 /**

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -28,6 +28,12 @@ const rebillingState = {
   rebilled: 'rebilled',
   unrebillable: 'unrebillable'
 };
+const rebillingStateLabel = {
+  rebill: 'rebill',
+  reversal: 'reversal',
+  rebilled: 'rebilled',
+  unrebillable: 'original'
+};
 
 class Invoice extends Totals {
   constructor (id) {
@@ -339,9 +345,12 @@ class Invoice extends Totals {
     return null;
   }
 
-  set rebillingStateLabel (rebillingStateLabel) {
-    assertNullableString(rebillingStateLabel);
-    this._rebillingStateLabel = rebillingStateLabel;
+  /**
+   * sets the rebilling state label only used by the UI
+   */
+  set rebillingStateLabel (value) {
+    assertNullableEnum(value, Object.values(rebillingStateLabel));
+    this._rebillingStateLabel = value;
   }
 
   get rebillingStateLabel () {
@@ -350,12 +359,11 @@ class Invoice extends Totals {
 
   toJSON () {
     const { hasTransactionErrors, displayLabel } = this;
-    const invoice = {
+    return {
       hasTransactionErrors,
       displayLabel,
       ...super.toJSON()
     };
-    return getRebillingStateLabels(invoice);
   }
 
   /**
@@ -400,28 +408,6 @@ class Invoice extends Totals {
     return this._linkedInvoices;
   }
 }
-
-/**
- * This is a helper method to correct the rebilling state labels for the invoice and linked invoices.
- * @param {Object} invoice
- * @returns JSON Object
- */
-const getRebillingStateLabels = (invoice) => {
-  if (invoice.rebillingState === 'rebilled' && invoice.originalInvoiceId === invoice.id) {
-    invoice.rebillingStateLabel = 'original';
-    return invoice;
-  }
-  if (invoice.linkedInvoices.length > 0) {
-    if (invoice.linkedInvoices[0].rebillingStateLabel === 'rebilled' && invoice.linkedInvoices[0].originalInvoiceId === invoice.id) {
-      invoice.linkedInvoices[0].rebillingStateLabel = 'original';
-      return invoice;
-    } else {
-      invoice.linkedInvoices[1].rebillingStateLabel = 'original';
-      return invoice;
-    }
-  }
-  return invoice;
-};
 
 module.exports = Invoice;
 module.exports.rebillingState = rebillingState;

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -339,11 +339,23 @@ class Invoice extends Totals {
     return null;
   }
 
+  get rebillingStateLabel () {
+    if (this.rebillingState === 'rebilled' && this.originalInvoiceId === this.id) {
+      return 'original';
+    }
+    if (this.linkedInvoices.length > 0) {
+      return this.linkedInvoices[0].originalInvoiceId === this.id ? 'original' : this.rebillingState;
+    } else {
+      return this.rebillingState;
+    }
+  }
+
   toJSON () {
-    const { hasTransactionErrors, displayLabel } = this;
+    const { hasTransactionErrors, displayLabel, rebillingStateLabel } = this;
     return {
       hasTransactionErrors,
       displayLabel,
+      rebillingStateLabel,
       ...super.toJSON()
     };
   }

--- a/src/lib/models/invoice.js
+++ b/src/lib/models/invoice.js
@@ -339,25 +339,23 @@ class Invoice extends Totals {
     return null;
   }
 
+  set rebillingStateLabel (rebillingStateLabel) {
+    assertNullableString(rebillingStateLabel);
+    this._rebillingStateLabel = rebillingStateLabel;
+  }
+
   get rebillingStateLabel () {
-    if (this.rebillingState === 'rebilled' && this.originalInvoiceId === this.id) {
-      return 'original';
-    }
-    if (this.linkedInvoices.length > 0) {
-      return this.linkedInvoices[0].originalInvoiceId === this.id ? 'original' : this.rebillingState;
-    } else {
-      return this.rebillingState;
-    }
+    return this._rebillingStateLabel;
   }
 
   toJSON () {
-    const { hasTransactionErrors, displayLabel, rebillingStateLabel } = this;
-    return {
+    const { hasTransactionErrors, displayLabel } = this;
+    const invoice = {
       hasTransactionErrors,
       displayLabel,
-      rebillingStateLabel,
       ...super.toJSON()
     };
+    return getRebillingStateLabels(invoice);
   }
 
   /**
@@ -402,6 +400,28 @@ class Invoice extends Totals {
     return this._linkedInvoices;
   }
 }
+
+/**
+ * This is a helper method to correct the rebilling state labels for the invoice and linked invoices.
+ * @param {Object} invoice
+ * @returns JSON Object
+ */
+const getRebillingStateLabels = (invoice) => {
+  if (invoice.rebillingState === 'rebilled' && invoice.originalInvoiceId === invoice.id) {
+    invoice.rebillingStateLabel = 'original';
+    return invoice;
+  }
+  if (invoice.linkedInvoices.length > 0) {
+    if (invoice.linkedInvoices[0].rebillingStateLabel === 'rebilled' && invoice.linkedInvoices[0].originalInvoiceId === invoice.id) {
+      invoice.linkedInvoices[0].rebillingStateLabel = 'original';
+      return invoice;
+    } else {
+      invoice.linkedInvoices[1].rebillingStateLabel = 'original';
+      return invoice;
+    }
+  }
+  return invoice;
+};
 
 module.exports = Invoice;
 module.exports.rebillingState = rebillingState;

--- a/test/lib/mappers/invoice.js
+++ b/test/lib/mappers/invoice.js
@@ -31,16 +31,20 @@ const invoiceRow = {
   metadata: { foo: 'bar' },
   isFlaggedForRebilling: true,
   linkedBillingInvoices: [{
-    billingInvoiceId: '5a1577d7-8dc9-4d67-aadc-37d7ea85abca'
+    billingInvoiceId: '5a1577d7-8dc9-4d67-aadc-37d7ea85abca',
+    rebillingState: 'rebilled'
   },
   {
-    billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e866'
+    billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e866',
+    rebillingState: 'reversal'
   }],
   originalBillingInvoice: {
-    billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899'
+    billingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899',
+    rebillingState: 'rebilled'
   },
   originalBillingInvoiceId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899',
-  billingBatchId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899'
+  billingBatchId: '4139a53a-a1f0-4dc9-bf1a-b97e41c5e899',
+  rebillingState: 'rebilled'
 };
 
 experiment('lib/mappers/invoice', () => {
@@ -102,6 +106,12 @@ experiment('lib/mappers/invoice', () => {
 
     test('maps the batch id', () => {
       expect(result.billingBatchId).to.equal(invoiceRow.billingBatchId);
+    });
+
+    test('maps the rebillingStateLabels correctly', () => {
+      expect(result.rebillingStateLabel).to.equal('rebilled');
+      expect(result.linkedInvoices[0].rebillingStateLabel).to.equal('reversal');
+      expect(result.linkedInvoices[1].rebillingStateLabel).to.equal('original');
     });
   });
 

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -421,7 +421,7 @@ experiment('lib/models/invoice', () => {
       test('"de minimis bill" when isDeMinimis is true', async () => {
         invoice = new Invoice();
         invoice.fromHash({
-          billingInvoiceId: uuid(),
+          id: uuid(),
           isDeMinimis: true,
           legacyId: null,
           netTotal: 0,
@@ -434,7 +434,7 @@ experiment('lib/models/invoice', () => {
       test('"NALD revised bill" when a legacy id is present', async () => {
         invoice = new Invoice();
         invoice.fromHash({
-          billingInvoiceId: uuid(),
+          id: uuid(),
           isDeMinimis: false,
           legacyId: '12345:583',
           netTotal: 0,
@@ -447,7 +447,7 @@ experiment('lib/models/invoice', () => {
       test('"zero value bill" when net amount is 0', async () => {
         invoice = new Invoice();
         invoice.fromHash({
-          billingInvoiceId: uuid(),
+          id: uuid(),
           isDeMinimis: false,
           legacyId: null,
           netTotal: 0,
@@ -460,7 +460,7 @@ experiment('lib/models/invoice', () => {
       test('null if none of the expected criteria are met', async () => {
         invoice = new Invoice();
         invoice.fromHash({
-          billingInvoiceId: uuid(),
+          id: uuid(),
           isDeMinimis: false,
           legacyId: null,
           netTotal: 50,
@@ -469,6 +469,64 @@ experiment('lib/models/invoice', () => {
         const result = invoice.toJSON();
         expect(result.displayLabel).to.equal(null);
       });
+    });
+
+    experiment('rebillinStateLabel, set to', () => {
+      test('"original" when the id === original invoice id', async () => {
+        const id = uuid();
+        invoice = new Invoice();
+        invoice.fromHash({
+          id: id,
+          legacyId: null,
+          netTotal: 0,
+          invoiceNumber: null,
+          rebillingState: 'rebilled',
+          originalInvoiceId: id
+        });
+        const result = invoice.toJSON();
+        expect(result.rebillingStateLabel).to.equal('original');
+      });
+
+      test('"NALD revised bill" when a legacy id is present', async () => {
+        const id = uuid();
+        invoice = new Invoice();
+        invoice.fromHash({
+          id: id,
+          legacyId: null,
+          netTotal: 0,
+          invoiceNumber: null,
+          rebillingState: 'rebilled',
+          originalInvoiceId: id
+        });
+        const result = invoice.toJSON();
+        expect(result.displayLabel).to.equal('NALD revised bill');
+      });
+
+      // test('"zero value bill" when net amount is 0', async () => {
+      //   invoice = new Invoice();
+      //   invoice.fromHash({
+      //     billingInvoiceId: uuid(),
+      //     isDeMinimis: false,
+      //     legacyId: null,
+      //     netTotal: 0,
+      //     invoiceNumber: null
+      //   });
+      //   const result = invoice.toJSON();
+      //   expect(result.displayLabel).to.equal('Zero value bill');
+      // });
+
+      // test('null if none of the expected criteria are met', async () => {
+      //   invoice = new Invoice();
+      //   invoice.fromHash({
+      //     billingInvoiceId: uuid(),
+      //     isDeMinimis: false,
+      //     legacyId: null,
+      //     netTotal: 50,
+      //     invoiceNumber: null
+      //   });
+      //   const result = invoice.toJSON();
+      //   expect(result.displayLabel).to.equal(null);
+      // });
     });
   });
 

--- a/test/lib/models/invoice.js
+++ b/test/lib/models/invoice.js
@@ -470,63 +470,39 @@ experiment('lib/models/invoice', () => {
         expect(result.displayLabel).to.equal(null);
       });
     });
+  });
 
-    experiment('rebillinStateLabel, set to', () => {
-      test('"original" when the id === original invoice id', async () => {
-        const id = uuid();
-        invoice = new Invoice();
-        invoice.fromHash({
-          id: id,
-          legacyId: null,
-          netTotal: 0,
-          invoiceNumber: null,
-          rebillingState: 'rebilled',
-          originalInvoiceId: id
-        });
-        const result = invoice.toJSON();
-        expect(result.rebillingStateLabel).to.equal('original');
-      });
+  experiment('.rebillingStateLabel', () => {
+    test('can be set to "rebill"', async () => {
+      invoice.rebillingStateLabel = 'rebill';
+      expect(invoice.rebillingStateLabel).to.equal('rebill');
+    });
 
-      test('"NALD revised bill" when a legacy id is present', async () => {
-        const id = uuid();
-        invoice = new Invoice();
-        invoice.fromHash({
-          id: id,
-          legacyId: null,
-          netTotal: 0,
-          invoiceNumber: null,
-          rebillingState: 'rebilled',
-          originalInvoiceId: id
-        });
-        const result = invoice.toJSON();
-        expect(result.displayLabel).to.equal('NALD revised bill');
-      });
+    test('can be set to "reversal"', async () => {
+      invoice.rebillingStateLabel = 'reversal';
+      expect(invoice.rebillingStateLabel).to.equal('reversal');
+    });
 
-      // test('"zero value bill" when net amount is 0', async () => {
-      //   invoice = new Invoice();
-      //   invoice.fromHash({
-      //     billingInvoiceId: uuid(),
-      //     isDeMinimis: false,
-      //     legacyId: null,
-      //     netTotal: 0,
-      //     invoiceNumber: null
-      //   });
-      //   const result = invoice.toJSON();
-      //   expect(result.displayLabel).to.equal('Zero value bill');
-      // });
+    test('can be set to "reversal"', async () => {
+      invoice.rebillingStateLabel = 'rebilled';
+      expect(invoice.rebillingStateLabel).to.equal('rebilled');
+    });
 
-      // test('null if none of the expected criteria are met', async () => {
-      //   invoice = new Invoice();
-      //   invoice.fromHash({
-      //     billingInvoiceId: uuid(),
-      //     isDeMinimis: false,
-      //     legacyId: null,
-      //     netTotal: 50,
-      //     invoiceNumber: null
-      //   });
-      //   const result = invoice.toJSON();
-      //   expect(result.displayLabel).to.equal(null);
-      // });
+    test('can be set to "original"', async () => {
+      invoice.rebillingStateLabel = 'original';
+      expect(invoice.rebillingStateLabel).to.equal('original');
+    });
+
+    test('can be set to null', async () => {
+      invoice.rebillingStateLabel = null;
+      expect(invoice.rebillingStateLabel).to.equal(null);
+    });
+
+    test('throws an error if set to another string', async () => {
+      const func = () => {
+        invoice.rebillingStateLabel = 'invalid-state';
+      };
+      expect(func).to.throw();
     });
   });
 


### PR DESCRIPTION
Feat/water 3089 rebilling state label
-- rebilling state label added to the invoice model to move the logic of identifying the original invoice that could have a rebilled status similar to the rebilled invoice. 