### PR TITLE
Fix slow licence versions 4 charge workflow query

### DIFF
--- a/src/lib/connectors/repos/queries/licence-versions.js
+++ b/src/lib/connectors/repos/queries/licence-versions.js
@@ -1,22 +1,29 @@
+'use strict'
 
-exports.getNewLicenceVersionsForChargeVersionWorkflow = `select
-distinct licenceVersions.licence_version_id,
-  licenceVersions.licence_id
-from
-(select * from water.licence_versions where
-date_created >= :dateAndTime
-union
-select lv.* from water.licences l
-inner join water.licence_versions lv on
-l.licence_id = lv.licence_id
-and lv.status in ('superseded', 'current')
-left join water.charge_versions cv on
-l.licence_ref = cv.licence_ref where
-cv.licence_ref is null) as licenceVersions where
-licence_version_id not in (select
-licence_version_id from water.charge_version_workflows where 
-licence_version_id is not null)
-and licence_id not in (select licence_id from water.charge_versions cv 
-join water.billing_batch_charge_version_years bbcvy on cv.charge_version_id = bbcvy.charge_version_id 
-join water.billing_batches bb on bb.billing_batch_id = bbcvy.billing_batch_id 
-where bb.status in ('review', 'ready'));`
+exports.getNewLicenceVersionsForChargeVersionWorkflow = `SELECT DISTINCT
+lvs.licence_version_id,
+lvs.licence_id
+FROM (
+  SELECT lv.licence_version_id,
+    lv.licence_id
+  FROM water.licence_versions lv
+  WHERE lv.date_created >= :dateAndTime
+  UNION
+  SELECT lv.licence_version_id,
+    lv.licence_id
+  FROM water.licences l
+    INNER JOIN water.licence_versions lv ON l.licence_id = lv.licence_id
+    AND lv.status IN ('superseded', 'current')
+    LEFT JOIN water.charge_versions cv ON l.licence_ref = cv.licence_ref
+  WHERE cv.licence_ref IS NULL
+) AS lvs
+LEFT JOIN water.charge_version_workflows cvw ON cvw.licence_version_id = lvs.licence_version_id
+LEFT JOIN (
+  SELECT licence_id
+  FROM water.charge_versions cv
+    INNER JOIN water.billing_batch_charge_version_years bbcvy ON bbcvy.charge_version_id = cv.charge_version_id
+    INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bbcvy.billing_batch_id
+  WHERE bb.status IN ('review', 'ready')
+) sub_cv ON sub_cv.licence_id = lvs.licence_id
+WHERE cvw.licence_version_id IS NULL
+AND sub_cv.licence_id IS NULL;`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3745

This issue was found whilst working on [Remove node-cron for BullMQ jobs](https://github.com/DEFRA/water-abstraction-service/pull/1780). In the module `charge-versions` node-cron is used to kick off a process that creates a job for every licence version ID not in the charge workflow.

We needed to recreate that with a BullMQ repeatable job so got cracking. The current process is scheduled to kick off every 6 hours but we wanted to see it running so amended the schedule to every minute.

Well, the job triggered and then we waited for the `onComplete` to fire. And waited, and waited, _and waited_! 🤔

It just didn't seem to be completing. So, we traced through the code and ended up at `src/lib/connectors/repos/queries/licence-versions.js`.

We ran it locally, just to see if it returned anything but instead found ourselves waiting for 18 minutes for it to complete! 🤯😱

Picking a different tool and switching off the app, on repeated runs we got timings of 6 to 7 minutes. It didn't seem like an overly complex query but it was certainly 'messy'. Seeing `SELECT *` all over the place was an immediate 'smell' that the proper care hadn't been taken with it.

We're no SQL experts, but a quick Google on performance tips highlighted `NOT IN` should be avoided and be replaced with `LEFT JOIN .. IS NULL`. When we tidied up the query and dropped the `NOT IN`, the timings went down to less than a second. ✊😎

<details>
<summary>Timings and results before</summary>

<img width="708" alt="Screenshot 2022-08-19 at 18 16 29" src="https://user-images.githubusercontent.com/1789650/185681173-ad6eb962-c149-4183-bfef-9cb0218a9894.png">

</details>

<details>
<summary>Timings and results after</summary>

<img width="611" alt="Screenshot 2022-08-19 at 18 19 49" src="https://user-images.githubusercontent.com/1789650/185681351-9c095710-dc2a-4b5c-9055-c84e31ff0103.png">

</details>