### PR TITLE
WATER-3451: Edit flag not set correctly

### DIFF
--- a/src/lib/models/billing-volume.js
+++ b/src/lib/models/billing-volume.js
@@ -191,7 +191,7 @@ class BillingVolume extends Model {
 
   /**
    * Allocates billing volume
-   * @param {Number} ML
+   * @param {Number} volume ML
    */
   allocate (volume) {
     this.assertIsNotApproved();
@@ -202,7 +202,7 @@ class BillingVolume extends Model {
 
   /**
    * De-allocate billing volume
-   * @param {Number} ML
+   * @param {Number} volume ML
    */
   deallocate (volume) {
     this.assertIsNotApproved();
@@ -220,10 +220,13 @@ class BillingVolume extends Model {
     const { calculatedVolume } = this;
 
     this.assertIsNotApproved();
+
     if (!assignBillableStatuses.includes(this.twoPartTariffStatus)) {
       this.volume = is.object(calculatedVolume) && is.directInstanceOf(calculatedVolume, Decimal)
         ? this.calculatedVolume.toDecimalPlaces(6).toNumber()
         : this.calculatedVolume;
+    } else if (calculatedVolume === null) {
+      this.calculatedVolume = this.volume;
     }
     return this;
   }

--- a/test/modules/billing/mappers/billing-volume.js
+++ b/test/modules/billing/mappers/billing-volume.js
@@ -149,5 +149,16 @@ experiment('modules/billing/mappers/billing-volume', () => {
         expect(result.twoPartTariffReview.email).to.equal('nobody@example.com');
       });
     });
+
+    experiment('when there is a null calculated volume', () => {
+      beforeEach(async () => {
+        billingVolume.calculatedVolume = null;
+        result = billingVolumeMapper.modelToDb(billingVolume);
+      });
+
+      test('the calculated volume remains as null', async () => {
+        expect(result.calculatedVolume).to.equal(null);
+      });
+    });
   });
 });

--- a/test/modules/billing/services/volume-matching-service/matching-service.js
+++ b/test/modules/billing/services/volume-matching-service/matching-service.js
@@ -54,7 +54,7 @@ experiment('modules/billing/services/volume-matching-service/matching-service', 
     test('the matching is aborted early and error codes assigned', async () => {
       expect(result).to.be.an.array().length(1);
       expect(result[0].volume).to.equal(0);
-      expect(result[0].calculatedVolume).to.equal(null);
+      expect(result[0].calculatedVolume.toNumber()).to.equal(0);
       expect(result[0].twoPartTariffStatus).to.equal(twoPartTariffStatuses.ERROR_NO_RETURNS_SUBMITTED);
     });
   });


### PR DESCRIPTION
See: https://eaflood.atlassian.net/browse/WATER-3451
 - Make sure the calculated volume is equal to the original volume if it has been set to null
 
Please note that this is a prerequisite for:  https://github.com/DEFRA/water-abstraction-ui/pull/2010