### PR TITLE
Config 2nd instance to run background jobs

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,6 +93,12 @@ module.exports = {
       stripTrailingSlash: true
     }
   },
+  serverBackground: {
+    port: 8012,
+    router: {
+      stripTrailingSlash: true
+    }
+  },
 
   testMode,
 

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -18,6 +18,25 @@
         "instances" : "max",
         "exec_mode" : "cluster"
       }
+    },
+    {
+      "name": "service-background",
+      "ignore_watch": [
+        "node_modules",
+        "src/lib/temp",
+        "temp",
+        ".git",
+        ".git/index.lock"
+      ],
+      "script": "index-background.js",
+      "env": {
+        "watch": true
+      },
+      "env_production": {
+        "watch": false,
+        "instances" : "max",
+        "exec_mode" : "cluster"
+      }
     }
   ]
 }

--- a/index-background.js
+++ b/index-background.js
@@ -1,0 +1,105 @@
+// provides all API services consumed by VML and VML Admin front ends
+require('dotenv').config()
+
+const Blipp = require('blipp')
+const Good = require('@hapi/good')
+const GoodWinston = require('good-winston')
+const Hapi = require('@hapi/hapi')
+const HapiAuthJwt2 = require('hapi-auth-jwt2')
+
+const config = require('./config')
+const routes = require('./src/routes/background.js')
+const db = require('./src/lib/connectors/db')
+const { validate } = require('./src/lib/validate')
+
+// Initialise logger
+const { logger } = require('./src/logger')
+const goodWinstonStream = new GoodWinston({ winston: logger })
+
+// Define server
+const server = Hapi.server({
+  ...config.serverBackground
+})
+
+// Register plugins
+const registerServerPlugins = async (server) => {
+  // Third-party plugins
+  await server.register({
+    plugin: Good,
+    options: {
+      ...config.good,
+      reporters: {
+        winston: [goodWinstonStream]
+      }
+    }
+  })
+  await server.register({
+    plugin: Blipp,
+    options: config.blipp
+  })
+
+  // JWT token auth
+  await server.register(HapiAuthJwt2)
+}
+
+const configureServerAuthStrategy = (server) => {
+  server.auth.strategy('jwt', 'jwt', {
+    ...config.jwt,
+    validate
+  })
+  server.auth.default('jwt')
+}
+
+const start = async function () {
+  try {
+    await registerServerPlugins(server)
+    configureServerAuthStrategy(server)
+    server.route(routes)
+
+    if (!module.parent) {
+      await server.start()
+      const name = `${process.env.SERVICE_NAME}-background`
+      const uri = server.info.uri
+      server.log('info', `Service ${name} running at: ${uri}`)
+    }
+  } catch (err) {
+    logger.error('Failed to start server', err)
+  }
+}
+
+const stop = () => {
+  server.stop({ timeout: 5000 }).then(function (err) {
+    console.log('hapi server stopped')
+    process.exit((err) ? 1 : 0)
+  })
+}
+
+const processError = message => err => {
+  logger.error(message, err)
+  process.exit(1)
+}
+
+process
+  .on('unhandledRejection', processError('unhandledRejection'))
+  .on('uncaughtException', processError('uncaughtException'))
+  .on('SIGINT', async () => {
+    logger.info('Stopping water background service')
+
+    await server.stop()
+    logger.info('1/2: Hapi server stopped')
+
+    setTimeout(async () => {
+      await db.pool.end()
+      logger.info('2/2: Connection pool closed')
+
+      return process.exit(0)
+    }, 10000)
+  })
+
+if (!module.parent) {
+  start()
+}
+
+module.exports = server
+module.exports._start = start
+module.exports._stop = stop

--- a/index-background.js
+++ b/index-background.js
@@ -14,6 +14,7 @@ const { validate } = require('./src/lib/validate')
 
 // Initialise logger
 const { logger } = require('./src/logger')
+const { _start } = require('.')
 const goodWinstonStream = new GoodWinston({ winston: logger })
 
 // Define server
@@ -67,13 +68,6 @@ const start = async function () {
   }
 }
 
-const stop = () => {
-  server.stop({ timeout: 5000 }).then(function (err) {
-    console.log('hapi server stopped')
-    process.exit((err) ? 1 : 0)
-  })
-}
-
 const processError = message => err => {
   logger.error(message, err)
   process.exit(1)
@@ -100,6 +94,7 @@ if (!module.parent) {
   start()
 }
 
-module.exports = server
-module.exports._start = start
-module.exports._stop = stop
+module.exports = {
+  server,
+  start
+}

--- a/index-background.js
+++ b/index-background.js
@@ -14,7 +14,6 @@ const { validate } = require('./src/lib/validate')
 
 // Initialise logger
 const { logger } = require('./src/logger')
-const { _start } = require('.')
 const goodWinstonStream = new GoodWinston({ winston: logger })
 
 // Define server

--- a/src/routes/background.js
+++ b/src/routes/background.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const pkg = require('../../package.json')
+const { version } = pkg
+
+module.exports = [
+  {
+    method: 'GET',
+    path: '/status',
+    handler: () => ({ version }),
+    config: { auth: false, description: 'Check service status' }
+  }
+]

--- a/test/routes/background.test.js
+++ b/test/routes/background.test.js
@@ -1,0 +1,25 @@
+const { server, start } = require('../../index-background')
+
+const { experiment, test, beforeEach, before } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+
+experiment('/status', () => {
+  let response
+
+  before(async () => {
+    await start()
+  })
+
+  beforeEach(async () => {
+    const request = { method: 'get', url: '/status' }
+    response = await server.inject(request)
+  })
+
+  test('responds with a status code of 200', async () => {
+    expect(response.statusCode).to.equal(200)
+  })
+
+  test('responds with an object containing the application version', async () => {
+    expect(response.result.version).to.match(/\d*\.\d*\.\d*/g)
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3745

The service is responsible for handling multiple background processes as well as all requests from the other apps. It is the main point of contact for anything to do with the water schema for example.

This means if it needs to run any intensive processes all those other things slow down and in some cases, errors are seen. For example, the charge versions import seems to be causing the service to use 100% of the available resources allocated to it, which was leading to other requests erroring.

We want to look to see if, like the UI, we can create a second instance of the service using pm2 to manage it. If we can, we can then start to look at using the 'background' instance to run the more intensive jobs and the normal instance handling requests from the other apps.

So, in this initial change, we are just going to look at the pm2 config and use a different startup file.