### PR TITLE
WATER 3329: Addition of SLD as a unit type in the tagging flow

### DIFF
--- a/src/modules/gauging-stations/routes/index.js
+++ b/src/modules/gauging-stations/routes/index.js
@@ -6,7 +6,7 @@ const controller = require('../controller');
 
 const VALID_DAY = Joi.number().integer().min(1).max(31);
 const VALID_MONTH = Joi.number().integer().min(1).max(12);
-const VALID_THRESHOLD_UNITS = Joi.string().required().allow('Ml/d', 'm3/s', 'm3/d', 'l/s', 'mAOD', 'mASD', 'm');
+const VALID_THRESHOLD_UNITS = Joi.string().required().valid('Ml/d', 'm3/s', 'm3/d', 'l/s', 'mAOD', 'mASD', 'm', 'SLD');
 
 module.exports = {
   getGaugingStations: {

--- a/test/modules/gauging-stations/routes.js
+++ b/test/modules/gauging-stations/routes.js
@@ -18,3 +18,26 @@ experiment('.getGaugingStation', () => {
     expect(routes.getGaugingStation.path).to.equal('/water/1.0/gauging-stations/{stationGuid}');
   });
 });
+
+experiment('.createLicenceGaugingStationLink', () => {
+  const payload = {
+    licenceId: '00000000-0000-0000-0000-000000000001',
+    licenceVersionPurposeConditionId: '00000000-0000-0000-0000-000000000002',
+    thresholdUnit: 'SLD',
+    thresholdValue: 10,
+    restrictionType: 'flow',
+    alertType: 'reduce'
+  };
+
+  test('it has a valid thresholdUnit in the payload', () => {
+    const schema = routes.createLicenceGaugingStationLink.config.validate.payload;
+    const result = schema.validate(payload);
+    expect(result.value).to.equal(payload);
+  });
+
+  test('it has an invalid thresholdUnit in the payload', () => {
+    const schema = routes.createLicenceGaugingStationLink.config.validate.payload;
+    const result = schema.validate({ ...payload, thresholdUnit: 'xxx' });
+    expect(result.error.message).to.equal('"thresholdUnit" must be one of [Ml/d, m3/s, m3/d, l/s, mAOD, mASD, m, SLD]');
+  });
+});


### PR DESCRIPTION
See: https://eaflood.atlassian.net/browse/WATER-3329
This is a prerequisite for: https://github.com/DEFRA/water-abstraction-ui/pull/1983