### PR TITLE
Addition of mBOD as a unit type in the tagging flow

### DIFF
--- a/src/modules/gauging-stations/routes/index.js
+++ b/src/modules/gauging-stations/routes/index.js
@@ -6,7 +6,7 @@ const controller = require('../controller')
 
 const VALID_DAY = Joi.number().integer().min(1).max(31)
 const VALID_MONTH = Joi.number().integer().min(1).max(12)
-const VALID_THRESHOLD_UNITS = Joi.string().required().valid('Ml/d', 'm3/s', 'm3/d', 'l/s', 'mAOD', 'mASD', 'm', 'SLD')
+const VALID_THRESHOLD_UNITS = Joi.string().required().valid('Ml/d', 'm3/s', 'm3/d', 'l/s', 'mAOD', 'mBOD', 'mASD', 'm', 'SLD')
 
 module.exports = {
   getGaugingStations: {

--- a/test/modules/gauging-stations/routes.test.js
+++ b/test/modules/gauging-stations/routes.test.js
@@ -38,6 +38,6 @@ experiment('.createLicenceGaugingStationLink', () => {
   test('it has an invalid thresholdUnit in the payload', () => {
     const schema = routes.createLicenceGaugingStationLink.config.validate.payload
     const result = schema.validate({ ...payload, thresholdUnit: 'xxx' })
-    expect(result.error.message).to.equal('"thresholdUnit" must be one of [Ml/d, m3/s, m3/d, l/s, mAOD, mASD, m, SLD]')
+    expect(result.error.message).to.equal('"thresholdUnit" must be one of [Ml/d, m3/s, m3/d, l/s, mAOD, mBOD, mASD, m, SLD]')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3616

There are licences that have hands-off levels measured in mBOD. mBOD = metres below ordinance datum. As an Environment Officer, I want to tag licences with hands-off levels measured in metres below ordinance datum, so that I can send water abstraction alerts to these licences.

This adds mBOD to the unit of measurement drop down when specifying a threshold as part of the tagging flow.