### PR TITLE
Fix only() left in unit tests

### DIFF
--- a/test/modules/returns/controllers/csv-upload.test.js
+++ b/test/modules/returns/controllers/csv-upload.test.js
@@ -55,7 +55,7 @@ const requestFactory = (returnId, lines = []) => {
   }
 }
 
-experiment.only('modules/returns/controllers/csv-upload', () => {
+experiment('modules/returns/controllers/csv-upload', () => {
   experiment('.postUpload', () => {
     let request
     let h


### PR DESCRIPTION
We hadn't spotted in [use standard js for linting](https://github.com/DEFRA/water-abstraction-service/pull/1696) that a `test.only()` had been added, no doubt as the team was trying to figure out why a test wasn't passing.

We already have a fix to our CI pipeline which will check for these and fail the build. But that has not yet been added to the service CI.

Anyway, this is a quick fix to remove the `only()` and get _all_ the unit tests running again.