### PR TITLE
BUGFIX: Fix zero volume issue in connector

### DIFF
--- a/src/lib/connectors/repos/charge-categories.js
+++ b/src/lib/connectors/repos/charge-categories.js
@@ -35,7 +35,7 @@ const findOneByProperties = async (isTidal, lossFactor, isRestrictedSource, mode
   const model = await ChargeCategory
     .forge()
     .where({ is_tidal: isTidal, loss_factor: lossFactor, model_tier: modelTier, is_restricted_source: isRestrictedSource })
-    .where('min_volume', '<', volume)
+    .where('min_volume', '<=', volume)
     .where('max_volume', '>=', volume)
     .fetch({ require: false });
 


### PR DESCRIPTION
The total quantity to use for a charge reference can now be zero.