### PR TITLE
Sroc upload -- allow public water only for water undertakers

### DIFF
--- a/src/modules/charge-versions-upload/lib/helpers.js
+++ b/src/modules/charge-versions-upload/lib/helpers.js
@@ -57,8 +57,8 @@ const getLicence = async licenceNumber => {
   if (!cache.licences[licenceNumber]) {
     assertLicenceNumber(licenceNumber)
     // Only include required properties
-    const { id, startDate, expiredDate, lapsedDate, revokedDate, regionalChargeArea } = await licencesService.getLicenceByLicenceRef(licenceNumber)
-    cache.licences[licenceNumber] = deepFreeze({ id, licenceNumber, startDate, expiredDate, lapsedDate, revokedDate, regionalChargeArea })
+    const { id, startDate, expiredDate, lapsedDate, revokedDate, regionalChargeArea, isWaterUndertaker } = await licencesService.getLicenceByLicenceRef(licenceNumber)
+    cache.licences[licenceNumber] = deepFreeze({ id, licenceNumber, startDate, expiredDate, lapsedDate, revokedDate, regionalChargeArea, isWaterUndertaker })
   }
   return cache.licences[licenceNumber]
 }

--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -4,7 +4,7 @@ const {
   testMaxDecimalPlaces, testBlankWhen, testPopulatedWhen, testSupportedSourceOrBlank, testValidReferenceLineDescription,
   testMaxValue, testMaxDigits, testMatchTPTPurpose, testDateAfterLicenceDate, testDateBefore, testValidDate,
   testDateRange, testPurpose, testDateBeforeSrocStartDate, testDateBeforeLicenceDate, testValidLicence,
-  testLicenceHasInvoiceAccount, testNumberGreaterThanOrEqualToZero
+  testLicenceHasInvoiceAccount, testNumberGreaterThanOrEqualToZero, testNotWaterUndertaker
 } = require('./tests')
 
 const csvFields = {
@@ -144,7 +144,8 @@ const csvFields = {
   chargeReferenceDetailsPublicWaterSupply: {
     validate: [
       testNotBlank,
-      testAcceptedTerm(['Y', 'N'])
+      testAcceptedTerm(['Y', 'N']),
+      testNotWaterUndertaker
     ]
   },
   chargeReferenceDetailsAggregateFactor: {

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -20,9 +20,9 @@ const testValidLicence = async (field, _licenceNumber, licence) => {
   const { expiredDate, lapsedDate, revokedDate } = licence || {}
   if (licence && [expiredDate, lapsedDate, revokedDate].every(date => !date || new Date(date) >= billing.srocStartDate)) {
     return ''
-  } else {
-    return `${field} is not valid`
   }
+
+  return `${field} is not valid`
 }
 
 const testLicenceHasInvoiceAccount = async (field, _licenceNumber, licence, headings, columns) => {
@@ -30,11 +30,13 @@ const testLicenceHasInvoiceAccount = async (field, _licenceNumber, licence, head
   const invoiceAccount = await helpers.getInvoiceAccount(licence, invoiceAccountNumber)
   if (invoiceAccount) {
     return ''
-  } else if (invoiceAccountNumber) {
-    return `charge_information_billing_account is not valid for ${field}`
-  } else {
-    return `charge_information_billing_account is required for ${field}`
   }
+
+  if (invoiceAccountNumber) {
+    return `charge_information_billing_account is not valid for ${field}`
+  }
+
+  return `charge_information_billing_account is required for ${field}`
 }
 
 const testValidDate = async (field, date = '') => helpers.formatDate(date) ? '' : `"${field} has an incorrect format, expected DD/MM/YYYY"`
@@ -78,9 +80,9 @@ const testDateBeforeSrocStartDate = async (field, date = '') => {
   const { srocStartDate } = billing
   if (date && formattedDate < srocStartDate) {
     return `${field} is before ${moment(srocStartDate).format('D MMMM YYYY')}`
-  } else {
-    return ''
   }
+
+  return ''
 }
 
 const testPurpose = async (field, description, licence) => {
@@ -88,6 +90,7 @@ const testPurpose = async (field, description, licence) => {
     const licenceVersionPurposes = await helpers.getLicenceVersionPurposes(licence.id)
     return licenceVersionPurposes.find(licenceVersionPurpose => licenceVersionPurpose.purposeUse.description === description) ? '' : `${field} is not an accepted term`
   }
+
   return ''
 }
 
@@ -95,25 +98,25 @@ const testSupportedSourceOrBlank = async (field, name) => {
   if (name) {
     const supportedSources = await helpers.getSupportedSources()
     return supportedSources.find(supportedSource => supportedSource.name === name) ? '' : `${field} is not an accepted term`
-  } else {
-    return ''
   }
+
+  return ''
 }
 
 const testPopulatedWhen = (fieldName, fieldValue, fieldTitle) => async (field, val, _licence, headings, columns) => {
   if (getColumnValue(headings, columns, fieldName) === fieldValue) {
     return val ? '' : `${field} is blank when the ${fieldTitle} is "${fieldValue}"`
-  } else {
-    return ''
   }
+
+  return ''
 }
 
 const testBlankWhen = (fieldName, fieldValue, fieldTitle) => async (field, val, _licence, headings, columns) => {
   if (getColumnValue(headings, columns, fieldName) === fieldValue) {
     return val ? `${field} is populated when the ${fieldTitle} is "${fieldValue}"` : ''
-  } else {
-    return ''
   }
+
+  return ''
 }
 
 const testDateRange = async (field, dateRange) => {
@@ -173,13 +176,14 @@ const testMatchTPTPurpose = async (field, term, _licence, headings, columns) => 
     const purposeUses = await helpers.getPurposeUses()
     const purpose = purposeUses.find(purposeUse => purposeUse.description === description)
     return purpose && purpose.isTwoPartTariff ? '' : `${field} does not match the purpose`
-  } else {
-    return ''
   }
+
+  return ''
 }
 
 const testValidReferenceLineDescription = async (field, description) => {
   const invalidCharacters = /[“”?^£≥≤—]/
+
   return invalidCharacters.test(description) ? `${field} contains at least one unaccepted character` : ''
 }
 

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -183,27 +183,39 @@ const testValidReferenceLineDescription = async (field, description) => {
   return invalidCharacters.test(description) ? `${field} contains at least one unaccepted character` : ''
 }
 
-exports.testNotBlank = testNotBlank
-exports.testAcceptedTerm = testAcceptedTerm
-exports.testMaxLength = testMaxLength
-exports.testMaxValue = testMaxValue
-exports.testMaxDigits = testMaxDigits
-exports.testValidLicence = testValidLicence
-exports.testLicenceHasInvoiceAccount = testLicenceHasInvoiceAccount
-exports.testValidDate = testValidDate
-exports.testDateAfterLicenceDate = testDateAfterLicenceDate
-exports.testDateBeforeLicenceDate = testDateBeforeLicenceDate
-exports.testDateBeforeSrocStartDate = testDateBeforeSrocStartDate
-exports.testPurpose = testPurpose
-exports.testSupportedSourceOrBlank = testSupportedSourceOrBlank
-exports.testPopulatedWhen = testPopulatedWhen
-exports.testBlankWhen = testBlankWhen
-exports.testDateRange = testDateRange
-exports.testNumber = testNumber
-exports.testNumberGreaterThanZero = testNumberGreaterThanZero
-exports.testNumberGreaterThanOrEqualToZero = testNumberGreaterThanOrEqualToZero
-exports.testNumberLessThanOne = testNumberLessThanOne
-exports.testMaxDecimalPlaces = testMaxDecimalPlaces
-exports.testDateBefore = testDateBefore
-exports.testMatchTPTPurpose = testMatchTPTPurpose
-exports.testValidReferenceLineDescription = testValidReferenceLineDescription
+const testNotWaterUndertaker = async (field, value, licence) => {
+  // We include a check for licence to ensure we don't incorrectly give an error if no licence is present
+  if (value === 'Y' && licence && !licence.isWaterUndertaker) {
+    return `${field} cannot be Y if the licence holder is not a water undertaker`
+  }
+
+  return ''
+}
+
+module.exports = {
+  testNotBlank,
+  testAcceptedTerm,
+  testMaxLength,
+  testMaxValue,
+  testMaxDigits,
+  testValidLicence,
+  testLicenceHasInvoiceAccount,
+  testValidDate,
+  testDateAfterLicenceDate,
+  testDateBeforeLicenceDate,
+  testDateBeforeSrocStartDate,
+  testPurpose,
+  testSupportedSourceOrBlank,
+  testPopulatedWhen,
+  testBlankWhen,
+  testDateRange,
+  testNumber,
+  testNumberGreaterThanZero,
+  testNumberGreaterThanOrEqualToZero,
+  testNumberLessThanOne,
+  testMaxDecimalPlaces,
+  testDateBefore,
+  testMatchTPTPurpose,
+  testValidReferenceLineDescription,
+  testNotWaterUndertaker
+}

--- a/test/modules/charge-versions-upload/lib/validator/validator.test.js
+++ b/test/modules/charge-versions-upload/lib/validator/validator.test.js
@@ -82,6 +82,14 @@ experiment('validator', () => {
   })
 
   experiment('.validate', () => {
+    const dummyLicence = {
+      startDate: '2022-03-31',
+      expiredDate: '2022-05-01',
+      lapsedDate: '2022-05-01',
+      revokedDate: '2022-05-01',
+      isWaterUndertaker: true
+    }
+
     beforeEach(() => {
       billing.srocStartDate = new Date('2022-04-01')
       helpers.getSupportedSources.resolves([
@@ -91,14 +99,10 @@ experiment('validator', () => {
         { description: PURPOSE_USE_DESCRIPTION, isTwoPartTariff: false },
         { description: PURPOSE_USE_DESCRIPTION_TPT, isTwoPartTariff: true }
       ])
-      helpers.getLicence = async licenceNumber => licenceNumber !== 'INVALID'
-        ? {
-            startDate: '2022-03-31',
-            expiredDate: '2022-05-01',
-            lapsedDate: '2022-05-01',
-            revokedDate: '2022-05-01'
-          }
-        : undefined
+
+      helpers.getLicence = async licenceNumber => licenceNumber === 'INVALID'
+        ? undefined
+        : dummyLicence
       helpers.getLicenceVersionPurposes.resolves([
         { purposeUse: { description: PURPOSE_USE_DESCRIPTION } },
         { purposeUse: { description: PURPOSE_USE_DESCRIPTION_TPT } }
@@ -399,6 +403,17 @@ experiment('validator', () => {
         test('is not an accepted term', async () => {
           const row = { ...testRow, chargeReferenceDetailsPublicWaterSupply: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply is not an accepted term']))
+        })
+
+        test('is Y when the licence holder is not a water undertaker', async () => {
+          helpers.getLicence = async licenceNumber => {
+            return {
+              ...dummyLicence,
+              isWaterUndertaker: false
+            }
+          }
+          const row = { ...testRow, chargeReferenceDetailsPublicWaterSupply: 'Y' }
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply cannot be Y if the licence holder is not a water undertaker']))
         })
       })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3702

We add validation to the sroc upload feature to reject rows where the public water field is `Y` but the licence holder is not a water undertaker.