### PR TITLE
Adds a migration script and amends model

### DIFF
--- a/migrations/20211201114914-sroc-flags.js
+++ b/migrations/20211201114914-sroc-flags.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20211201114914-sroc-flags-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20211201114914-sroc-flags-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20211201114914-sroc-flags-down.sql
+++ b/migrations/sqls/20211201114914-sroc-flags-down.sql
@@ -1,0 +1,6 @@
+/* Replace with your SQL commands */
+
+ALTER table water.charge_versions
+drop column charging_scheme;
+
+drop type water.charging_scheme;

--- a/migrations/sqls/20211201114914-sroc-flags-up.sql
+++ b/migrations/sqls/20211201114914-sroc-flags-up.sql
@@ -1,0 +1,8 @@
+/* Replace with your SQL commands */
+
+create type water.charging_scheme as enum ('presroc', 'sroc');
+
+ALTER table water.charge_versions
+add column charging_scheme water.charging_scheme default 'presroc';
+
+update water.charge_versions set charging_scheme = 'presroc';

--- a/src/lib/models/charge-version.js
+++ b/src/lib/models/charge-version.js
@@ -38,6 +38,10 @@ class ChargeVersion extends Model {
     this._chargeElements = [];
   }
 
+  get licence () {
+    return this._licence;
+  }
+
   /**
    * Licence
    * @param {Licence}
@@ -47,8 +51,8 @@ class ChargeVersion extends Model {
     this._licence = licence;
   }
 
-  get licence () {
-    return this._licence;
+  get scheme () {
+    return this._scheme;
   }
 
   /**
@@ -60,8 +64,8 @@ class ChargeVersion extends Model {
     this._scheme = scheme;
   }
 
-  get scheme () {
-    return this._scheme;
+  get versionNumber () {
+    return this._versionNumber;
   }
 
   /**
@@ -73,8 +77,8 @@ class ChargeVersion extends Model {
     this._versionNumber = versionNumber;
   }
 
-  get versionNumber () {
-    return this._versionNumber;
+  get dateRange () {
+    return this._dateRange;
   }
 
   /**
@@ -86,8 +90,8 @@ class ChargeVersion extends Model {
     this._dateRange = dateRange;
   }
 
-  get dateRange () {
-    return this._dateRange;
+  get status () {
+    return this._status;
   }
 
   /**
@@ -97,10 +101,6 @@ class ChargeVersion extends Model {
   set status (status) {
     validators.assertEnum(status, Object.values(STATUS));
     this._status = status;
-  }
-
-  get status () {
-    return this._status;
   }
 
   /**
@@ -116,6 +116,10 @@ class ChargeVersion extends Model {
     this._region = region;
   }
 
+  get source () {
+    return this._source;
+  }
+
   /**
    * Source
    * @param {String}
@@ -125,8 +129,8 @@ class ChargeVersion extends Model {
     this._source = source;
   }
 
-  get source () {
-    return this._source;
+  get company () {
+    return this._company;
   }
 
   /**
@@ -138,8 +142,8 @@ class ChargeVersion extends Model {
     this._company = company;
   }
 
-  get company () {
-    return this._company;
+  get invoiceAccount () {
+    return this._invoiceAccount;
   }
 
   /**
@@ -151,8 +155,8 @@ class ChargeVersion extends Model {
     this._invoiceAccount = invoiceAccount;
   }
 
-  get invoiceAccount () {
-    return this._invoiceAccount;
+  get chargeElements () {
+    return this._chargeElements;
   }
 
   /**
@@ -164,21 +168,21 @@ class ChargeVersion extends Model {
     this._chargeElements = chargeElements;
   }
 
-  get chargeElements () {
-    return this._chargeElements;
+  get changeReason () {
+    return this._changeReason;
   }
 
   /**
- * Change Reason
- * @param {ChangeReason}
- */
+   * Change Reason
+   * @param {ChangeReason}
+   */
   set changeReason (changeReason) {
     validators.assertIsNullableInstanceOf(changeReason, ChangeReason);
     this._changeReason = changeReason;
   }
 
