### PR TITLE
Update sync-licence-version-purpose-conditions-from-digitise.js

### DIFF
--- a/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
+++ b/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
@@ -64,7 +64,7 @@ const handler = async () => {
             } = await licenceVersionPurposeConditionsService.getLicenceVersionConditionByPartialExternalId(licenceVersionPurposeConditionLegacyId);
             const licenceVersionPurposeConditionTypeId = await licenceVersionPurposeConditionsService.getLicenceVersionConditionType(licenceVersionPurposeConditionId);
             const notes = getDigitiseText(thisSchema, eachArSegment.content).replace(/\n/g, ' ');
-            const externalId = `digitise:${eachLicence.licence_id}:${licenceVersionPurposeConditionId}`;
+            const externalId = `digitise:${eachLicence.licence_id}:${eachLicence.licenceVersionPurposeConditionId}:${thisSchema}`;
 
             // Upsert the record
             licenceVersionPurposeConditionsService.upsertByExternalId(externalId, licenceVersionPurposeId, licenceVersionPurposeConditionTypeId, notes, 'digitise');

--- a/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
+++ b/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
@@ -64,7 +64,7 @@ const handler = async () => {
             } = await licenceVersionPurposeConditionsService.getLicenceVersionConditionByPartialExternalId(licenceVersionPurposeConditionLegacyId);
             const licenceVersionPurposeConditionTypeId = await licenceVersionPurposeConditionsService.getLicenceVersionConditionType(licenceVersionPurposeConditionId);
             const notes = getDigitiseText(thisSchema, eachArSegment.content).replace(/\n/g, ' ');
-            const externalId = `digitise:${eachLicence.licence_id}:${eachLicence.licenceVersionPurposeConditionId}:${thisSchema}`;
+            const externalId = `digitise:${eachLicence.licence_id}:${licenceVersionPurposeConditionId}:${thisSchema}`;
 
             // Upsert the record
             licenceVersionPurposeConditionsService.upsertByExternalId(externalId, licenceVersionPurposeId, licenceVersionPurposeConditionTypeId, notes, 'digitise');

--- a/test/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
+++ b/test/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
@@ -148,7 +148,7 @@ experiment('.handler', () => {
 
     test('add the licence version purpose condition to the licence', async () => {
       const args = LVPCService.upsertByExternalId.lastCall.args;
-      expect(args[0]).to.equal('digitise:123456:test/ref/01');
+      expect(args[0]).to.equal('digitise:123456:lvpc-id:/wr22/2.5');
       expect(args[1]).to.equal('lvp-id');
       expect(args[2].licenceVersionPurposeConditionTypeId).to.equal('test-lvpc-type-id');
       expect(args[4]).to.equal('digitise');


### PR DESCRIPTION
Fixes a minor bug whereby the external key was not sufficiently unique, so some conditions were not being copied