### PR TITLE
SRoC - increase the timeout for the import/ upload process

### DIFF
--- a/src/modules/charge-versions-upload/jobs/update-charge-information-save.js
+++ b/src/modules/charge-versions-upload/jobs/update-charge-information-save.js
@@ -109,3 +109,10 @@ exports.handler = handleUpdateChargeInformation
 exports.onFailed = onFailed
 exports.onComplete = onComplete
 exports.jobName = JOB_NAME
+exports.workerOptions = {
+  // default values are in the comments below
+  maxStalledCount: 2, // 1
+  stalledInterval: 30000, // 30 seconds
+  lockDuration: 120000, // 30 seconds
+  lockRenewTime: 60000 // defaults to half lockDuration
+}

--- a/src/modules/charge-versions-upload/jobs/update-charge-information-start.js
+++ b/src/modules/charge-versions-upload/jobs/update-charge-information-start.js
@@ -109,3 +109,10 @@ exports.handler = handleChargeInformationUploadStart
 exports.onFailed = onFailed
 exports.onComplete = onComplete
 exports.jobName = JOB_NAME
+exports.workerOptions = {
+  // default values are in the comments below
+  maxStalledCount: 2, // 1
+  stalledInterval: 30000, // 30 seconds
+  lockDuration: 120000, // 30 seconds
+  lockRenewTime: 60000 // defaults to half lockDuration
+}

--- a/src/modules/charge-versions-upload/jobs/update-charge-information-to-json.js
+++ b/src/modules/charge-versions-upload/jobs/update-charge-information-to-json.js
@@ -115,3 +115,10 @@ exports.handler = handleChargeInformationMapToJsonStart
 exports.onFailed = onFailed
 exports.onComplete = onComplete
 exports.jobName = JOB_NAME
+exports.workerOptions = {
+  // default values are in the comments below
+  maxStalledCount: 2, // 1
+  stalledInterval: 30000, // 30 seconds
+  lockDuration: 120000, // 30 seconds
+  lockRenewTime: 60000 // defaults to half lockDuration
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3742

During BAT It was noted that some uploads were failing and the system was erroring in various places.

From reviewing the logs we know one of the reasons was that BullMQ was failing to ‘lock jobs' in a sufficient amount of time. Digging into the BullMQ issues on its repo we found a primary cause of this is low system resources. We could see that the API service which runs the job was hogging 100% of CPU time, which was the cause of the errors being seen i.e. low system resources.