### PR TITLE
Removes all Charge Version Workflows when Cypress is run

### DIFF
--- a/integration-tests/billing/services/queries/charge-versions.js
+++ b/integration-tests/billing/services/queries/charge-versions.js
@@ -5,4 +5,4 @@ exports.deleteChargeElements = `DELETE FROM water.charge_elements where charge_v
 exports.deleteChargeVersions = `DELETE FROM water.charge_versions WHERE licence_ref IN 
     (select licence_ref from water.licences WHERE is_test = true);`;
 
-exports.deleteChargeVerionWorkflows = `DELETE from water.charge_version_workflows`;
+exports.deleteChargeVerionWorkflows = 'DELETE from water.charge_version_workflows';

--- a/integration-tests/billing/services/queries/charge-versions.js
+++ b/integration-tests/billing/services/queries/charge-versions.js
@@ -5,6 +5,4 @@ exports.deleteChargeElements = `DELETE FROM water.charge_elements where charge_v
 exports.deleteChargeVersions = `DELETE FROM water.charge_versions WHERE licence_ref IN 
     (select licence_ref from water.licences WHERE is_test = true);`;
 
-exports.deleteChargeVerionWorkflows = `
-DELETE from water.charge_version_workflows where licence_id IN 
-  (SELECT licence_id from water.licences where is_test = true)`;
+exports.deleteChargeVerionWorkflows = `DELETE from water.charge_version_workflows`;


### PR DESCRIPTION
To be really clear:

Currently, we only delete Charge Version Workflows in a Cypress run for licences which are 'test' licences.

This change will delete *all* charge version workflows instead.

Requested in https://eaflood.atlassian.net/browse/WATER-3598 to aid QA efforts.