### PR TITLE
Further CSV upload refactoring

### DIFF
--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -84,19 +84,16 @@ const csvFields = {
   },
   charge_reference_details_charge_element_group: {
     validate: [
-      testNotBlank,
       testAcceptedTerm('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''))
     ]
   },
   charge_reference_details_source: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
   charge_reference_details_loss: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['high', 'medium', 'low'])
     ]
   },
@@ -118,7 +115,6 @@ const csvFields = {
   },
   charge_reference_details_modelling: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(Object.values(WATER_MODEL))
     ]
   },
@@ -131,7 +127,6 @@ const csvFields = {
   },
   charge_reference_details_supported_source_charge: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
@@ -144,7 +139,6 @@ const csvFields = {
   },
   charge_reference_details_public_water_supply: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['Y', 'N']),
       testNotWaterUndertaker
     ]
@@ -176,19 +170,16 @@ const csvFields = {
   },
   charge_reference_details_winter_discount: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
   charge_reference_details_two_part_tariff_agreement_applies: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
   charge_reference_details_canal_and_river_trust_agreement_applies: {
     validate: [
-      testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },

--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -49,7 +49,6 @@ const csvFields = {
     ]
   },
   charge_element_time_limit_start: {
-
     validate: [
       testNotBlank,
       testValidDate,
@@ -57,7 +56,6 @@ const csvFields = {
     ]
   },
   charge_element_time_limit_end: {
-
     validate: [
       testNotBlank,
       testValidDate,

--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -2,8 +2,8 @@ const { WATER_MODEL } = require('../../../../lib/models/constants')
 const {
   testAcceptedTerm, testNotBlank, testMaxLength, testNumberLessThanOne, testNumberGreaterThanZero, testNumber,
   testMaxDecimalPlaces, testBlankWhen, testPopulatedWhen, testSupportedSourceOrBlank, testValidReferenceLineDescription,
-  testMaxValue, testMaxDigits, testMatchTPTPurpose, testDateAfterLicenceDate, testDateBefore, testValidDate,
-  testDateRange, testPurpose, testDateBeforeSrocStartDate, testDateBeforeLicenceDate, testValidLicence,
+  testMaxValue, testMaxDigits, testMatchTPTPurpose, testDateAfterLicenceExpiredDate, testDateBefore, testValidDate,
+  testDateRange, testPurpose, testDateBeforeSrocStartDate, testDateBeforeLicenceStartDate, testValidLicence,
   testLicenceHasInvoiceAccount, testNotWaterUndertaker
 } = require('./tests')
 
@@ -19,7 +19,7 @@ const csvFields = {
     validate: [
       testNotBlank,
       testValidDate,
-      testDateBeforeLicenceDate('startDate', 'start date'),
+      testDateBeforeLicenceStartDate,
       testDateBeforeSrocStartDate
     ]
   },
@@ -66,8 +66,7 @@ const csvFields = {
       testNotBlank,
       testValidDate,
       testDateBefore('charge_element_time_limit_start', 'time limit start'),
-      // Note that this field is camel case as we are getting `expiredDate` from a licence object
-      testDateAfterLicenceDate('expiredDate', 'expiry date')
+      testDateAfterLicenceExpiredDate
     ]
   },
   charge_element_loss: {

--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -8,14 +8,14 @@ const {
 } = require('./tests')
 
 const csvFields = {
-  licenceNumber: {
+  licence_number: {
     validate: [
       testNotBlank,
       testValidLicence,
       testLicenceHasInvoiceAccount
     ]
   },
-  chargeInformationStartDate: {
+  charge_information_start_date: {
     validate: [
       testNotBlank,
       testValidDate,
@@ -23,83 +23,84 @@ const csvFields = {
       testDateBeforeSrocStartDate
     ]
   },
-  chargeInformationBillingAccount: {
+  charge_information_billing_account: {
     // see validation above in licenceNumber when entered: "testLicenceHasInvoiceAccount"
   },
-  chargeElementPurpose: {
+  charge_element_purpose: {
     validate: [
       testNotBlank,
       testPurpose
     ]
   },
-  chargeElementDescription: {
+  charge_element_description: {
     validate: [
       testNotBlank
     ]
   },
-  chargeElementAbstractionPeriod: {
+  charge_element_abstraction_period: {
     validate: [
       testDateRange
     ]
   },
-  chargeElementAuthorisedQuantity: {
+  charge_element_authorised_quantity: {
     validate: [
       testNumber,
       testMaxDecimalPlaces(6)
     ]
   },
-  chargeElementTimeLimitStart: {
+  charge_element_time_limit_start: {
     skip: [
-      testPopulatedWhen('chargeElementTimeLimitEnd', '')
+      testPopulatedWhen('charge_element_time_limit_end', '')
     ],
     validate: [
       testNotBlank,
       testValidDate,
-      testDateBefore('chargeInformationStartDate', 'charge information start date')
+      testDateBefore('charge_information_start_date', 'charge information start date')
     ]
   },
-  chargeElementTimeLimitEnd: {
+  charge_element_time_limit_end: {
     skip: [
-      testPopulatedWhen('chargeElementTimeLimitStart', '')
+      testPopulatedWhen('charge_element_time_limit_start', '')
     ],
     validate: [
       testNotBlank,
       testValidDate,
-      testDateBefore('chargeElementTimeLimitStart', 'time limit start'),
+      testDateBefore('charge_element_time_limit_start', 'time limit start'),
+      // Note that this field is camel case as we are getting `expiredDate` from a licence object
       testDateAfterLicenceDate('expiredDate', 'expiry date')
     ]
   },
-  chargeElementLoss: {
+  charge_element_loss: {
     validate: [
       testAcceptedTerm(['high', 'medium', 'low'])
     ]
   },
-  chargeElementAgreementApply: {
+  charge_element_agreement_apply: {
     allow: [''],
     validate: [
       testAcceptedTerm(['Y', 'N']),
       testMatchTPTPurpose
     ]
   },
-  chargeReferenceDetailsChargeElementGroup: {
+  charge_reference_details_charge_element_group: {
     validate: [
       testNotBlank,
       testAcceptedTerm('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''))
     ]
   },
-  chargeReferenceDetailsSource: {
+  charge_reference_details_source: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
-  chargeReferenceDetailsLoss: {
+  charge_reference_details_loss: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['high', 'medium', 'low'])
     ]
   },
-  chargeReferenceDetailsVolume: {
+  charge_reference_details_volume: {
     validate: [
       testNotBlank,
       testMaxDigits(17),
@@ -109,46 +110,46 @@ const csvFields = {
       testMaxValue(1000000000000000)
     ]
   },
-  chargeReferenceDetailsWaterAvailability: {
+  charge_reference_details_water_availability: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
-  chargeReferenceDetailsModelling: {
+  charge_reference_details_modelling: {
     validate: [
       testNotBlank,
       testAcceptedTerm(Object.values(WATER_MODEL))
     ]
   },
-  chargeReferenceLineDescription: {
+  charge_reference_line_description: {
     validate: [
       testNotBlank,
       testMaxLength(180),
       testValidReferenceLineDescription
     ]
   },
-  chargeReferenceDetailsSupportedSourceCharge: {
+  charge_reference_details_supported_source_charge: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
-  chargeReferenceDetailsSupportedSourceName: {
+  charge_reference_details_supported_source_name: {
     validate: [
       testSupportedSourceOrBlank,
-      testPopulatedWhen('chargeReferenceDetailsSupportedSourceCharge', 'Y', 'supported source charge'),
-      testBlankWhen('chargeReferenceDetailsSupportedSourceCharge', 'N', 'supported source charge')
+      testPopulatedWhen('charge_reference_details_supported_source_charge', 'Y', 'supported source charge'),
+      testBlankWhen('charge_reference_details_supported_source_charge', 'N', 'supported source charge')
     ]
   },
-  chargeReferenceDetailsPublicWaterSupply: {
+  charge_reference_details_public_water_supply: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N']),
       testNotWaterUndertaker
     ]
   },
-  chargeReferenceDetailsAggregateFactor: {
+  charge_reference_details_aggregate_factor: {
     validate: [
       testNotBlank,
       testMaxDecimalPlaces(15),
@@ -156,7 +157,7 @@ const csvFields = {
       testNumberGreaterThanZero
     ]
   },
-  chargeReferenceDetailsAdjustmentFactor: {
+  charge_reference_details_adjustment_factor: {
     validate: [
       testNotBlank,
       testMaxDecimalPlaces(15),
@@ -164,7 +165,7 @@ const csvFields = {
       testNumberGreaterThanZero
     ]
   },
-  chargeReferenceDetailsAbatementFactor: {
+  charge_reference_details_abatement_factor: {
     allow: [''],
     validate: [
       testMaxDecimalPlaces(15),
@@ -173,25 +174,25 @@ const csvFields = {
       testNumberLessThanOne
     ]
   },
-  chargeReferenceDetailsWinterDiscount: {
+  charge_reference_details_winter_discount: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
-  chargeReferenceDetailsTwoPartTariffAgreementApplies: {
+  charge_reference_details_two_part_tariff_agreement_applies: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
-  chargeReferenceDetailsCanalAndRiverTrustAgreementApplies: {
+  charge_reference_details_canal_and_river_trust_agreement_applies: {
     validate: [
       testNotBlank,
       testAcceptedTerm(['Y', 'N'])
     ]
   },
-  chargeInformationNotes: {
+  charge_information_notes: {
     validate: [
       testMaxLength(500)
     ]

--- a/src/modules/charge-versions-upload/lib/validator/csvFields.js
+++ b/src/modules/charge-versions-upload/lib/validator/csvFields.js
@@ -49,9 +49,7 @@ const csvFields = {
     ]
   },
   charge_element_time_limit_start: {
-    skip: [
-      testPopulatedWhen('charge_element_time_limit_end', '')
-    ],
+
     validate: [
       testNotBlank,
       testValidDate,
@@ -59,9 +57,7 @@ const csvFields = {
     ]
   },
   charge_element_time_limit_end: {
-    skip: [
-      testPopulatedWhen('charge_element_time_limit_start', '')
-    ],
+
     validate: [
       testNotBlank,
       testValidDate,
@@ -75,7 +71,7 @@ const csvFields = {
     ]
   },
   charge_element_agreement_apply: {
-    allow: [''],
+    allowEmpty: true,
     validate: [
       testAcceptedTerm(['Y', 'N']),
       testMatchTPTPurpose
@@ -159,7 +155,7 @@ const csvFields = {
     ]
   },
   charge_reference_details_abatement_factor: {
-    allow: [''],
+    allowEmpty: true,
     validate: [
       testMaxDecimalPlaces(15),
       testNumber,

--- a/src/modules/charge-versions-upload/lib/validator/index.js
+++ b/src/modules/charge-versions-upload/lib/validator/index.js
@@ -40,8 +40,8 @@ const validateRows = async (rows, headings, jobName) => {
   const validateRow = async (columns, rowIndex) => {
     logger.info(`${jobName}: validating row ${rowIndex} of ${rows.length}`)
 
-    // TODO: get column number of `licence_number` and change to `(columns[3])` (or whatever)
-    const licence = await helpers.getLicence(columns[headings.indexOf('licence_number')])
+    // licence_number is the first column in the file
+    const licence = await helpers.getLicence(columns[0])
 
     const fields = headings.map((heading, colIndex) => ({ heading, val: columns[colIndex] }))
 

--- a/src/modules/charge-versions-upload/lib/validator/index.js
+++ b/src/modules/charge-versions-upload/lib/validator/index.js
@@ -40,15 +40,6 @@ const validateRows = async (rows, headings, jobName) => {
     // We only want to return the first error as returning multiple errors may not be desired
     // eg. if a field is empty then we only need that error and not any subsequent errors for eg. date comparison
     return filteredErrors[0]
-
-    // for (const test of validators) {
-    //   const message = await test(heading, val, licence, headings, columns)
-
-    //   // We return the first error we encounter
-    //   if (message) {
-    //     return message
-    //   }
-    // }
   }
 
   const validateRow = async (columns, rowIndex) => {

--- a/src/modules/charge-versions-upload/lib/validator/index.js
+++ b/src/modules/charge-versions-upload/lib/validator/index.js
@@ -1,4 +1,4 @@
-const { snakeCase, camelCase, sortBy, isEqual } = require('lodash')
+const { snakeCase, sortBy, isEqual } = require('lodash')
 const csvParser = require('../csv-adapter/csv-parser')
 const { csvFields } = require('./csvFields')
 const helpers = require('../helpers')
@@ -48,7 +48,7 @@ const validateRows = async (rows, headings, jobName) => {
     const errors = []
 
     for (const { heading, val } of fields) {
-      const { skip = [], validate: validator, allow = [] } = csvFields[camelCase(heading)] || {}
+      const { skip = [], validate: validator, allow = [] } = csvFields[heading] || {}
 
       // TODO: possibly refactor to a `allowEmpty` flag
       if (allow.includes(val)) {

--- a/src/modules/charge-versions-upload/lib/validator/index.js
+++ b/src/modules/charge-versions-upload/lib/validator/index.js
@@ -1,4 +1,4 @@
-const { snakeCase, sortBy, isEqual } = require('lodash')
+const { sortBy, isEqual } = require('lodash')
 const csvParser = require('../csv-adapter/csv-parser')
 const { csvFields } = require('./csvFields')
 const helpers = require('../helpers')
@@ -8,7 +8,7 @@ const ROW_OFFSET = 2 // Takes into account the header row and the row index star
 const CHARGE_ELEMENT_TIME_LIMIT_START_COLUMN = 7
 const CHARGE_ELEMENT_TIME_LIMIT_END_COLUMN = 8
 
-const expectedHeadings = Object.keys(csvFields).map(heading => snakeCase(heading))
+const expectedHeadings = Object.keys(csvFields)
 
 /**
  * Validates that all the headings (the first column) are

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -1,7 +1,6 @@
 const { billing } = require('../../../../../config')
 const helpers = require('../helpers')
 const moment = require('moment')
-const { assertNullableNumeric } = require('../../../../lib/models/validators')
 
 const getColumnValue = (headings, columns, fieldName) => columns[headings.indexOf(fieldName)]
 
@@ -140,12 +139,15 @@ const testDateRange = async (field, dateRange) => {
 }
 
 const testNumber = async (field, number) => {
-  let valid
-  try {
-    assertNullableNumeric(number)
-    valid = true
-  } catch (_e) {}
-  return valid ? '' : `${field} is not a number`
+  if (number === null) {
+    return
+  }
+
+  if (!isNaN(parseInt(number))) {
+    return
+  }
+
+  return `${field} is not a number`
 }
 
 const testNumberGreaterThanZero = async (field, number) => parseFloat(number) > 0 ? '' : `${field} is less than or equal to 0`

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -41,8 +41,12 @@ const testLicenceHasInvoiceAccount = async (field, _licenceNumber, licence, head
 const testValidDate = async (field, date = '') => helpers.formatDate(date) ? '' : `"${field} has an incorrect format, expected DD/MM/YYYY"`
 
 const testDateBeforeLicenceStartDate = async (field, date, licence) => {
+  if (!licence) {
+    return ''
+  }
+
   try {
-    const licenceDate = licence?.startDate
+    const licenceDate = licence.startDate
     if (!licenceDate) {
       return ''
     }
@@ -58,8 +62,12 @@ const testDateBeforeLicenceStartDate = async (field, date, licence) => {
 }
 
 const testDateAfterLicenceExpiredDate = async (field, date, licence) => {
+  if (!licence) {
+    return ''
+  }
+
   try {
-    const licenceDate = licence?.expiredDate
+    const licenceDate = licence.expiredDate
     if (!licenceDate) {
       return ''
     }

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -1,6 +1,5 @@
 const { billing } = require('../../../../../config')
 const helpers = require('../helpers')
-const { get } = require('lodash')
 const moment = require('moment')
 const { assertNullableNumeric } = require('../../../../lib/models/validators')
 
@@ -41,38 +40,38 @@ const testLicenceHasInvoiceAccount = async (field, _licenceNumber, licence, head
 
 const testValidDate = async (field, date = '') => helpers.formatDate(date) ? '' : `"${field} has an incorrect format, expected DD/MM/YYYY"`
 
-const testDateBeforeLicenceDate = (fieldName, fieldTitle) => async (field, date, licence) => {
-  let valid
+const testDateBeforeLicenceStartDate = async (field, date, licence) => {
   try {
-    const licenceDate = get(licence, fieldName)
-    if (licenceDate) {
-      const comparisonDate = new Date(licence[fieldName])
-      const formattedDate = helpers.formatDate(date)
-      if (formattedDate >= comparisonDate) {
-        valid = true
-      }
-    } else {
-      valid = true
+    const licenceDate = licence?.startDate
+    if (!licenceDate) {
+      return ''
+    }
+
+    const comparisonDate = new Date(licenceDate)
+    const formattedDate = helpers.formatDate(date)
+    if (formattedDate >= comparisonDate) {
+      return ''
     }
   } catch (_e) {}
-  return valid ? '' : `${field} is before the licence ${fieldTitle}`
+
+  return `${field} is before the licence start date`
 }
 
-const testDateAfterLicenceDate = (fieldName, fieldTitle) => async (field, date, licence) => {
-  let valid
+const testDateAfterLicenceExpiredDate = async (field, date, licence) => {
   try {
-    const licenceDate = get(licence, fieldName)
-    if (licenceDate) {
-      const comparisonDate = new Date(licence[fieldName])
-      const formattedDate = helpers.formatDate(date)
-      if (formattedDate <= comparisonDate) {
-        valid = true
-      }
-    } else {
-      valid = true
+    const licenceDate = licence?.expiredDate
+    if (!licenceDate) {
+      return ''
+    }
+
+    const comparisonDate = new Date(licenceDate)
+    const formattedDate = helpers.formatDate(date)
+    if (formattedDate <= comparisonDate) {
+      return ''
     }
   } catch (_e) {}
-  return valid ? '' : `${field} is after the licence ${fieldTitle}`
+
+  return `${field} is after the licence expiry date`
 }
 
 const testDateBeforeSrocStartDate = async (field, date = '') => {
@@ -203,8 +202,8 @@ module.exports = {
   testValidLicence,
   testLicenceHasInvoiceAccount,
   testValidDate,
-  testDateAfterLicenceDate,
-  testDateBeforeLicenceDate,
+  testDateAfterLicenceExpiredDate,
+  testDateBeforeLicenceStartDate,
   testDateBeforeSrocStartDate,
   testPurpose,
   testSupportedSourceOrBlank,

--- a/src/modules/charge-versions-upload/lib/validator/tests.js
+++ b/src/modules/charge-versions-upload/lib/validator/tests.js
@@ -1,10 +1,10 @@
 const { billing } = require('../../../../../config')
 const helpers = require('../helpers')
-const { get, snakeCase } = require('lodash')
+const { get } = require('lodash')
 const moment = require('moment')
 const { assertNullableNumeric } = require('../../../../lib/models/validators')
 
-const getColumnValue = (headings, columns, fieldName) => columns[headings.indexOf(snakeCase(fieldName))]
+const getColumnValue = (headings, columns, fieldName) => columns[headings.indexOf(fieldName)]
 
 const testNotBlank = async (field, val) => val === '' ? `${field} is blank` : ''
 
@@ -26,7 +26,7 @@ const testValidLicence = async (field, _licenceNumber, licence) => {
 }
 
 const testLicenceHasInvoiceAccount = async (field, _licenceNumber, licence, headings, columns) => {
-  const invoiceAccountNumber = getColumnValue(headings, columns, 'chargeInformationBillingAccount')
+  const invoiceAccountNumber = getColumnValue(headings, columns, 'charge_information_billing_account')
   const invoiceAccount = await helpers.getInvoiceAccount(licence, invoiceAccountNumber)
   if (invoiceAccount) {
     return ''
@@ -170,7 +170,7 @@ const testDateBefore = (fieldName, fieldTitle) => async (field, date, _licence, 
 
 const testMatchTPTPurpose = async (field, term, _licence, headings, columns) => {
   if (term === 'Y') {
-    const description = getColumnValue(headings, columns, 'chargeElementPurpose')
+    const description = getColumnValue(headings, columns, 'charge_element_purpose')
     const purposeUses = await helpers.getPurposeUses()
     const purpose = purposeUses.find(purposeUse => purposeUse.description === description)
     return purpose && purpose.isTwoPartTariff ? '' : `${field} does not match the purpose`

--- a/test/modules/charge-versions-upload/lib/validator/validator.test.js
+++ b/test/modules/charge-versions-upload/lib/validator/validator.test.js
@@ -248,7 +248,7 @@ experiment('validator', () => {
       experiment('when the charge reference details charge element group', () => {
         test('is blank', async () => {
           const row = { ...testRow, chargeReferenceDetailsChargeElementGroup: '' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_charge_element_group is blank']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_charge_element_group is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
@@ -260,7 +260,7 @@ experiment('validator', () => {
       experiment('when the charge reference details source', () => {
         test('is blank', async () => {
           const row = { ...testRow, chargeReferenceDetailsSource: '' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_source is blank']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_source is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
@@ -272,7 +272,7 @@ experiment('validator', () => {
       experiment('when the charge reference details loss', () => {
         test('is blank', async () => {
           const row = { ...testRow, chargeReferenceDetailsLoss: '' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_loss is blank']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_loss is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
@@ -333,7 +333,7 @@ experiment('validator', () => {
       experiment('when the charge reference details modelling', () => {
         test('is blank', async () => {
           const row = { ...testRow, chargeReferenceDetailsModelling: '' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_modelling is blank']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_modelling is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
@@ -362,7 +362,7 @@ experiment('validator', () => {
       experiment('when the charge reference details supported source charge', () => {
         test('is blank', async () => {
           const row = { ...testRow, chargeReferenceDetailsSupportedSourceCharge: '' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_charge is blank']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_charge is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
@@ -402,7 +402,7 @@ experiment('validator', () => {
       experiment('when the charge reference details public water supply', () => {
         test('is blank', async () => {
           const row = { ...testRow, chargeReferenceDetailsPublicWaterSupply: '' }
-          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply is blank']))
+          expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
@@ -495,7 +495,7 @@ experiment('validator', () => {
         experiment('when the charge reference details winter discount', () => {
           test('is blank', async () => {
             const row = { ...testRow, chargeReferenceDetailsWinterDiscount: '' }
-            expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_winter_discount is blank']))
+            expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_winter_discount is not an accepted term']))
           })
 
           test('is not an accepted term', async () => {
@@ -507,7 +507,7 @@ experiment('validator', () => {
         experiment('when the charge reference details two part tariff agreement applies', () => {
           test('is blank', async () => {
             const row = { ...testRow, chargeReferenceDetailsTwoPartTariffAgreementApplies: '' }
-            expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_two_part_tariff_agreement_applies is blank']))
+            expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_two_part_tariff_agreement_applies is not an accepted term']))
           })
 
           test('is not an accepted term', async () => {
@@ -519,7 +519,7 @@ experiment('validator', () => {
         experiment('when the charge reference details canal and river trust agreement applies', () => {
           test('is blank', async () => {
             const row = { ...testRow, chargeReferenceDetailsCanalAndRiverTrustAgreementApplies: '' }
-            expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_canal_and_river_trust_agreement_applies is blank']))
+            expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_canal_and_river_trust_agreement_applies is not an accepted term']))
           })
 
           test('is not an accepted term', async () => {

--- a/test/modules/charge-versions-upload/lib/validator/validator.test.js
+++ b/test/modules/charge-versions-upload/lib/validator/validator.test.js
@@ -12,7 +12,6 @@ const sandbox = require('sinon').createSandbox()
 const repos = require('../../../../../src/lib/connectors/repos')
 const { billing } = require('../../../../../config')
 const { validate } = require('../../../../../src/modules/charge-versions-upload/lib/validator')
-const { snakeCase } = require('lodash')
 const helpers = require('../../../../../src/modules/charge-versions-upload/lib/helpers')
 
 const SUPPORTED_SOURCE_NAME = 'Valid Supported Source Name'
@@ -22,37 +21,37 @@ const LINE_DESCRIPTION = 'Valid Line Description'
 const INVOICE_ACCOUNT = 'Valid Invoice Account'
 
 const testRow = {
-  licenceNumber: 'TEST/LICENCE/1',
-  chargeInformationStartDate: '01/04/2022',
-  chargeInformationBillingAccount: 'TEST/BILLING/ACCOUNT',
-  chargeElementPurpose: PURPOSE_USE_DESCRIPTION_TPT,
-  chargeElementDescription: 'Test Description',
-  chargeElementAbstractionPeriod: '01/04-31/03',
-  chargeElementAuthorisedQuantity: '2920.123456',
-  chargeElementTimeLimitStart: '',
-  chargeElementTimeLimitEnd: '',
-  chargeElementLoss: 'medium',
-  chargeElementAgreementApply: 'Y',
-  chargeReferenceDetailsChargeElementGroup: 'A',
-  chargeReferenceDetailsSource: 'N',
-  chargeReferenceDetailsLoss: 'medium',
-  chargeReferenceDetailsVolume: '2920',
-  chargeReferenceDetailsWaterAvailability: 'Y',
-  chargeReferenceDetailsModelling: 'tier 1',
-  chargeReferenceLineDescription: LINE_DESCRIPTION,
-  chargeReferenceDetailsSupportedSourceCharge: 'N',
-  chargeReferenceDetailsSupportedSourceName: '',
-  chargeReferenceDetailsPublicWaterSupply: 'Y',
-  chargeReferenceDetailsAggregateFactor: '1',
-  chargeReferenceDetailsAdjustmentFactor: '1',
-  chargeReferenceDetailsAbatementFactor: '0.1',
-  chargeReferenceDetailsWinterDiscount: 'N',
-  chargeReferenceDetailsTwoPartTariffAgreementApplies: 'N',
-  chargeReferenceDetailsCanalAndRiverTrustAgreementApplies: 'N',
-  chargeInformationNotes: ''
+  licence_number: 'TEST/LICENCE/1',
+  charge_information_start_date: '01/04/2022',
+  charge_information_billing_account: 'TEST/BILLING/ACCOUNT',
+  charge_element_purpose: PURPOSE_USE_DESCRIPTION_TPT,
+  charge_element_description: 'Test Description',
+  charge_element_abstraction_period: '01/04-31/03',
+  charge_element_authorised_quantity: '2920.123456',
+  charge_element_time_limit_start: '',
+  charge_element_time_limit_end: '',
+  charge_element_loss: 'medium',
+  charge_element_agreement_apply: 'Y',
+  charge_reference_details_charge_element_group: 'A',
+  charge_reference_details_source: 'N',
+  charge_reference_details_loss: 'medium',
+  charge_reference_details_volume: '2920',
+  charge_reference_details_water_availability: 'Y',
+  charge_reference_details_modelling: 'tier 1',
+  charge_reference_line_description: LINE_DESCRIPTION,
+  charge_reference_details_supported_source_charge: 'N',
+  charge_reference_details_supported_source_name: '',
+  charge_reference_details_public_water_supply: 'Y',
+  charge_reference_details_aggregate_factor: '1',
+  charge_reference_details_adjustment_factor: '1',
+  charge_reference_details_abatement_factor: '0.1',
+  charge_reference_details_winter_discount: 'N',
+  charge_reference_details_two_part_tariff_agreement_applies: 'N',
+  charge_reference_details_canal_and_river_trust_agreement_applies: 'N',
+  charge_information_notes: ''
 }
 
-const getHeadings = data => Object.keys(data).map(heading => snakeCase(heading))
+const getHeadings = data => Object.keys(data)
 const getValues = data => Object.values(data)
 
 const testValidate = async (firstRow, ...otherRows) => validate([getHeadings(firstRow), getValues(firstRow), ...otherRows.map(getValues)].join('\n'))
@@ -129,244 +128,244 @@ experiment('validator', () => {
 
       experiment('when the licence number', () => {
         test('is blank', async () => {
-          const row = { ...testRow, licenceNumber: '' }
+          const row = { ...testRow, licence_number: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, licence_number is blank']))
         })
 
         test('is invalid', async () => {
-          const row = { ...testRow, licenceNumber: 'INVALID' }
+          const row = { ...testRow, licence_number: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, licence_number is not valid']))
         })
       })
 
       experiment('when the charge information start date', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeInformationStartDate: '' }
+          const row = { ...testRow, charge_information_start_date: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_information_start_date is blank']))
         })
 
         test('has an incorrect date format', async () => {
-          const row = { ...testRow, chargeInformationStartDate: 'INVALID' }
+          const row = { ...testRow, charge_information_start_date: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, "charge_information_start_date has an incorrect format, expected DD/MM/YYYY"']))
         })
 
         test('is before the licence start date', async () => {
-          const row = { ...testRow, chargeInformationStartDate: '30/03/2022' }
+          const row = { ...testRow, charge_information_start_date: '30/03/2022' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_information_start_date is before the licence start date']))
         })
 
         test('is before 1 April 2022', async () => {
-          const row = { ...testRow, chargeInformationStartDate: '31/03/2022' }
+          const row = { ...testRow, charge_information_start_date: '31/03/2022' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_information_start_date is before 1 April 2022']))
         })
       })
 
       experiment('when the charge element purpose', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeElementPurpose: '', chargeElementAgreementApply: '' }
+          const row = { ...testRow, charge_element_purpose: '', charge_element_agreement_apply: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_purpose is blank']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeElementPurpose: 'INVALID', chargeElementAgreementApply: '' }
+          const row = { ...testRow, charge_element_purpose: 'INVALID', charge_element_agreement_apply: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_purpose is not an accepted term']))
         })
       })
 
       test('when the charge element description is blank', async () => {
-        const row = { ...testRow, chargeElementDescription: '' }
+        const row = { ...testRow, charge_element_description: '' }
         expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_description is blank']))
       })
 
       test('when the charge element abstraction period has an incorrect date format', async () => {
-        const row = { ...testRow, chargeElementAbstractionPeriod: 'INVALID' }
+        const row = { ...testRow, charge_element_abstraction_period: 'INVALID' }
         expect(await testValidate(row)).to.equal(rowErrors(['Row 2, "charge_element_abstraction_period is an incorrect format, expected DD/MM-DD/MM"']))
       })
 
       experiment('when the charge element authorised quantity', () => {
         test('is not a number', async () => {
-          const row = { ...testRow, chargeElementAuthorisedQuantity: 'INVALID' }
+          const row = { ...testRow, charge_element_authorised_quantity: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_authorised_quantity is not a number']))
         })
 
         test('has more than 6 decimal places', async () => {
-          const row = { ...testRow, chargeElementAuthorisedQuantity: '10.1234567' }
+          const row = { ...testRow, charge_element_authorised_quantity: '10.1234567' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_authorised_quantity has more than 6 decimal places']))
         })
       })
 
       experiment('when the charge element time limit start', () => {
-        const row = { ...testRow, chargeElementTimeLimitEnd: '01/04/2022' }
+        const row = { ...testRow, charge_element_time_limit_end: '01/04/2022' }
 
         test('has an incorrect date format', async () => {
-          row.chargeElementTimeLimitStart = 'INVALID'
+          row.charge_element_time_limit_start = 'INVALID'
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, "charge_element_time_limit_start has an incorrect format, expected DD/MM/YYYY"']))
         })
 
         test('is before the charge information start date', async () => {
-          row.chargeElementTimeLimitStart = '01/01/2022'
+          row.charge_element_time_limit_start = '01/01/2022'
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_time_limit_start is before the charge information start date']))
         })
       })
 
       experiment('when the charge element time limit end', () => {
-        const row = { ...testRow, chargeElementTimeLimitStart: '01/04/2022' }
+        const row = { ...testRow, charge_element_time_limit_start: '01/04/2022' }
 
         test('has an incorrect date format', async () => {
-          row.chargeElementTimeLimitEnd = 'INVALID'
+          row.charge_element_time_limit_end = 'INVALID'
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, "charge_element_time_limit_end has an incorrect format, expected DD/MM/YYYY"']))
         })
 
         test('is before the time limit start', async () => {
-          row.chargeElementTimeLimitEnd = '01/01/2022'
+          row.charge_element_time_limit_end = '01/01/2022'
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_time_limit_end is before the time limit start']))
         })
 
         test('is after the licence expiry date', async () => {
-          row.chargeElementTimeLimitEnd = '01/06/2022'
+          row.charge_element_time_limit_end = '01/06/2022'
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_time_limit_end is after the licence expiry date']))
         })
       })
 
       test('when the charge element loss is not an accepted term', async () => {
-        const row = { ...testRow, chargeElementLoss: 'INVALID' }
+        const row = { ...testRow, charge_element_loss: 'INVALID' }
         expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_loss is not an accepted term']))
       })
 
       experiment('when the charge element agreement apply', () => {
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeElementAgreementApply: 'INVALID' }
+          const row = { ...testRow, charge_element_agreement_apply: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_agreement_apply is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeElementPurpose: PURPOSE_USE_DESCRIPTION, chargeElementAgreementApply: 'Y' }
+          const row = { ...testRow, charge_element_purpose: PURPOSE_USE_DESCRIPTION, charge_element_agreement_apply: 'Y' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_element_agreement_apply does not match the purpose']))
         })
       })
 
       experiment('when the charge reference details charge element group', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsChargeElementGroup: '' }
+          const row = { ...testRow, charge_reference_details_charge_element_group: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_charge_element_group is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsChargeElementGroup: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_charge_element_group: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_charge_element_group is not an accepted term']))
         })
       })
 
       experiment('when the charge reference details source', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsSource: '' }
+          const row = { ...testRow, charge_reference_details_source: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_source is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsSource: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_source: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_source is not an accepted term']))
         })
       })
 
       experiment('when the charge reference details loss', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsLoss: '' }
+          const row = { ...testRow, charge_reference_details_loss: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_loss is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsLoss: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_loss: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_loss is not an accepted term']))
         })
       })
 
       experiment('when the charge reference details volume', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: '' }
+          const row = { ...testRow, charge_reference_details_volume: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is blank']))
         })
 
         test('is not a number', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_volume: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is not a number']))
         })
 
         test('is zero', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: '0' }
+          const row = { ...testRow, charge_reference_details_volume: '0' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is less than or equal to 0']))
         })
 
         test('is a negative number', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: '-1' }
+          const row = { ...testRow, charge_reference_details_volume: '-1' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is less than or equal to 0']))
         })
 
         test('has more than 6 decimal places', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: '123.1234567' }
+          const row = { ...testRow, charge_reference_details_volume: '123.1234567' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume has more than 6 decimal places']))
         })
 
         test('is greater than 1000000000000000', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: '1000000000000001' }
+          const row = { ...testRow, charge_reference_details_volume: '1000000000000001' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume is too large']))
         })
 
         test('has too many digits', async () => {
-          const row = { ...testRow, chargeReferenceDetailsVolume: '12345678.0123456789' }
+          const row = { ...testRow, charge_reference_details_volume: '12345678.0123456789' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_volume has too many digits']))
         })
       })
 
       experiment('when the charge reference details water availability', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsWaterAvailability: '' }
+          const row = { ...testRow, charge_reference_details_water_availability: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_water_availability is blank']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsWaterAvailability: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_water_availability: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_water_availability is not an accepted term']))
         })
       })
 
       experiment('when the charge reference details modelling', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsModelling: '' }
+          const row = { ...testRow, charge_reference_details_modelling: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_modelling is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsModelling: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_modelling: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_modelling is not an accepted term']))
         })
       })
 
       experiment('when the charge reference line description', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceLineDescription: '' }
+          const row = { ...testRow, charge_reference_line_description: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_line_description is blank']))
         })
 
         test('contains more than 180 characters', async () => {
-          const row = { ...testRow, chargeReferenceLineDescription: 'a'.repeat(181) }
+          const row = { ...testRow, charge_reference_line_description: 'a'.repeat(181) }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_line_description has more than 180 characters']))
         })
 
         test('contains unaccepted characters', async () => {
-          const row = { ...testRow, chargeReferenceLineDescription: 'I_N_V_A_L_I_D?' }
+          const row = { ...testRow, charge_reference_line_description: 'I_N_V_A_L_I_D?' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_line_description contains at least one unaccepted character']))
         })
       })
 
       experiment('when the charge reference details supported source charge', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsSupportedSourceCharge: '' }
+          const row = { ...testRow, charge_reference_details_supported_source_charge: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_charge is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsSupportedSourceCharge: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_supported_source_charge: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_charge is not an accepted term']))
         })
       })
@@ -375,7 +374,7 @@ experiment('validator', () => {
         test('is not an accepted term', async () => {
           const row = {
             ...testRow,
-            chargeReferenceDetailsSupportedSourceName: 'INVALID'
+            charge_reference_details_supported_source_name: 'INVALID'
           }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_name is not an accepted term']))
         })
@@ -383,8 +382,8 @@ experiment('validator', () => {
         test('is blank and the supported source charge is "Y"', async () => {
           const row = {
             ...testRow,
-            chargeReferenceDetailsSupportedSourceName: '',
-            chargeReferenceDetailsSupportedSourceCharge: 'Y'
+            charge_reference_details_supported_source_name: '',
+            charge_reference_details_supported_source_charge: 'Y'
           }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_name is blank when the supported source charge is "Y"']))
         })
@@ -392,8 +391,8 @@ experiment('validator', () => {
         test('is populated and the supported source charge is "N"', async () => {
           const row = {
             ...testRow,
-            chargeReferenceDetailsSupportedSourceName: SUPPORTED_SOURCE_NAME,
-            chargeReferenceDetailsSupportedSourceCharge: 'N'
+            charge_reference_details_supported_source_name: SUPPORTED_SOURCE_NAME,
+            charge_reference_details_supported_source_charge: 'N'
           }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_supported_source_name is populated when the supported source charge is "N"']))
         })
@@ -401,12 +400,12 @@ experiment('validator', () => {
 
       experiment('when the charge reference details public water supply', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsPublicWaterSupply: '' }
+          const row = { ...testRow, charge_reference_details_public_water_supply: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply is not an accepted term']))
         })
 
         test('is not an accepted term', async () => {
-          const row = { ...testRow, chargeReferenceDetailsPublicWaterSupply: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_public_water_supply: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply is not an accepted term']))
         })
 
@@ -417,113 +416,113 @@ experiment('validator', () => {
               isWaterUndertaker: false
             }
           }
-          const row = { ...testRow, chargeReferenceDetailsPublicWaterSupply: 'Y' }
+          const row = { ...testRow, charge_reference_details_public_water_supply: 'Y' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_public_water_supply cannot be Y if the licence holder is not a water undertaker']))
         })
       })
 
       experiment('when the charge reference details aggregate factor', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAggregateFactor: '' }
+          const row = { ...testRow, charge_reference_details_aggregate_factor: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_aggregate_factor is blank']))
         })
 
         test('is not a number', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAggregateFactor: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_aggregate_factor: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_aggregate_factor is not a number']))
         })
 
         test('has more than 15 decimal places', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAggregateFactor: '1.1234567890123456' }
+          const row = { ...testRow, charge_reference_details_aggregate_factor: '1.1234567890123456' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_aggregate_factor has more than 15 decimal places']))
         })
 
         test('is less than or equal to 0', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAggregateFactor: '0' }
+          const row = { ...testRow, charge_reference_details_aggregate_factor: '0' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_aggregate_factor is less than or equal to 0']))
         })
       })
 
       experiment('when the charge reference details adjustment factor', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAdjustmentFactor: '' }
+          const row = { ...testRow, charge_reference_details_adjustment_factor: '' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_adjustment_factor is blank']))
         })
 
         test('is not a number', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAdjustmentFactor: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_adjustment_factor: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_adjustment_factor is not a number']))
         })
 
         test('has more than 15 decimal places', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAdjustmentFactor: '1.1234567890123456' }
+          const row = { ...testRow, charge_reference_details_adjustment_factor: '1.1234567890123456' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_adjustment_factor has more than 15 decimal places']))
         })
 
         test('is less than or equal to 0', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAdjustmentFactor: '0' }
+          const row = { ...testRow, charge_reference_details_adjustment_factor: '0' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_adjustment_factor is less than or equal to 0']))
         })
       })
 
       experiment('when the charge reference details abatement factor', () => {
         test('is blank', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAbatementFactor: '' }
+          const row = { ...testRow, charge_reference_details_abatement_factor: '' }
           expect(await testValidate(row)).to.equal({ isValid: true })
         })
 
         test('is not a number', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAbatementFactor: 'INVALID' }
+          const row = { ...testRow, charge_reference_details_abatement_factor: 'INVALID' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_abatement_factor is not a number']))
         })
 
         test('has more than 15 decimal places', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAbatementFactor: '0.1234567890123456' }
+          const row = { ...testRow, charge_reference_details_abatement_factor: '0.1234567890123456' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_abatement_factor has more than 15 decimal places']))
         })
 
         test('is less than or equal to 0', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAbatementFactor: '0' }
+          const row = { ...testRow, charge_reference_details_abatement_factor: '0' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_abatement_factor is less than or equal to 0']))
         })
 
         test('is greater than or equal to 1', async () => {
-          const row = { ...testRow, chargeReferenceDetailsAbatementFactor: '1' }
+          const row = { ...testRow, charge_reference_details_abatement_factor: '1' }
           expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_abatement_factor is greater than or equal to 1']))
         })
 
         experiment('when the charge reference details winter discount', () => {
           test('is blank', async () => {
-            const row = { ...testRow, chargeReferenceDetailsWinterDiscount: '' }
+            const row = { ...testRow, charge_reference_details_winter_discount: '' }
             expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_winter_discount is not an accepted term']))
           })
 
           test('is not an accepted term', async () => {
-            const row = { ...testRow, chargeReferenceDetailsWinterDiscount: 'INVALID' }
+            const row = { ...testRow, charge_reference_details_winter_discount: 'INVALID' }
             expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_winter_discount is not an accepted term']))
           })
         })
 
         experiment('when the charge reference details two part tariff agreement applies', () => {
           test('is blank', async () => {
-            const row = { ...testRow, chargeReferenceDetailsTwoPartTariffAgreementApplies: '' }
+            const row = { ...testRow, charge_reference_details_two_part_tariff_agreement_applies: '' }
             expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_two_part_tariff_agreement_applies is not an accepted term']))
           })
 
           test('is not an accepted term', async () => {
-            const row = { ...testRow, chargeReferenceDetailsTwoPartTariffAgreementApplies: 'INVALID' }
+            const row = { ...testRow, charge_reference_details_two_part_tariff_agreement_applies: 'INVALID' }
             expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_two_part_tariff_agreement_applies is not an accepted term']))
           })
         })
 
         experiment('when the charge reference details canal and river trust agreement applies', () => {
           test('is blank', async () => {
-            const row = { ...testRow, chargeReferenceDetailsCanalAndRiverTrustAgreementApplies: '' }
+            const row = { ...testRow, charge_reference_details_canal_and_river_trust_agreement_applies: '' }
             expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_canal_and_river_trust_agreement_applies is not an accepted term']))
           })
 
           test('is not an accepted term', async () => {
-            const row = { ...testRow, chargeReferenceDetailsCanalAndRiverTrustAgreementApplies: 'INVALID' }
+            const row = { ...testRow, charge_reference_details_canal_and_river_trust_agreement_applies: 'INVALID' }
             expect(await testValidate(row)).to.equal(rowErrors(['Row 2, charge_reference_details_canal_and_river_trust_agreement_applies is not an accepted term']))
           })
         })
@@ -532,8 +531,8 @@ experiment('validator', () => {
       test('when the contents of a row has two invalid fields ', async () => {
         expect(await testValidate({
           ...testRow,
-          chargeReferenceDetailsAbatementFactor: '1',
-          licenceNumber: 'INVALID'
+          charge_reference_details_abatement_factor: '1',
+          licence_number: 'INVALID'
         })).to.equal({
           errorType: 'rows',
           validationErrors: [
@@ -547,12 +546,12 @@ experiment('validator', () => {
 
     experiment('with multiple rows', () => {
       // Two rows with test licence 2
-      const testRow2 = { ...testRow, licenceNumber: 'TEST/LICENCE/2', chargeReferenceDetailsChargeElementGroup: 'A', chargeReferenceDetailsLoss: 'high' }
-      const testRow3 = { ...testRow, licenceNumber: 'TEST/LICENCE/2', chargeReferenceDetailsChargeElementGroup: 'A', chargeReferenceDetailsLoss: 'low' }
+      const testRow2 = { ...testRow, licence_number: 'TEST/LICENCE/2', charge_reference_details_charge_element_group: 'A', charge_reference_details_loss: 'high' }
+      const testRow3 = { ...testRow, licence_number: 'TEST/LICENCE/2', charge_reference_details_charge_element_group: 'A', charge_reference_details_loss: 'low' }
 
       // Two rows with test licence 3
-      const testRow4 = { ...testRow, licenceNumber: 'TEST/LICENCE/3', chargeReferenceDetailsChargeElementGroup: 'B' }
-      const testRow5 = { ...testRow, licenceNumber: 'TEST/LICENCE/3', chargeReferenceDetailsChargeElementGroup: 'B' }
+      const testRow4 = { ...testRow, licence_number: 'TEST/LICENCE/3', charge_reference_details_charge_element_group: 'B' }
+      const testRow5 = { ...testRow, licence_number: 'TEST/LICENCE/3', charge_reference_details_charge_element_group: 'B' }
 
       test('when the contents of a csv with 5 rows are valid ', async () => {
         expect(await testValidate(testRow, testRow2, testRow3, testRow4, testRow5)).to.equal({
@@ -564,9 +563,9 @@ experiment('validator', () => {
         expect(await testValidate(
           testRow,
           testRow2,
-          { ...testRow3, licenceNumber: 'INVALID' },
+          { ...testRow3, licence_number: 'INVALID' },
           testRow4,
-          { ...testRow5, chargeReferenceDetailsAbatementFactor: '1' }
+          { ...testRow5, charge_reference_details_abatement_factor: '1' }
         )).to.equal({
           errorType: 'rows',
           validationErrors: [
@@ -581,8 +580,8 @@ experiment('validator', () => {
         test('all reference details are the same', async () => {
           expect(await testValidate(
             testRow,
-            { ...testRow2, chargeReferenceDetailsLoss: 'low' },
-            { ...testRow3, chargeReferenceDetailsLoss: 'low' },
+            { ...testRow2, charge_reference_details_loss: 'low' },
+            { ...testRow3, charge_reference_details_loss: 'low' },
             testRow4,
             testRow5
           )).to.equal({
@@ -599,8 +598,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeReferenceDetailsSource: 'Y' },
-            { ...testRow5, chargeReferenceDetailsSource: 'N' }
+            { ...testRow4, charge_reference_details_source: 'Y' },
+            { ...testRow5, charge_reference_details_source: 'N' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence and group as row 6 but charge_reference_details_source is different'],
@@ -613,8 +612,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeReferenceDetailsLoss: 'low' },
-            { ...testRow5, chargeReferenceDetailsLoss: 'high' }
+            { ...testRow4, charge_reference_details_loss: 'low' },
+            { ...testRow5, charge_reference_details_loss: 'high' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence and group as row 6 but charge_reference_details_loss is different'],
@@ -627,8 +626,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeReferenceDetailsVolume: '10' },
-            { ...testRow5, chargeReferenceDetailsVolume: '25' }
+            { ...testRow4, charge_reference_details_volume: '10' },
+            { ...testRow5, charge_reference_details_volume: '25' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence and group as row 6 but charge_reference_details_volume is different'],
@@ -641,8 +640,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeReferenceDetailsWaterAvailability: 'Y' },
-            { ...testRow5, chargeReferenceDetailsWaterAvailability: 'N' }
+            { ...testRow4, charge_reference_details_water_availability: 'Y' },
+            { ...testRow5, charge_reference_details_water_availability: 'N' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence and group as row 6 but charge_reference_details_water_availability is different'],
@@ -655,8 +654,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeReferenceDetailsModelling: 'tier 1' },
-            { ...testRow5, chargeReferenceDetailsModelling: 'tier 2' }
+            { ...testRow4, charge_reference_details_modelling: 'tier 1' },
+            { ...testRow5, charge_reference_details_modelling: 'tier 2' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence and group as row 6 but charge_reference_details_modelling is different'],
@@ -669,8 +668,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeInformationBillingAccount: 'BILLING-ACCOUNT-ONE' },
-            { ...testRow5, chargeInformationBillingAccount: 'BILLING-ACCOUNT-TWO' }
+            { ...testRow4, charge_information_billing_account: 'BILLING-ACCOUNT-ONE' },
+            { ...testRow5, charge_information_billing_account: 'BILLING-ACCOUNT-TWO' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence as row 6 but charge_information_billing_account is different'],
@@ -683,8 +682,8 @@ experiment('validator', () => {
             testRow,
             testRow2,
             testRow3,
-            { ...testRow4, chargeInformationStartDate: '01/04/2022' },
-            { ...testRow5, chargeInformationStartDate: '02/05/2023' }
+            { ...testRow4, charge_information_start_date: '01/04/2022' },
+            { ...testRow5, charge_information_start_date: '02/05/2023' }
           )).to.equal({
             errorType: 'rows',
             validationErrors: ['Row 5, has the same licence as row 6 but charge_information_start_date is different'],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3745

We are trying further optimisations to see if we can make the CSV upload even more performant. The main changes are:

- Rewritten the field names in `csvFields` from camel case to snake case to avoid unnecessary case conversion
- Remove unneeded `testNotBlank` validation, where we were first validating the field isn't blank and then validating for specific values; we now only test for the values as this will reject if the field is empty
- Specify exact columns where we can instead of looking up the column, as the CSV layout will not be changing
- Rework `testNumber` to use native JS instead of Joi, for a performance boost
- Refactor `csvFields` so generic `skip` and `allow` properties (which were only being used in very specific circumstances) are now tested for more specifically
- We now test all fields within a row, and all validators for a field, concurrently using `Promise.all`
