### PR TITLE
Persist data for sroc bill run CSV export

### DIFF
--- a/src/modules/billing/mappers/transaction.js
+++ b/src/modules/billing/mappers/transaction.js
@@ -383,6 +383,7 @@ const cmToModelMapper = createMapper()
   .map('calculation.WRLSChargingResponse.abatementAdjustment').to('calcS126Factor')
   .map('calculation.WRLSChargingResponse.s127Agreement').to('calcS127Factor')
   .map('calculation.WRLSChargingResponse.s130Agreement').to('calcS130Factor')
+  .map('calculation.WRLSChargingResponse.winterOnlyAdjustment').to('calcWinterDiscountFactor')
   .map('calculation.WRLSChargingResponse.eiucFactor').to('calcEiucFactor')
   .map('calculation.WRLSChargingResponse.eiucSourceFactor').to('calcEiucSourceFactor')
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3586

Most of the changes needed for exporting bill run CSV files are done in the UI. However while working on this we have spotted some issues where data is not being correctly persisted in the service.