### PR TITLE
Bugfix - WATER - 3321

### DIFF
--- a/src/modules/billing/services/charge-version-service/two-part-tariff-seasons.js
+++ b/src/modules/billing/services/charge-version-service/two-part-tariff-seasons.js
@@ -24,9 +24,6 @@ const createTwoPartTariffBatches = (isSummer = false, isWinterAllYear = false) =
 const isNALDEraTwoPartTariffDate = date =>
   helpers.getFinancialYear(date) <= 2021;
 
-const isWRLSEraTwoPartTariffDate = date =>
-  helpers.getFinancialYear(date) >= 2021;
-
 const isApprovedNaldBillingVolume = billingVolume =>
   billingVolume.source === BATCH_SOURCE.nald && billingVolume.isApproved;
 

--- a/src/modules/billing/services/charge-version-service/two-part-tariff-seasons.js
+++ b/src/modules/billing/services/charge-version-service/two-part-tariff-seasons.js
@@ -129,9 +129,8 @@ const getTwoPartTariffSeasonsForChargeVersion = async (chargeVersionRow, existin
   if (isNALDEraTwoPartTariffDate(chargeVersionRow.startDate)) {
     seasons.push(await getNALDTwoPartTariffSeasons(chargeVersionRow));
   }
-  if (isWRLSEraTwoPartTariffDate(chargeVersionRow.startDate)) {
-    seasons.push(await getWRLSTwoPartTariffSeasons(chargeVersionRow, existingTPTBatches));
-  }
+  // always add WRLS seasons because there might be a new charge version with a historic start date
+  seasons.push(await getWRLSTwoPartTariffSeasons(chargeVersionRow, existingTPTBatches));
 
   return {
     [RETURN_SEASONS.summer]: seasons.some(isSummerFlagSet),

--- a/src/modules/billing/services/supplementary-billing-service/supplementary-processor.js
+++ b/src/modules/billing/services/supplementary-billing-service/supplementary-processor.js
@@ -61,7 +61,7 @@ const getGroupingKey = transaction => {
   // Create a list of keys which will form the grouping key
   const keys = [...commonTransactionKeys];
   transaction.isTwoPartTariffSupplementary
-    ? keys.push('abstractionPeriod')
+    ? keys.push('isSummer')
     : keys.push('authorisedDays', 'volume');
 
   // The 'new licence' flag only affects WRLS transactions so it does not

--- a/test/modules/billing/services/charge-version-service/two-part-tariff-seasons.js
+++ b/test/modules/billing/services/charge-version-service/two-part-tariff-seasons.js
@@ -90,6 +90,7 @@ experiment('modules/billing/services/charge-version-service/two-part-tariff-seas
             isSummer: true,
             isApproved: true
           }]);
+          returnRequirementVersionService.getByLicenceId.resolves([]);
           result = await twoPartTariffSeasons.getTwoPartTariffSeasonsForChargeVersion(chargeVersionRow);
         });
 
@@ -100,7 +101,7 @@ experiment('modules/billing/services/charge-version-service/two-part-tariff-seas
         });
 
         test('return requirememts are not fetched', async () => {
-          expect(returnRequirementVersionService.getByLicenceId.called).to.be.false();
+          expect(returnRequirementVersionService.getByLicenceId.called).to.be.true();
         });
 
         test('resolved with only the summer season flag set', async () => {
@@ -118,6 +119,7 @@ experiment('modules/billing/services/charge-version-service/two-part-tariff-seas
             isSummer: false,
             isApproved: true
           }]);
+          returnRequirementVersionService.getByLicenceId.resolves([]);
           result = await twoPartTariffSeasons.getTwoPartTariffSeasonsForChargeVersion(chargeVersionRow);
         });
 
@@ -128,7 +130,7 @@ experiment('modules/billing/services/charge-version-service/two-part-tariff-seas
         });
 
         test('return requirememts are not fetched', async () => {
-          expect(returnRequirementVersionService.getByLicenceId.called).to.be.false();
+          expect(returnRequirementVersionService.getByLicenceId.called).to.be.true();
         });
 
         test('resolved with only the winter/all year season flag set', async () => {


### PR DESCRIPTION
Bugfix/water 3321
-- charge version year records were not created for historic years for new charge versions with a start date in the past. 
-- removed the flag to add 2PT season for WRSL charge versions with historic start date. 
-- this PR also reverts an earlier fix to avoid zero balance invoices. This has a negative impact on 2PT bill runs and has to be reverted. Zero balance invoices for supp. bill runs are unavoidable due to the imported bill runs from NALD because NALD did not run separate winter and summer 2PT bill runs. 