### PR TITLE
bugfix/water-3500

### DIFF
--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -23,7 +23,7 @@ join (
     and t.source_transaction_id is null
     and b.status='sent'
     and i.is_de_minimis=false
-    and rebilling_state not in ('reversal', 'rebilled')
+    and i.rebilling_state not in ('reversal', 'rebilled')
 ) t on t.licence_id=l.licence_id and t.financial_year_ending>= b.from_financial_year_ending and t.financial_year_ending<=b.to_financial_year_ending
 where b.billing_batch_id=:batchId
 and l.licence_id not in (

--- a/src/lib/connectors/repos/queries/billing-transactions.js
+++ b/src/lib/connectors/repos/queries/billing-transactions.js
@@ -23,6 +23,7 @@ join (
     and t.source_transaction_id is null
     and b.status='sent'
     and i.is_de_minimis=false
+    and rebilling_state not in ('reversal', 'rebilled')
 ) t on t.licence_id=l.licence_id and t.financial_year_ending>= b.from_financial_year_ending and t.financial_year_ending<=b.to_financial_year_ending
 where b.billing_batch_id=:batchId
 and l.licence_id not in (


### PR DESCRIPTION
-- exclude rebilled and reversed transactions in the
supplementary process because they have already
been corrected and cancelled out.