### PR TITLE
Fix non-prod delete all bill runs function

### DIFF
--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -239,20 +239,16 @@ const getBatchDownloadData = {
   }
 }
 
-if (config.featureToggles.deleteAllBillingData) {
-  const deleteAllBillingData = {
-    method: 'DELETE',
-    path: BASE_PATH,
-    handler: controller.deleteAllBillingData,
-    config: {
-      description: 'Deletes all billing and charge version data (!)',
-      auth: {
-        scope: [billing]
-      }
+const deleteAllBillingData = {
+  method: 'DELETE',
+  path: BASE_PATH,
+  handler: controller.deleteAllBillingData,
+  config: {
+    description: 'Deletes all billing and charge version data (!)',
+    auth: {
+      scope: [billing]
     }
   }
-
-  exports.deleteAllBillingData = deleteAllBillingData
 }
 
 const postSetBatchStatusToCancel = {
@@ -307,5 +303,7 @@ module.exports = {
   postCreateBatch,
   postApproveReviewBatch,
   getBatchDownloadData,
-  postSetBatchStatusToCancel
+  postSetBatchStatusToCancel,
+  // We only include delete all bill runs when running in non-prod environments
+  ...(config.featureToggles.deleteAllBillingData) && { deleteAllBillingData }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3712

There is a feature when the app is running in a non-production mode which enables in the UI the ability to delete all bill runs.

It relies on an endpoint in the service enabled via a feature toggle. Unfortunately, it looks like we broke it when tidying up the modules in `src/modules/billing/routes/batches.js` as part of [Fix module.exports](https://github.com/DEFRA/water-abstraction-team/issues/28).

This change fixes the issue and makes the endpoint accessible again.