### PR TITLE
Add simplified endpoints to retrieve the data relating to batches for a financial year

### DIFF
--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -24,6 +24,7 @@ const { jobName: refreshTotalsJobName } = require('../jobs/refresh-totals');
 const { jobName: approveBatchJobName } = require('../jobs/approve-batch');
 const batchStatus = require('../jobs/lib/batch-status');
 const { BATCH_STATUS } = require('../../../lib/models/batch');
+const { BillingBatch } = require('../../../lib/connectors/bookshelf');
 /**
  * Resource that will create a new batch skeleton which will
  * then be asynchronously populated with charge versions by a
@@ -200,6 +201,23 @@ const postSetBatchStatusToCancel = async (request, h) => {
   }
 };
 
+const getBatchBillableYears = async (request, h) => {
+  const { regionId, batchType, financialYearEnding, isSummer } = request.payload;
+
+  const model = await BillingBatch
+    .forge()
+    .where({
+      region_id: regionId,
+      batch_type: batchType,
+      is_summer: isSummer
+    })
+    .where('status', 'in', ['sent'])
+    .fetch();
+  const response = model ? model.toJSON() : null;
+
+  return h.response(response).code(200);
+};
+
 exports.getBatch = getBatch;
 exports.getBatches = getBatches;
 exports.getBatchDownloadData = getBatchDownloadData;
@@ -215,3 +233,5 @@ exports.postCreateBatch = postCreateBatch;
 
 exports.deleteAllBillingData = deleteAllBillingData;
 exports.postSetBatchStatusToCancel = postSetBatchStatusToCancel;
+
+exports.getBatchBillableYears = getBatchBillableYears;

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -204,9 +204,7 @@ const postSetBatchStatusToCancel = async (request, h) => {
   }
 };
 
-// TODO: We also need to filter out years which don't have a licence or anything recorded against it as there's no point
-// in creating a batch
-const getBatchBillableYears = async (request, h) => {
+const postBatchBillableYears = async (request, h) => {
   const { regionId, isSummer, currentFinancialYear } = request.payload;
 
   const existingBatches = await BillingBatch
@@ -257,5 +255,5 @@ module.exports = {
   postCreateBatch,
   deleteAllBillingData,
   postSetBatchStatusToCancel,
-  getBatchBillableYears
+  postBatchBillableYears
 };

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -211,7 +211,8 @@ const getBatchBillableYears = async (request, h) => {
 
   const allPossibleEndDates = allPossibleCycles
     .filter(cycle => cycle.isSummer === isSummer)
-    .map(cycle => charging.getFinancialYear(cycle.endDate));
+    .map(cycle => charging.getFinancialYear(cycle.endDate))
+    .sort((a, b) => b - a);
 
   const existingBatches = await BillingBatch
     .where({

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -221,8 +221,7 @@ const postBatchBillableYears = async (request, h) => {
     ])
     .fetchAll({ columns: ['to_financial_year_ending'] });
 
-  const batchFinancialYears = existingBatches.toJSON().map(batch => batch.toFinancialYearEnding);
-
+  const batchFinancialYears = await existingBatches.toJSON().map(batch => batch.toFinancialYearEnding);
   const unsentYears = _determineUnsentYears(currentFinancialYear, batchFinancialYears);
 
   return h.response({ unsentYears }).code(200);

--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -284,7 +284,6 @@ const getBatchBillableYears = {
         userEmail: Joi.string().email().required(),
         regionId: Joi.string().uuid().required(),
         batchType: Joi.string().valid('annual', 'supplementary', 'two_part_tariff').required(),
-        financialYearEnding: Joi.number().required(),
         isSummer: Joi.boolean().default(false)
       })
     }

--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -283,8 +283,8 @@ const getBatchBillableYears = {
       payload: Joi.object().keys({
         userEmail: Joi.string().email().required(),
         regionId: Joi.string().uuid().required(),
-        batchType: Joi.string().valid('annual', 'supplementary', 'two_part_tariff').required(),
-        isSummer: Joi.boolean().default(false)
+        isSummer: Joi.boolean().default(false),
+        currentFinancialYear: Joi.number().required()
       })
     }
     // auth: {

--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -274,17 +274,39 @@ const postSetBatchStatusToCancel = {
   }
 };
 
-exports.getBatch = getBatch;
-exports.getBatches = getBatches;
-exports.getBatchInvoices = getBatchInvoices;
-exports.getBatchInvoiceDetail = getBatchInvoiceDetail;
-exports.getBatchInvoicesDetails = getBatchInvoicesDetails;
-exports.getInvoiceLicence = getInvoiceLicence;
-exports.deleteBatchInvoice = deleteBatchInvoice;
-exports.deleteBatch = deleteBatch;
+const getBatchBillableYears = {
+  method: 'POST',
+  path: `${BASE_PATH}/billable-years`,
+  handler: controller.getBatchBillableYears,
+  config: {
+    validate: {
+      payload: Joi.object().keys({
+        userEmail: Joi.string().email().required(),
+        regionId: Joi.string().uuid().required(),
+        batchType: Joi.string().valid('annual', 'supplementary', 'two_part_tariff').required(),
+        financialYearEnding: Joi.number().required(),
+        isSummer: Joi.boolean().default(false)
+      })
+    }
+    // auth: {
+    //   scope: [billing]
+    // }
+  }
+};
 
-exports.postApproveBatch = postApproveBatch;
-exports.postCreateBatch = postCreateBatch;
-exports.postApproveReviewBatch = postApproveReviewBatch;
-exports.getBatchDownloadData = getBatchDownloadData;
-exports.postSetBatchStatusToCancel = postSetBatchStatusToCancel;
+module.exports = {
+  getBatchBillableYears,
+  getBatch,
+  getBatches,
+  getBatchInvoices,
+  getBatchInvoiceDetail,
+  getBatchInvoicesDetails,
+  getInvoiceLicence,
+  deleteBatchInvoice,
+  deleteBatch,
+  postApproveBatch,
+  postCreateBatch,
+  postApproveReviewBatch,
+  getBatchDownloadData,
+  postSetBatchStatusToCancel
+};

--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -274,10 +274,10 @@ const postSetBatchStatusToCancel = {
   }
 };
 
-const getBatchBillableYears = {
+const postBatchBillableYears = {
   method: 'POST',
   path: `${BASE_PATH}/billable-years`,
-  handler: controller.getBatchBillableYears,
+  handler: controller.postBatchBillableYears,
   config: {
     validate: {
       payload: Joi.object().keys({
@@ -286,15 +286,14 @@ const getBatchBillableYears = {
         isSummer: Joi.boolean().default(false),
         currentFinancialYear: Joi.number().required()
       })
+    },
+    auth: {
+      scope: [billing]
     }
-    // auth: {
-    //   scope: [billing]
-    // }
   }
 };
 
 module.exports = {
-  getBatchBillableYears,
   getBatch,
   getBatches,
   getBatchInvoices,
@@ -304,6 +303,7 @@ module.exports = {
   deleteBatchInvoice,
   deleteBatch,
   postApproveBatch,
+  postBatchBillableYears,
   postCreateBatch,
   postApproveReviewBatch,
   getBatchDownloadData,

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -62,17 +62,17 @@ const getExistingBatch = (batches, toFinancialYearEnding) => {
     BATCH_STATUS.review
   ];
 
-  const existingBatch = batches.find(b => liveStatuses.includes(b.status) && b.toFinancialYearEnding === toFinancialYearEnding);
+  const existingBatch = batches.find(batch => liveStatuses.includes(batch.status) && batch.toFinancialYearEnding === toFinancialYearEnding);
   return mapBatch(existingBatch);
 };
 
 const getDuplicateSentBatch = (batches, batchType, toFinancialYearEnding, isSummer, scheme) => {
-  const duplicateSentBatch = batches.find(b =>
-    b.status === BATCH_STATUS.sent &&
-      b.batchType === batchType &&
-      b.toFinancialYearEnding === toFinancialYearEnding &&
-      b.isSummer === isSummer &&
-      b.scheme === scheme);
+  const duplicateSentBatch = batches.find(batch =>
+    batch.status === BATCH_STATUS.sent &&
+      batch.batchType === batchType &&
+      batch.toFinancialYearEnding === toFinancialYearEnding &&
+      batch.isSummer === isSummer &&
+      batch.scheme === scheme);
   return mapBatch(duplicateSentBatch);
 };
 

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -55,14 +55,14 @@ const getBatches = async (page = 1, perPage = Number.MAX_SAFE_INTEGER) => {
 
 const mapBatch = batch => batch ? mappers.batch.dbToModel(batch) : null;
 
-const getExistingBatch = batches => {
+const getExistingBatch = (batches, toFinancialYearEnding) => {
   const liveStatuses = [
     BATCH_STATUS.processing,
     BATCH_STATUS.ready,
     BATCH_STATUS.review
   ];
 
-  const existingBatch = batches.find(b => liveStatuses.includes(b.status));
+  const existingBatch = batches.find(b => liveStatuses.includes(b.status) && b.toFinancialYearEnding === toFinancialYearEnding);
   return mapBatch(existingBatch);
 };
 
@@ -78,7 +78,7 @@ const getDuplicateSentBatch = (batches, batchType, toFinancialYearEnding, isSumm
 const getExistingAndDuplicateBatchesForRegion = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
   const batches = await newRepos.billingBatches.findByRegionId(regionId);
   return {
-    existingBatch: getExistingBatch(batches),
+    existingBatch: getExistingBatch(batches, toFinancialYearEnding),
     duplicateSentBatch: getDuplicateSentBatch(batches, batchType, toFinancialYearEnding, isSummer)
   };
 };

--- a/test/modules/billing/routes/batches.js
+++ b/test/modules/billing/routes/batches.js
@@ -591,4 +591,81 @@ experiment('modules/billing/routes', () => {
       expect(pre[0].assign).to.equal('batch');
     });
   });
+
+  experiment.only('postBatchBillableYears', () => {
+    let request;
+    let server;
+
+    beforeEach(async () => {
+      server = await getServer(routes.postBatchBillableYears);
+
+      request = {
+        method: 'POST',
+        url: '/water/1.0/billing/batches/billable-years',
+        payload: {
+          userEmail: 'charging@example.com',
+          regionId: '054517f2-be00-4505-a3cc-df65a89cd8e1',
+          isSummer: true,
+          currentFinancialYear: 2022
+        },
+        auth
+      };
+    });
+
+    test('returns the 200 for a valid payload', async () => {
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+    });
+
+    test('returns a 400 if the userEmail is not a valid email', async () => {
+      request.payload.userEmail = 'a string';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the userEmail is omitted', async () => {
+      delete request.payload.userEmail;
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the regionId is not a uuid', async () => {
+      request.payload.regionId = 'a string';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the regionId is omitted', async () => {
+      delete request.payload.regionId;
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the currentFinancialYear is not a number', async () => {
+      request.payload.currentFinancialYear = false;
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the currentFinancialYear is omitted', async () => {
+      delete request.payload.currentFinancialYear;
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 400 if the isSummer is an unexpected value', async () => {
+      request.payload.isSummer = 'nope';
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('returns a 200 if the isSummer is omitted (defaults to false)', async () => {
+      delete request.payload.isSummer;
+
+      const response = await server.inject(request);
+
+      expect(response.statusCode).to.equal(200);
+      expect(response.request.payload.isSummer).to.equal(false);
+    });
+  });
 });

--- a/test/modules/billing/routes/batches.js
+++ b/test/modules/billing/routes/batches.js
@@ -592,7 +592,7 @@ experiment('modules/billing/routes', () => {
     });
   });
 
-  experiment.only('postBatchBillableYears', () => {
+  experiment('postBatchBillableYears', () => {
     let request;
     let server;
 

--- a/test/modules/billing/services/batch-service.js
+++ b/test/modules/billing/services/batch-service.js
@@ -660,12 +660,14 @@ experiment('modules/billing/services/batch-service', () => {
           {
             billingBatchId: '11111111-0000-0000-0000-000000000000',
             batchType: 'supplementary',
+            toFinancialYearEnding: 2020,
             isSummer: false,
             status: 'sent'
           },
           {
             billingBatchId: '33333333-0000-0000-0000-000000000000',
             batchType: 'supplementary',
+            toFinancialYearEnding: 2020,
             isSummer: false,
             status: 'processing'
           }
@@ -897,19 +899,20 @@ experiment('modules/billing/services/batch-service', () => {
         newRepos.billingBatches.findByRegionId.resolves([{
           billingBatchId: existingBatchId,
           batchType: 'supplementary',
+          toFinancialYearEnding: 2022,
           isSummer: false,
           status: 'processing'
         }]);
       });
 
       test('the function rejects', async () => {
-        const func = () => batchService.create(regionId, 'supplementary', 2019, false);
+        const func = () => batchService.create(regionId, 'supplementary', 2022, false);
         expect(func()).to.reject();
       });
 
       test('a Boom Conflict error is thrown with expected message and batch', async () => {
         try {
-          await batchService.create(regionId, 'supplementary', 2019, false);
+          await batchService.create(regionId, 'supplementary', 2022, false);
           fail();
         } catch (err) {
           expect(err.isBoom).to.be.true();


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3679

By default when creating a 2-part tariff bill run the current financial year is built. The users have identified scenarios where previous financial years have not been billed. This means they currently cannot generate the bill runs for them.

This change adds a new endpoint that when passed a batch (bill run) type, region, season and current financial will return an array of `unsent` financial years.

It queries the DB for batches that have been created (ignoring, for example, errored ones). It also generates a list of financial years counting 3 back from the current financial year. Any in the second list that appears in the first is removed.

For example

- `2020` exists and has been sent
- `2022` is the current financial year
- `[2020]` is compared to `[2022, 2021, 2020]`
- result sent back is `{ unsentYears: [2022, 2021] }`

This is used in [water-abstaction-ui](https://github.com/DEFRA/water-abstraction-ui/pull/2104) to determine whether to show a page to a user to select the year to bill, and to provide the options to display to the user when the page is shown.