### PR TITLE
SRoC charge creation - additional characters required in charge reference description

### DIFF
--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -179,8 +179,8 @@ const testMatchTPTPurpose = async (field, term, _licence, headings, columns) => 
 }
 
 const testValidReferenceLineDescription = async (field, description) => {
-  const validCharacters = /[^a-z &*,./()\-\d]/i
-  return validCharacters.test(description) ? `${field} contains at least one unaccepted character` : ''
+  const invalidCharacters = /[“”\?\^£≥≤—]/
+  return invalidCharacters.test(description) ? `${field} contains at least one unaccepted character` : ''
 }
 
 exports.testNotBlank = testNotBlank

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -179,7 +179,7 @@ const testMatchTPTPurpose = async (field, term, _licence, headings, columns) => 
 }
 
 const testValidReferenceLineDescription = async (field, description) => {
-  const invalidCharacters = /[“”\?\^£≥≤—]/
+  const invalidCharacters = /[“”?^£≥≤—]/
   return invalidCharacters.test(description) ? `${field} contains at least one unaccepted character` : ''
 }
 

--- a/test/modules/charge-versions-upload/lib/validator/validator.test.js
+++ b/test/modules/charge-versions-upload/lib/validator/validator.test.js
@@ -345,7 +345,7 @@ experiment('validator', () => {
         })
 
         test('contains unaccepted characters', async () => {
-          const row = { ...testRow, chargeReferenceLineDescription: 'I_N_V_A_L_I_D' }
+          const row = { ...testRow, chargeReferenceLineDescription: 'I_N_V_A_L_I_D?' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_line_description contains at least one unaccepted character']))
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3700

As part of the SRoC charge creation process, users need to enter a description for the charge reference. B&D want to be able to use ; (semi colon) and ' (apostrophe) in this description.

The list of allowed characters in WRLS is currently limited to letters (lower and upper case), hyphen (dash), numbers, forward slash, ampersand (&), asterisk , commas, brackets.

The following characters are not accepted by SOP “ ? ^ £ ≥ ≤ — (long dash).

We should allow ; and ' in WRLS, in addition to the currently accepted characters. We are amending to a 'not allowed' list instead, and only exclude those characters not accepted by SOP.