### PR TITLE
Bugfix Water - 3281 - only remove the include in supp. billing flag for licences in the current batch

### DIFF
--- a/src/lib/connectors/repos/queries/licences.js
+++ b/src/lib/connectors/repos/queries/licences.js
@@ -27,11 +27,19 @@ const updateIncludeInSupplementaryBillingStatusForBatch = `
       join water.billing_batch_charge_version_years y
         on b.billing_batch_id = y.billing_batch_id
       join water.charge_versions cv
-        on y.charge_version_id = cv.charge_version_id
+        on y.charge_version_id = cv.charge_version_id      
   where l.licence_ref = cv.licence_ref
   and b.billing_batch_id = :batchId
   and b.batch_type = 'supplementary'
-  and l.include_in_supplementary_billing = :from;
+  and l.include_in_supplementary_billing = :from
+  and l.licence_id in (
+    select il.licence_id
+    from 
+      water.billing_invoice_licences il 
+        join water.billing_invoices i
+          on il.billing_invoice_id = i.billing_invoice_id 
+    where i.billing_batch_id = :batchIfd
+    ); 
 `;
 
 const getLicencesByInvoiceAccount = `


### PR DESCRIPTION
bugfix/water-3281
-- only update the incluce in supp. bill run flag
for licences in the current batch.