### PR TITLE
Export bill run CSV file for sroc

### DIFF
--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -167,8 +167,14 @@ const getBatchDownloadData = async request => {
         .map(transaction => transaction.chargeElement.chargeVersionId)
     ))
   })))
+
   const chargeVersions = await chargeVersionService.getManyByChargeVersionIds(chargeVersionIds)
-  return { invoices, chargeVersions, scheme: batch.scheme }
+
+  return {
+    invoices,
+    chargeVersions,
+    scheme: batch.scheme
+  }
 }
 
 /**

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -168,7 +168,7 @@ const getBatchDownloadData = async request => {
     ))
   })))
   const chargeVersions = await chargeVersionService.getManyByChargeVersionIds(chargeVersionIds)
-  return { invoices, chargeVersions }
+  return { invoices, chargeVersions, scheme: batch.scheme }
 }
 
 /**

--- a/test/modules/billing/controllers/batches.test.js
+++ b/test/modules/billing/controllers/batches.test.js
@@ -949,7 +949,12 @@ experiment('modules/billing/controller', () => {
     let request, invoices, result
     beforeEach(async () => {
       request = {
-        pre: { batch: { id: 'test-batch-id' } }
+        pre: {
+          batch: {
+            id: 'test-batch-id',
+            scheme: 'SCHEME'
+          }
+        }
       }
       invoices = getInvoices()
 
@@ -971,6 +976,10 @@ experiment('modules/billing/controller', () => {
     test('returns the result of both service calls', () => {
       expect(result.invoices).to.be.equal(invoices)
       expect(result.chargeVersions).to.be.equal([{ foo: 'bar' }])
+    })
+
+    test('returns the batch scheme', () => {
+      expect(result.scheme).to.equal('SCHEME')
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3586

We are updating the "download bill run" functionality to support sroc, which entails checking the bill run scheme and using a different set of output fields for alcs and sroc.