### PR TITLE
Remove node-cron for BullMQ jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,6 @@ ENABLE_DELETE_ALL_BILLING_DATA_FEATURE=
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug
+
+# Use Cron type syntax to set timings for these background processes
+WRLS_CRON_CHARGE_VERSION_WORKFLOW='0 */6 * * *'

--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,4 @@ WRLS_LOG_LEVEL=debug
 
 # Use Cron type syntax to set timings for these background processes
 WRLS_CRON_CHARGE_VERSION_WORKFLOW='0 */6 * * *'
+WRLS_CRON_CHECK_FOR_UPDATED_INVOICE_ACCOUNTS='0 */12 * * *'

--- a/config.js
+++ b/config.js
@@ -50,7 +50,8 @@ module.exports = {
       requestEvent: 60000, // 1 minute
       checkStatus: 15000, // 15 seconds
       sendMessages: 15000 // 15 seconds
-    }
+    },
+    chargeVersionWorkflow: process.env.WRLS_CRON_CHARGE_VERSION_WORKFLOW || '0 */6 * * *'
   },
 
   jwt: {

--- a/config.js
+++ b/config.js
@@ -51,7 +51,8 @@ module.exports = {
       checkStatus: 15000, // 15 seconds
       sendMessages: 15000 // 15 seconds
     },
-    chargeVersionWorkflow: process.env.WRLS_CRON_CHARGE_VERSION_WORKFLOW || '0 */6 * * *'
+    chargeVersionWorkflow: process.env.WRLS_CRON_CHARGE_VERSION_WORKFLOW || '0 */6 * * *',
+    checkForUpdatedInvoiceAccounts: process.env.WRLS_CRON_CHECK_FOR_UPDATED_INVOICE_ACCOUNTS || '0 */12 * * *'
   },
 
   jwt: {

--- a/src/modules/billing/jobs/check-for-updated-invoice-accounts.js
+++ b/src/modules/billing/jobs/check-for-updated-invoice-accounts.js
@@ -1,49 +1,52 @@
 'use strict'
+
 /**
- * This file contains the job handler and createMessage function
- * for grabbing a list of the invoice accounts whose entities have
- * a mismatch between last_hash and current_hash.
+ * This job grabs a list of the invoice accounts whose entities have a mismatch between last_hash and current_hash.
+ *
+ * It then emails the NALD service mailbox with the details
  */
-const cron = require('node-cron')
-const moment = require('moment')
-const { logger } = require('../../../logger')
+
 const config = require('../../../../config')
 const invoiceAccountsConnector = require('../../../lib/connectors/crm-v2/invoice-accounts')
-const messageQueue = require('../../../lib/message-queue-v2')
-const { jobNames } = require('../../../lib/constants')
+const { logger } = require('../../../logger')
 const notifyService = require('../../../lib/notify')
 
-const createMessage = () => {
-  return ([
-    jobNames.findUpdatedInvoiceAccounts,
-    {},
-    {
-      jobId: `${jobNames.findUpdatedInvoiceAccounts}.${moment().format('YYYYMMDDA')}`
-    }
-  ])
-}
+const JOB_NAME = 'billing.find-update-invoice-accounts'
 
-const handler = async () => {
-  logger.info(`Processing ${jobNames.findUpdatedInvoiceAccounts}`)
+const createMessage = () => ([
+  JOB_NAME,
+  {},
+  {
+    repeat: {
+      cron: config.jobs.checkForUpdatedInvoiceAccounts
+    }
+  }
+])
+
+const handler = async (job) => {
+  logger.info(`Handling job ${job.name} ${job.id}`)
 
   // Call CRM to identify the invoice accounts
   const invoiceAccountsWithUpdatedEntities = await invoiceAccountsConnector.fetchInvoiceAccountsWithUpdatedEntities()
+
+  logger.info(`Job ${job.name} got ${invoiceAccountsWithUpdatedEntities.length} results`)
+
   const templateId = config.notify.templates.nald_entity_changes_detected
   const recipient = process.env.NALD_SERVICE_MAILBOX
 
   if (invoiceAccountsWithUpdatedEntities.length > 0 && recipient) {
-    const content = invoiceAccountsWithUpdatedEntities.map(invoiceAccount => `
-      ${invoiceAccount.invoiceAccountNumber} (Legacy identifier ${invoiceAccount.companyLegacyId})
-    `)
+    const content = invoiceAccountsWithUpdatedEntities.map(invoiceAccount =>
+      `${invoiceAccount.invoiceAccountNumber} (Legacy identifier ${invoiceAccount.companyLegacyId})`
+    )
     notifyService.sendEmail(templateId, recipient, { content })
   }
 }
 
-const onFailedHandler = async (job, err) => logger.error(err.message)
+const onFailed = (job, err) => {
+  logger.error(`Job ${job.name} ${job.id} failed`, err)
+}
 
-cron.schedule('0 */12 * * *', () => messageQueue.getQueueManager().add(jobNames.findUpdatedInvoiceAccounts, {}))
-
-exports.jobName = jobNames.findUpdatedInvoiceAccounts
+exports.jobName = JOB_NAME
 exports.createMessage = createMessage
 exports.handler = handler
-exports.onFailed = onFailedHandler
+exports.onFailed = onFailed

--- a/src/modules/billing/register-subscribers.js
+++ b/src/modules/billing/register-subscribers.js
@@ -41,6 +41,7 @@ module.exports = {
       .register(updateInvoices)
       .register(syncSupportedSources)
 
+    server.queueManager.add(checkForUpdatedInvoiceAccounts.jobName)
     server.queueManager.add(syncChargeCategories.jobName)
     server.queueManager.add(syncSupportedSources.jobName)
     await server.queueManager.deleteKeysByPattern('*billing.customer-file-refresh*')

--- a/src/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.js
+++ b/src/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const moment = require('moment')
+
+const config = require('../../../../config')
+const licenceVersions = require('../../../lib/connectors/repos/licence-versions')
+const { logger } = require('../../../logger')
+
+const { jobName: CREATE_CHARGE_VERSION_JOB_NAME } = require('./create-charge-version-workflows')
+const JOB_NAME = 'licence-not-in-charge-version-workflow'
+
+const createMessage = () => ([
+  JOB_NAME,
+  {},
+  {
+    repeat: {
+      cron: config.jobs.chargeVersionWorkflow
+    }
+  }
+])
+
+const handler = async (job) => {
+  logger.info(`Handling job ${job.name} ${job.id}`)
+
+  const results = await licenceVersions.findIdsByDateNotInChargeVersionWorkflows(moment().add(-2, 'month').toISOString())
+
+  logger.info(`Job ${job.name} got ${results.length} results`)
+
+  return results
+}
+
+const onComplete = async (job, queueManager) => {
+  logger.info(`Completing job ${job.name} ${job.id}`)
+
+  if (job.returnvalue) {
+    job.returnvalue.forEach(licenceIds => {
+      queueManager.add(CREATE_CHARGE_VERSION_JOB_NAME, licenceIds.licenceVersionId, licenceIds.licenceId)
+    })
+  }
+}
+
+const onFailed = (job, err) => {
+  logger.error(`Job ${job.name} ${job.id} failed`, err)
+}
+
+exports.jobName = JOB_NAME
+exports.createMessage = createMessage
+exports.handler = handler
+exports.onComplete = onComplete
+exports.onFailed = onFailed
+exports.hasScheduler = true

--- a/src/modules/charge-versions/plugin.js
+++ b/src/modules/charge-versions/plugin.js
@@ -1,27 +1,16 @@
 'use strict'
 
-const cron = require('node-cron')
-const { logger } = require('../../logger')
-const licenceVersions = require('../../lib/connectors/repos/licence-versions')
-const moment = require('moment')
 const createChargeVersionWorkflows = require('./jobs/create-charge-version-workflows')
-const bluebird = require('bluebird')
+const licenceNotInChargeVersionWorkflow = require('./jobs/licence-not-in-charge-version-workflow')
 
-const addJobToQueue = queueManager => async licenceVersion => {
-  await queueManager.add(createChargeVersionWorkflows.jobName, licenceVersion.licenceVersionId, licenceVersion.licenceId)
-}
+const registerSubscribers = async (server) => {
+  await server.queueManager.deleteKeysByPattern(`*${licenceNotInChargeVersionWorkflow.jobName}*`)
 
-const publishJobs = async queueManager => {
-  const batch = await licenceVersions.findIdsByDateNotInChargeVersionWorkflows(moment().add(-2, 'month').toISOString())
-  logger.info(`Creating charge version workflow batch - ${batch.length} item(s) found`)
-  return bluebird.map(batch, addJobToQueue(queueManager))
-}
+  server.queueManager
+    .register(licenceNotInChargeVersionWorkflow)
+    .register(createChargeVersionWorkflows)
 
-const registerSubscribers = async server => {
-  server.queueManager.register(createChargeVersionWorkflows)
-  if (!process.env.TRAVIS) {
-    cron.schedule('0 */6 * * *', () => publishJobs(server.queueManager))
-  }
+  server.queueManager.add(licenceNotInChargeVersionWorkflow.jobName)
 }
 
 exports.plugin = {
@@ -29,6 +18,3 @@ exports.plugin = {
   dependencies: ['hapiBull'],
   register: registerSubscribers
 }
-
-// exporting for testing
-module.exports.publishJobs = publishJobs

--- a/test/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.test.js
+++ b/test/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.test.js
@@ -1,0 +1,109 @@
+'use strict'
+
+// Test framework dependencies
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
+
+// Test helpers
+const uuid = require('uuid/v4')
+const licenceVersions = require('../../../../src/lib/connectors/repos/licence-versions')
+const { logger } = require('../../../../src/logger')
+
+// Thing under test
+const licenceNotInChargeVersionWorkflow = require('../../../../src/modules/charge-versions/jobs/licence-not-in-charge-version-workflow')
+
+experiment('modules/charge-versions/jobs/licence-not-in-charge-version-workflow', () => {
+  const job = {
+    id: uuid(),
+    name: licenceNotInChargeVersionWorkflow.jobName,
+    data: {}
+  }
+  const queryResult = [
+    { licenceVersionId: uuid(), licenceId: uuid() },
+    { licenceVersionId: uuid(), licenceId: uuid() }
+  ]
+
+  beforeEach(async () => {
+    // We stub the logger just to silence it's output during the tests
+    sandbox.stub(logger, 'info')
+
+    // Used in the handler to get the ID's of the licence Versions not in the charge workflow. We stub it so we can
+    // can control what it returns
+    sandbox.stub(licenceVersions, 'findIdsByDateNotInChargeVersionWorkflows')
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
+  test('exports the expected job name', async () => {
+    expect(licenceNotInChargeVersionWorkflow.jobName).to.equal('licence-not-in-charge-version-workflow')
+  })
+
+  experiment('.createMessage', () => {
+    test('creates the expected message array', async () => {
+      const message = licenceNotInChargeVersionWorkflow.createMessage()
+      expect(message).to.equal([
+        'licence-not-in-charge-version-workflow',
+        {},
+        {
+          repeat: {
+            cron: '0 */6 * * *'
+          }
+        }
+      ])
+    })
+  })
+
+  experiment('.handler', () => {
+    beforeEach(() => {
+      licenceVersions.findIdsByDateNotInChargeVersionWorkflows.resolves(queryResult)
+    })
+
+    test('it returns the licence versions not in the workflow', async () => {
+      const result = await licenceNotInChargeVersionWorkflow.handler(job)
+
+      expect(result).to.equal(queryResult)
+    })
+  })
+
+  experiment('.onComplete', () => {
+    const queueManager = { add: sandbox.stub() }
+
+    beforeEach(() => {
+      job.returnvalue = queryResult
+      licenceVersions.findIdsByDateNotInChargeVersionWorkflows.resolves(queryResult)
+    })
+
+    test('adds a job for each licence version not in the workflow', async () => {
+      await licenceNotInChargeVersionWorkflow.onComplete(job, queueManager)
+
+      expect(queueManager.add.calledTwice).to.be.true()
+
+      queryResult.forEach(result => {
+        expect(queueManager.add.calledWith(
+          'new-LicenceVersion', result.licenceVersionId, result.licenceId
+        )).to.be.true()
+      })
+    })
+  })
+
+  experiment('.onFailed', () => {
+    const err = new Error('something went wrong')
+
+    beforeEach(() => {
+      sandbox.stub(logger, 'error')
+    })
+
+    test('logs the reason for failure', async () => {
+      await licenceNotInChargeVersionWorkflow.onFailed(job, err)
+
+      expect(logger.error.called).to.be.true()
+      expect(logger.error.calledWith(
+        `Job ${job.name} ${job.id} failed`,
+        err
+      )).to.be.true()
+    })
+  })
+})

--- a/test/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.test.js
+++ b/test/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.test.js
@@ -99,7 +99,6 @@ experiment('modules/charge-versions/jobs/licence-not-in-charge-version-workflow'
     test('logs the reason for failure', async () => {
       await licenceNotInChargeVersionWorkflow.onFailed(job, err)
 
-      expect(logger.error.called).to.be.true()
       expect(logger.error.calledWith(
         `Job ${job.name} ${job.id} failed`,
         err

--- a/test/modules/charge-versions/plugin.test.js
+++ b/test/modules/charge-versions/plugin.test.js
@@ -1,75 +1,65 @@
 'use strict'
 
+// Test framework dependencies
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
-const sandbox = require('sinon').createSandbox()
-const cron = require('node-cron')
-const chargeVersionWorkflowPlugin = require('../../../src/modules/charge-versions/plugin')
-const licenceVersions = require('../../../src/lib/connectors/repos/licence-versions')
-const createChargeVersionWorkflows = require('../../../src/modules/charge-versions/jobs/create-charge-version-workflows')
 const { expect } = require('@hapi/code')
-const chargeVersionWorkflowJob = require('../../../src/modules/charge-versions/jobs/create-charge-version-workflows')
+const sandbox = require('sinon').createSandbox()
+
+// Test helpers
+const createChargeVersionWorkflows = require('../../../src/modules/charge-versions/jobs/create-charge-version-workflows')
+const licenceNotInChargeVersionWorkflow = require('../../../src/modules/charge-versions/jobs/licence-not-in-charge-version-workflow')
+
+// Thing under test
+const chargeVersionWorkflowPlugin = require('../../../src/modules/charge-versions/plugin')
+
 experiment('modules/charge-versions/plugin.js', () => {
   let server
 
   beforeEach(async () => {
     server = {
       queueManager: {
-        add: sandbox.stub().resolves(),
-        register: sandbox.stub().resolves()
+        add: sandbox.stub(),
+        register: sandbox.stub().returnsThis(),
+        deleteKeysByPattern: sandbox.stub()
       }
     }
-    sandbox.stub(cron, 'schedule')
-    sandbox.stub(licenceVersions, 'findIdsByDateNotInChargeVersionWorkflows').returns([{ licenceVersionId: 'test-version-id', licenceId: 'test-licence-id' }])
   })
 
   afterEach(async () => {
     sandbox.restore()
   })
 
-  test('has a plugin name', async () => {
+  test('has a plugin name', () => {
     expect(chargeVersionWorkflowPlugin.plugin.name).to.equal('charge-version-workflow-jobs')
   })
 
-  test('requires hapiBull plugin', async () => {
+  test('requires hapiBull plugin', () => {
     expect(chargeVersionWorkflowPlugin.plugin.dependencies).to.equal(['hapiBull'])
   })
 
   experiment('register', () => {
-    experiment('on target environments', () => {
-      beforeEach(async () => {
-        sandbox.stub(process, 'env').value({
-          NODE_ENV: 'test'
-        })
-        await chargeVersionWorkflowPlugin.plugin.register(server)
-      })
+    test('empties the queue of licence not in charge version workflow jobs', async () => {
+      await chargeVersionWorkflowPlugin.plugin.register(server)
 
-      test('adds subscriber for the charge charge version workflow job', async () => {
-        const [job] = server.queueManager.register.firstCall.args
-        expect(job).to.equal(createChargeVersionWorkflows)
-      })
-
-      test('schedules a cron job to run every 6 hours', async () => {
-        const [schedule, func] = cron.schedule.firstCall.args
-        expect(schedule).to.equal('0 */6 * * *')
-        expect(func).to.be.function()
-      })
-    })
-  })
-
-  experiment('publishJobs', () => {
-    beforeEach(async () => {
-      sandbox.stub(process, 'env').value({
-        NODE_ENV: 'test'
-      })
-      await chargeVersionWorkflowPlugin.publishJobs(server.queueManager)
+      expect(server.queueManager.deleteKeysByPattern.calledWith(
+        `*${licenceNotInChargeVersionWorkflow.jobName}*`
+      )).to.be.true()
     })
 
-    test('the right job details are added to the queue manager', async () => {
-      const [jobName, licenceVersionId, licenceId] = server.queueManager.add.args[0]
-      expect(server.queueManager.add.called).to.be.true()
-      expect(jobName).to.equal(chargeVersionWorkflowJob.jobName)
-      expect(licenceVersionId).to.equal('test-version-id')
-      expect(licenceId).to.equal('test-licence-id')
+    test('adds subscriber for the licence not in charge version workflow job', async () => {
+      await chargeVersionWorkflowPlugin.plugin.register(server)
+
+      expect(server.queueManager.register.calledWith(
+        licenceNotInChargeVersionWorkflow
+      )).to.be.true()
+    })
+
+    test('adds subscriber for the charge version workflow job', async () => {
+      await chargeVersionWorkflowPlugin.plugin.register(server)
+
+      expect(server.queueManager.register.calledWith(
+        createChargeVersionWorkflows
+      )).to.be.true()
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3745

This forms part of the work we are doing to [move all background processes to a background instance of the app](https://github.com/DEFRA/water-abstraction-service/pull/1766).

Another step to that is [Refactoring message-queue to centralise job registrations](https://github.com/DEFRA/water-abstraction-service/pull/1775). At the moment each module does its own thing when it comes to registering BullMQ jobs. The problem is it makes it really hard to see just what on earth is going on in the background of the service.

It has also led to inconsistencies, one of which is using both repeatable BullMQ jobs and [node-cron](https://github.com/node-cron/node-cron) to achieve the same thing.

This change is targeted where **node-cron** is being used to schedule creating jobs. This can easily be replaced by creating a [repeatble job](https://docs.bullmq.io/guide/jobs/repeatable) at startup that operates on the same cron schedule.

We'll also make the schedules configurable so we can have more control over when they run across the different environments.