### PR TITLE
Make charge version max upload consistent

### DIFF
--- a/src/modules/charge-versions-upload/routes.js
+++ b/src/modules/charge-versions-upload/routes.js
@@ -8,7 +8,7 @@ module.exports = {
     handler: controller.postUpload,
     config: {
       payload: {
-        maxBytes: 1000 * 1000 * 50
+        maxBytes: 1000 * 1000 * 20
       },
       validate: {
         params: Joi.object().keys({


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-ui/pull/2179

We spotted that the charge version upload UI says the max upload is 20MB. But behind the scenes, the UI code actually allowed 50MB. We sorted that to be consistent but then spotted that the service also has a max bytes check, and it too is inconsistent with what we tell users.

Again, we don't like inconsistency! So, this updates the route config to match what we are stating on the upload page.

N.B. They also expressed the max bytes using different formats. Yeahhh! 😩