### PR TITLE
Fix tests not using test redis DB

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,7 +12,6 @@ const isSrocLive = !isProduction && new Date() >= srocStartDate
 const crmUri = process.env.CRM_URI || 'http://127.0.0.1:8002/crm/1.0'
 const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 const isRedisLazy = !!process.env.LAZY_REDIS
-const usingTestDatabase = process.env.DATABASE_URL.includes('wabs_test')
 
 module.exports = {
 
@@ -248,7 +247,7 @@ module.exports = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD || '',
       ...(isTlsConnection) && { tls: {} },
-      db: usingTestDatabase ? 4 : 2,
+      db: process.env.NODE_ENV === 'test' ? 4 : 2,
       lazyConnect: isRedisLazy,
       maxRetriesPerRequest: null,
       enableReadyCheck: false

--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ const isSrocLive = !isProduction && new Date() >= srocStartDate
 const crmUri = process.env.CRM_URI || 'http://127.0.0.1:8002/crm/1.0'
 const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 const isRedisLazy = !!process.env.LAZY_REDIS
-const isPermitsTestDatabase = process.env.DATABASE_URL.includes('permits-test')
+const usingTestDatabase = process.env.DATABASE_URL.includes('wabs_test')
 
 module.exports = {
 
@@ -248,7 +248,7 @@ module.exports = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD || '',
       ...(isTlsConnection) && { tls: {} },
-      db: isPermitsTestDatabase ? 4 : 2,
+      db: usingTestDatabase ? 4 : 2,
       lazyConnect: isRedisLazy,
       maxRetriesPerRequest: null,
       enableReadyCheck: false


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/4

As part of [Apply consistent CI workflow](https://github.com/DEFRA/water-abstraction-service/pull/1710) we inadvertently broke the `isPermitsTestDatabase` property in `config.js`. This is used to determine which DB to use in Redis.

You may not be aware, but you can setup [multiple DB's in Redis](https://redis.io/commands/select/). You need to give it a number and Redis will create a DB for it. By default, it uses 0 but you can select something else in the connection and Redis will create a DB there.

We take advantage of this feature to

- use different db's for different apps (though it's not consistent)
- use a different db when running the unit tests (again, it's not consistent)

Recently, we've hit an issue when trying to shut down the app it is stalling. The job causing the issue is `notify.send`. It keeps failing because it has jobs with notification IDs but they don't exist in the PostgreSQL DB. After much digging, we found the issue only happened after running tests. It turns out that because we send real notifications via Notify in the tests (yes, [we know!](https://github.com/DEFRA/water-abstraction-team/issues/35)) we were creating test jobs in the normal Redis database with IDs that didn't match what was in the normal PostgreSQL DB. They should have been going into the test Redis DB.

The root cause was the `isPermitsTestDatabase` property in `config.js`. It was set to true only if the database URL provided included the DB name 'permits-test'. We had changed that to match what we call it locally and in our CI pipeline ('wabs_test'). So, now it's always coming up as `false` causing jobs added whilst running the unit tests to appear in the DB when just running it locally.

This change fixes the issue.