### PR TITLE
Update refresh-totals.js

### DIFF
--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -74,3 +74,7 @@ exports.createMessage = createMessage;
 exports.handler = handler;
 exports.hasScheduler = true;
 exports.onFailed = onFailedHandler;
+exports.workerOptions = {
+  lockDuration: 3600000,
+  lockRenewTime: 3600000 / 2
+};


### PR DESCRIPTION
Relates to https://eaflood.atlassian.net/browse/WATER-3499

Fixes a problem where the generation of a bill run fails when the bill run is substantial.

The issue was to do with BullMQ creating duplicate jobs due to non-completion of the first job run. The fix here is to manually over-ride the duration of the lock limit for the naughty job.