### PR TITLE
Test data fix

### DIFF
--- a/integration-tests/billing/fixtures/test-licences.yaml
+++ b/integration-tests/billing/fixtures/test-licences.yaml
@@ -2,7 +2,7 @@
   model: Region
   fields:
     chargeRegionId: S
-    naldRegionId: 6
+    naldRegionId: 9
     name: Southern (Test replica)
     displayName: Southern (Test replica)
     isTest: true


### PR DESCRIPTION
-- changes southern test region  nald region id to 9 to avoid conflicts with the import process using the same nald region id. 