### PR TITLE
bugfix/water-3370

### DIFF
--- a/src/modules/billing/services/supplementary-billing-service/supplementary-processor.js
+++ b/src/modules/billing/services/supplementary-billing-service/supplementary-processor.js
@@ -42,7 +42,6 @@ const commonTransactionKeys = [
   'section126Factor',
   'section127Agreement',
   'section130Agreement',
-  'isTwoPartTariffSupplementary',
   'invoiceAccountNumber',
   'financialYearEnding'
 ];
@@ -60,7 +59,7 @@ const commonTransactionKeys = [
 const getGroupingKey = transaction => {
   // Create a list of keys which will form the grouping key
   const keys = [...commonTransactionKeys];
-  transaction.isTwoPartTariffSupplementary
+  ((transaction.description.slice(0, 6).toLowerCase()) === 'second')
     ? keys.push('isSummer')
     : keys.push('authorisedDays', 'volume');
 

--- a/test/modules/billing/services/supplementary-billing-service/supplementary-processor.js
+++ b/test/modules/billing/services/supplementary-billing-service/supplementary-processor.js
@@ -181,13 +181,8 @@ experiment('modules/billing/services/supplementary-billing-service/supplementary
             isTwoPartTariffSupplementary: true,
             isCredit: false
           }),
-          createTransaction('historical-batch', ids[1], {
-            volume: 10,
-            isTwoPartTariffSupplementary: true,
-            isCredit: true
-          }),
           createTransaction(batchId, ids[2], {
-            volume: 10.345,
+            volume: 20.345,
             isTwoPartTariffSupplementary: true,
             isCredit: false
           })
@@ -197,7 +192,6 @@ experiment('modules/billing/services/supplementary-billing-service/supplementary
 
       test('the historical transactions are not reversed', async () => {
         expect(findTransactionById(result, ids[0]).action).to.be.null();
-        expect(findTransactionById(result, ids[1]).action).to.be.null();
       });
 
       test('the current batch transaction is deleted', async () => {


### PR DESCRIPTION
removed isTwoPartSupplementary flag from transaction grouping. This is causing issues when trying to negate nald second part charges with wrls second part charges. 