### PR TITLE
hotfix/water-3354

### DIFF
--- a/src/modules/billing/services/charge-version-service/index.js
+++ b/src/modules/billing/services/charge-version-service/index.js
@@ -102,7 +102,10 @@ const getTwoPartTariffTransactionTypes = async (batch, chargeVersion) => {
       chargeVersionHasAgreement: true
     };
   }
-  return [];
+  return {
+    types: [],
+    chargeVersionHasAgreement: false
+  };
 };
 
 /**


### PR DESCRIPTION
-- 2PT transaction types did not return the correct empty object.