-  get changeReason () {
-    return this._changeReason;
+  get apportionment () {
+    return this._apportionment;
   }
 
   /*
@@ -190,7 +194,9 @@ class ChargeVersion extends Model {
     this._apportionment = apportionment;
   }
 
-  get apportionment () { return this._apportionment; }
+  get error () {
+    return this._error;
+  }
 
   /**
    * Set the error flag
@@ -201,7 +207,9 @@ class ChargeVersion extends Model {
     this._error = error;
   }
 
-  get error () { return this._error; }
+  get billedUpToDate () {
+    return this._billedUpToDate;
+  }
 
   /**
    * Set the billed up to date
@@ -211,16 +219,24 @@ class ChargeVersion extends Model {
     this._billedUpToDate = this.getDateTimeFromValue(billedUpToDate);
   }
 
-  get billedUpToDate () { return this._billedUpToDate; }
+  get dateCreated () {
+    return this._dateCreated;
+  }
 
-  get dateCreated () { return this._dateCreated; }
   set dateCreated (value) {
     this._dateCreated = this.getDateTimeFromValue(value);
   }
 
-  get dateUpdated () { return this._dateUpdated; }
+  get dateUpdated () {
+    return this._dateUpdated;
+  }
+
   set dateUpdated (value) {
     this._dateUpdated = this.getDateTimeFromValue(value);
+  }
+
+  get createdBy () {
+    return this._createdBy;
   }
 
   /**
@@ -232,8 +248,8 @@ class ChargeVersion extends Model {
     this._createdBy = createdBy;
   }
 
-  get createdBy () {
-    return this._createdBy;
+  get approvedBy () {
+    return this._approvedBy;
   }
 
   /**
@@ -245,8 +261,17 @@ class ChargeVersion extends Model {
     this._approvedBy = approvedBy;
   }
 
-  get approvedBy () {
-    return this._approvedBy;
+  get chargingScheme () {
+    return this._chargingScheme;
+  }
+
+  set chargingScheme (chargingScheme) {
+    if (!chargingScheme) {
+      this._chargingScheme = 'presroc';
+    } else {
+      validators.assertNullableEnum(chargingScheme, ['sroc', 'presroc']);
+      this._chargingScheme = chargingScheme;
+    }
   }
 }
 

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -206,6 +206,7 @@ const approve = async (chargeVersionWorkflow, approvedBy) => {
   chargeVersion.fromHash({
     createdBy: chargeVersionWorkflow.createdBy,
     approvedBy,
+    chargingScheme: 'presroc',
     licence
   });
 

--- a/test/lib/models/charge-version.js
+++ b/test/lib/models/charge-version.js
@@ -362,4 +362,28 @@ experiment('lib/models/charge-version', () => {
       expect(func).to.throw();
     });
   });
+
+  experiment('.chargingScheme', () => {
+    test('can be set to sroc', async () => {
+      chargeVersion.chargingScheme = 'sroc';
+      expect(chargeVersion.chargingScheme).to.equal('sroc');
+    });
+
+    test('can be set to presroc', async () => {
+      chargeVersion.chargingScheme = 'presroc';
+      expect(chargeVersion.chargingScheme).to.equal('presroc');
+    });
+
+    test('can be set to null, which will default to presroc', async () => {
+      chargeVersion.chargingScheme = null;
+      expect(chargeVersion.chargingScheme).to.equal('presroc');
+    });
+
+    test('throws an error if set to any other type', async () => {
+      const func = () => {
+        chargeVersion.chargingScheme = new TestModel();
+      };
+      expect(func).to.throw();
+    });
+  });
 });

--- a/test/modules/charge-versions/services/charge-version-workflows.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.js
@@ -417,6 +417,11 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
       expect(chargeVersion.approvedBy).to.equal(approvingUser);
     });
 
+    test('the charging scheme of the new charge version is set', async () => {
+      const [chargeVersion] = chargeVersionService.create.lastCall.args;
+      expect(chargeVersion.chargingScheme).to.equal('presroc');
+    });
+
     test('the workflow record is deleted', async () => {
       expect(chargeVersionWorkflowRepo.deleteOne.calledWith(chargeVersionWorkflow.id)).to.be.true();
     });


### PR DESCRIPTION
This PR adds a migration script to create a new ENUM type column for the `water.charge_versions` table to be extended, so that it can house a definition of whether a given charge version belongs to the old charging scheme or the new charging scheme.

This change does not have a corresponding user story ticket.