### PR TITLE
Fix Test Region ID in test data

### DIFF
--- a/integration-tests/billing/fixtures/2PT1.yaml
+++ b/integration-tests/billing/fixtures/2PT1.yaml
@@ -2,7 +2,7 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
     displayName: Test Region
     isTest: true
@@ -157,4 +157,3 @@
     purposeUseId: $purposeUse.purposeUseId
     purposeAlias: SPRAY IRRIGATION DIRECT
     externalId: 1:12345678:A:AGR:400
-

--- a/integration-tests/billing/fixtures/2PT2.yaml
+++ b/integration-tests/billing/fixtures/2PT2.yaml
@@ -2,7 +2,7 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
     displayName: Test Region
     isTest: true
@@ -147,6 +147,3 @@
     purposeUseId: $purposeUse.purposeUseId
     purposeAlias: SPRAY IRRIGATION STORAGE
     externalId: 1:12345679:A:AGR:420
-
-
-

--- a/integration-tests/billing/fixtures/2PT2.yaml
+++ b/integration-tests/billing/fixtures/2PT2.yaml
@@ -110,7 +110,6 @@
     purposeSecondaryId : $purposeSecondary.purposeSecondaryId
     purposeUseId : $purposeUse.purposeUseId
     description: CE5
-    factorsOverridden: false
     isTest: true
 
 - ref: $returnVersion

--- a/integration-tests/billing/fixtures/AB1.yaml
+++ b/integration-tests/billing/fixtures/AB1.yaml
@@ -88,5 +88,4 @@
     purposeSecondaryId : $purposeSecondary.purposeSecondaryId
     purposeUseId : $purposeUse.purposeUseId
     description : CE1
-    factorsOverridden : false
     isTest: true

--- a/integration-tests/billing/fixtures/AB1.yaml
+++ b/integration-tests/billing/fixtures/AB1.yaml
@@ -2,9 +2,9 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
-    displayName: Test Region 
+    displayName: Test Region
     isTest: true
 
 - ref: $licence

--- a/integration-tests/billing/fixtures/AB2.yaml
+++ b/integration-tests/billing/fixtures/AB2.yaml
@@ -2,7 +2,7 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
     displayName: Test Region
     isTest: true
@@ -112,5 +112,3 @@
     description: CE2
     factorsOverridden: false
     isTest: true
-
-

--- a/integration-tests/billing/fixtures/AB2.yaml
+++ b/integration-tests/billing/fixtures/AB2.yaml
@@ -110,5 +110,4 @@
     purposeSecondaryId : $purposeSecondary.purposeSecondaryId
     purposeUseId : $purposeUse.purposeUseId
     description: CE2
-    factorsOverridden: false
     isTest: true

--- a/integration-tests/billing/fixtures/SB1-1.yaml
+++ b/integration-tests/billing/fixtures/SB1-1.yaml
@@ -88,5 +88,4 @@
     purposeSecondaryId : $purposeSecondary.purposeSecondaryId
     purposeUseId : $purposeUse.purposeUseId
     description : CE3
-    factorsOverridden : false
     isTest: true

--- a/integration-tests/billing/fixtures/SB1-1.yaml
+++ b/integration-tests/billing/fixtures/SB1-1.yaml
@@ -2,9 +2,9 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
-    displayName: Test Region 
+    displayName: Test Region
     isTest: true
 
 - ref: $licence

--- a/integration-tests/billing/fixtures/SB2-1.yaml
+++ b/integration-tests/billing/fixtures/SB2-1.yaml
@@ -88,5 +88,4 @@
     purposeSecondaryId : $purposeSecondary.purposeSecondaryId
     purposeUseId : $purposeUse.purposeUseId
     description : CE3
-    factorsOverridden : false
     isTest: true

--- a/integration-tests/billing/fixtures/SB2-1.yaml
+++ b/integration-tests/billing/fixtures/SB2-1.yaml
@@ -2,9 +2,9 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
-    displayName: Test Region 
+    displayName: Test Region
     isTest: true
 
 - ref: $licence

--- a/integration-tests/billing/fixtures/SB3-1.yaml
+++ b/integration-tests/billing/fixtures/SB3-1.yaml
@@ -2,9 +2,9 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
-    displayName: Test Region 
+    displayName: Test Region
     isTest: true
 
 - ref: $licence1

--- a/integration-tests/billing/fixtures/charge-version-workflows.yaml
+++ b/integration-tests/billing/fixtures/charge-version-workflows.yaml
@@ -2,9 +2,9 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
-    displayName: Test Region 
+    displayName: Test Region
     isTest: true
 
 - ref: $licence
@@ -20,7 +20,7 @@
     suspendFromBilling : false
     isTest: true
     regionId: $region.regionId
-    regions:      
+    regions:
       historicalAreaCode: 'ARCA'
       regionalChargeArea: 'Anglian'
 

--- a/integration-tests/billing/fixtures/historic-billing-2PT1.yaml
+++ b/integration-tests/billing/fixtures/historic-billing-2PT1.yaml
@@ -2,7 +2,7 @@
   model: Region
   fields:
     chargeRegionId: A
-    naldRegionId: 1
+    naldRegionId: 9
     name: Test Region
     displayName: Test Region
     isTest: true
@@ -158,4 +158,3 @@
     purposeUseId: $purposeUse.purposeUseId
     purposeAlias: SPRAY IRRIGATION DIRECT
     externalId: 1:12345678:A:AGR:400
-

--- a/test/lib/mappers/charge-version.js
+++ b/test/lib/mappers/charge-version.js
@@ -130,7 +130,7 @@ experiment('lib/mappers/charge-version', () => {
             regionId: uuid(),
             name: 'Test Region',
             chargeRegionId: 'T',
-            naldRegionId: 7,
+            naldRegionId: 9,
             displayName: 'Test Region'
           },
           regions: {

--- a/test/lib/mappers/region.js
+++ b/test/lib/mappers/region.js
@@ -20,7 +20,7 @@ experiment('modules/billing/mappers/region', () => {
         regionId: uuid(),
         name: 'Test Region',
         chargeRegionId: 'A',
-        naldRegionId: 1,
+        naldRegionId: 9,
         displayName: 'Display Region'
       };
 


### PR DESCRIPTION
It was flagged by @jozzey when first building their local environment that NALD imports weren't working. It was tracked down to the Test Region that was being created having a duplicate ID to an existing real region.

We thought we had fixed the problem in [Test data fix](https://github.com/DEFRA/water-abstraction-service/pull/1683) but turns out that was for something else.

This change goes through all the places in the test fixtures where we create the **Test Region** and ensures the ID is set to `9`.