### PR TITLE
Handle 0 Volumes

### DIFF
--- a/src/modules/charge-categories/routes.js
+++ b/src/modules/charge-categories/routes.js
@@ -15,7 +15,7 @@ module.exports = {
           loss: Joi.string().required().valid('low', 'medium', 'high'),
           isRestrictedSource: Joi.boolean().required(),
           waterModel: Joi.string().required().valid('no model', 'tier 1', 'tier 2'),
-          volume: Joi.number().min(0).required()
+          volume: Joi.number().greater(0).required()
         })
       }
     }

--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -4,7 +4,7 @@ const {
   testMaxDecimalPlaces, testBlankWhen, testPopulatedWhen, testSupportedSourceOrBlank, testValidReferenceLineDescription,
   testMaxValue, testMaxDigits, testMatchTPTPurpose, testDateAfterLicenceDate, testDateBefore, testValidDate,
   testDateRange, testPurpose, testDateBeforeSrocStartDate, testDateBeforeLicenceDate, testValidLicence,
-  testLicenceHasInvoiceAccount, testNumberGreaterThanOrEqualToZero
+  testLicenceHasInvoiceAccount
 } = require('./tests')
 
 const csvFields = {
@@ -104,7 +104,7 @@ const csvFields = {
       testNotBlank,
       testMaxDigits(17),
       testNumber,
-      testNumberGreaterThanOrEqualToZero,
+      testNumberGreaterThanZero,
       testMaxDecimalPlaces(6),
       testMaxValue(1000000000000000)
     ]

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -140,8 +140,6 @@ const testNumber = async (field, number) => {
 
 const testNumberGreaterThanZero = async (field, number) => parseFloat(number) > 0 ? '' : `${field} is less than or equal to 0`
 
-const testNumberGreaterThanOrEqualToZero = async (field, number) => parseFloat(number) >= 0 ? '' : `${field} is less than 0`
-
 const testNumberLessThanOne = async (field, number) => parseFloat(number) < 1 ? '' : `${field} is greater than or equal to 1`
 
 const testMaxDecimalPlaces = maxDecimalPlaces => async (field, number) => {
@@ -201,7 +199,6 @@ exports.testBlankWhen = testBlankWhen
 exports.testDateRange = testDateRange
 exports.testNumber = testNumber
 exports.testNumberGreaterThanZero = testNumberGreaterThanZero
-exports.testNumberGreaterThanOrEqualToZero = testNumberGreaterThanOrEqualToZero
 exports.testNumberLessThanOne = testNumberLessThanOne
 exports.testMaxDecimalPlaces = testMaxDecimalPlaces
 exports.testDateBefore = testDateBefore

--- a/test/modules/charge-categories/routes.test.js
+++ b/test/modules/charge-categories/routes.test.js
@@ -43,12 +43,6 @@ experiment('modules/charge-categories/routes', () => {
       const response = await server.inject(request)
       expect(response.statusCode).to.equal(200)
     })
-    test('returns the 200 for a volume of 0', async () => {
-      queryParams.volume = 0
-      request.url = request.url + '?' + new URLSearchParams(queryParams)
-      const response = await server.inject(request)
-      expect(response.statusCode).to.equal(200)
-    })
 
     test('returns a 400 if the source is not included in the query string', async () => {
       request.url = request.url + '?' + new URLSearchParams(omit(queryParams, 'source'))
@@ -101,6 +95,12 @@ experiment('modules/charge-categories/routes', () => {
     })
     test('returns a 400 if the volume is not a number', async () => {
       queryParams.volume = 'invalid'
+      request.url = request.url + '?' + new URLSearchParams(queryParams)
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(400)
+    })
+    test('returns a 400 if the volume is 0', async () => {
+      queryParams.volume = 0
       request.url = request.url + '?' + new URLSearchParams(queryParams)
       const response = await server.inject(request)
       expect(response.statusCode).to.equal(400)

--- a/test/modules/charge-versions-upload/lib/validator/validator.test.js
+++ b/test/modules/charge-versions-upload/lib/validator/validator.test.js
@@ -288,9 +288,14 @@ experiment('validator', () => {
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is not a number']))
         })
 
-        test('is not a number', async () => {
+        test('is zero', async () => {
+          const row = { ...testRow, chargeReferenceDetailsVolume: '0' }
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is less than or equal to 0']))
+        })
+
+        test('is a negative number', async () => {
           const row = { ...testRow, chargeReferenceDetailsVolume: '-1' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is less than 0']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is less than or equal to 0']))
         })
 
         test('has more than 6 decimal places', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3696

If 0 sent to charge module, it will always generate nil charge. WRLS should change validation to accept anything greater than 0.