### PR TITLE
Set up background tasks module

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -29,13 +29,13 @@
         ".git/index.lock"
       ],
       "script": "index-background.js",
+      "instances": 1,
+      "exec_mode" : "fork",
       "env": {
         "watch": true
       },
       "env_production": {
-        "watch": false,
-        "instances" : "max",
-        "exec_mode" : "cluster"
+        "watch": false
       }
     }
   ]

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -35,7 +35,8 @@
         "watch": true
       },
       "env_production": {
-        "watch": false
+        "watch": false,
+        "node_args": ["--max-old-space-size=4000"]
       }
     }
   ]

--- a/index-background.js
+++ b/index-background.js
@@ -11,8 +11,10 @@ const moment = require('moment')
 
 const config = require('./config')
 const db = require('./src/lib/connectors/db')
+const { JobRegistrationService } = require('./src/lib/queue-manager/job-registration-service')
 const { logger } = require('./src/logger')
 const routes = require('./src/routes/background.js')
+const { StartUpJobsService } = require('./src/lib/queue-manager/start-up-jobs-service')
 const { validate } = require('./src/lib/validate')
 
 // Hapi/good is used to log ops statistics, request responses and server log events. It's the reason you'll see
@@ -29,8 +31,15 @@ const server = Hapi.server({
   ...config.serverBackground
 })
 
+const plugins = [
+  require('./src/lib/queue-manager').plugin
+]
+
 // Register plugins
 const _registerServerPlugins = async (server) => {
+  // Service plugins
+  await server.register(plugins)
+
   // Third-party plugins
   await server.register({
     plugin: Good,
@@ -64,7 +73,13 @@ const start = async function () {
     _configureServerAuthStrategy(server)
     server.route(routes)
 
+    // TODO: Ideally we wouldn't bother registering all the Queues and workers when running unit tests. So, we would
+    // move this into the `if (!module.parent)` block. But when we do the tests only run the first few and then exit.
+    // We should look into what's happening and why we can't move it there.
+    JobRegistrationService.go(server.queueManager)
+
     if (!module.parent) {
+      StartUpJobsService.go(server.queueManager)
       await server.start()
       const name = `${process.env.SERVICE_NAME}-background`
       const uri = server.info.uri
@@ -86,6 +101,9 @@ process
   .on('SIGINT', async () => {
     logger.info('Stopping hapi server: existing requests have 25 seconds to complete')
     await server.stop({ timeout: 25 * 1000 })
+
+    logger.info('Stopping BullMQ workers')
+    await server.queueManager.closeAll()
 
     logger.info('Closing connection pool')
     await db.pool.end()

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const db = require('./src/lib/connectors/db')
 const { JobRegistrationService } = require('./src/lib/queue-manager/job-registration-service')
 const { logger } = require('./src/logger')
 const routes = require('./src/routes/water.js')
-const { StartUpJobsService } = require('./src/lib/queue-manager/start-up-jobs-service')
 const { validate } = require('./src/lib/validate')
 
 // Hapi/good is used to log ops statistics, request responses and server log events. It's the reason you'll see
@@ -139,7 +138,6 @@ const start = async function () {
     JobRegistrationService.go(server.queueManager)
 
     if (!module.parent) {
-      StartUpJobsService.go(server.queueManager)
       await server.start()
       const name = process.env.SERVICE_NAME
       const uri = server.info.uri
@@ -161,9 +159,6 @@ process
   .on('SIGINT', async () => {
     logger.info('Stopping hapi server: existing requests have 25 seconds to complete')
     await server.stop({ timeout: 25 * 1000 })
-
-    logger.info('Stopping BullMQ workers')
-    await server.queueManager.closeAll()
 
     logger.info('Closing connection pool')
     await db.pool.end()

--- a/src/lib/queue-manager/queue-manager.js
+++ b/src/lib/queue-manager/queue-manager.js
@@ -177,7 +177,10 @@ class QueueManager {
     for (const [jobName, { worker, queue }] of this._queues) {
       logger.info(`Closing queue and worker ${jobName}`)
       await this._closeQueue(jobName, queue)
-      await this._closeWorker(jobName, worker)
+
+      if (worker) {
+        await this._closeWorker(jobName, worker)
+      }
     }
   }
 
@@ -199,6 +202,10 @@ class QueueManager {
 
   _createWorkerAndQueueScheduler (wrlsJob, connection) {
     const result = {}
+
+    if (process.env.name !== 'service-background') {
+      return result
+    }
 
     // TODO: Implement metrics so we can see how workers are doing. Add the following line to workerOpts and require
     // `MetricsTime` from bullmq https://docs.bullmq.io/guide/metrics

--- a/src/modules/billing/jobs/process-charge-version-year.js
+++ b/src/modules/billing/jobs/process-charge-version-year.js
@@ -16,7 +16,11 @@ const config = require('../../../../config')
 const helpers = require('./lib/helpers')
 
 const fork = require('child_process').fork
-const child = fork('./src/modules/billing/jobs/lib/process-charge-version-year-worker.js')
+
+let child
+if (process.env.name === 'service-background') {
+  child = fork('./src/modules/billing/jobs/lib/process-charge-version-year-worker.js')
+}
 
 const createMessage = (batchId, billingBatchChargeVersionYearId) => ([
   JOB_NAME,

--- a/src/modules/billing/jobs/process-charge-version-year.js
+++ b/src/modules/billing/jobs/process-charge-version-year.js
@@ -1,21 +1,19 @@
 'use strict'
 
+const { fork } = require('child_process')
 const { get } = require('lodash')
 
-const JOB_NAME = 'billing.process-charge-version-year'
-const { logger } = require('../../../logger')
-const { jobName: prepareTransactionsJobName } = require('./prepare-transactions')
-
-const queueManager = require('../../../lib/queue-manager')
-
-const { BATCH_ERROR_CODE } = require('../../../lib/models/batch')
 const batchJob = require('./lib/batch-job')
 const chargeVersionYearService = require('../services/charge-version-year')
-
 const config = require('../../../../config')
 const helpers = require('./lib/helpers')
+const { logger } = require('../../../logger')
+const queueManager = require('../../../lib/queue-manager')
 
-const fork = require('child_process').fork
+// Constants
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch')
+const JOB_NAME = 'billing.process-charge-version-year'
+const { jobName: prepareTransactionsJobName } = require('./prepare-transactions')
 
 let child
 if (process.env.name === 'service-background') {
@@ -62,13 +60,15 @@ const handler = async job => {
 
 const onComplete = async job => batchJob.logOnComplete(job)
 
-exports.jobName = JOB_NAME
-exports.createMessage = createMessage
-exports.handler = handler
-exports.onFailed = helpers.onFailedHandler
-exports.onComplete = onComplete
-exports.workerOptions = {
-  concurrency: config.billing.processChargeVersionYearsJobConcurrency,
-  lockDuration: 3600000,
-  lockRenewTime: 3600000 / 2
+module.exports = {
+  jobName: JOB_NAME,
+  createMessage,
+  handler,
+  onFailed: helpers.onFailedHandler,
+  onComplete,
+  workerOptions: {
+    concurrency: config.billing.processChargeVersionYearsJobConcurrency,
+    lockDuration: 3600000,
+    lockRenewTime: 3600000 / 2
+  }
 }

--- a/src/modules/billing/jobs/update-invoices.js
+++ b/src/modules/billing/jobs/update-invoices.js
@@ -10,9 +10,13 @@ const { jobNames } = require('../../../lib/constants')
 
 const JOB_NAME = jobNames.updateInvoices
 const fork = require('child_process').fork
-const child = fork('./src/modules/billing/jobs/lib/update-invoices-worker.js')
 
 const { logger } = require('../../../logger')
+
+let child
+if (process.env.name === 'service-background') {
+  child = fork('./src/modules/billing/jobs/lib/update-invoices-worker.js')
+}
 
 const createMessage = data => ([
   JOB_NAME,

--- a/src/modules/billing/jobs/update-invoices.js
+++ b/src/modules/billing/jobs/update-invoices.js
@@ -1,17 +1,16 @@
-const uuid = require('uuid/v4')
+'use strict'
 
-// Models
-const { BATCH_ERROR_CODE } = require('../../../lib/models/batch')
+const fork = require('child_process').fork
+const uuid = require('uuid/v4')
 
 // Utils
 const batchJob = require('./lib/batch-job')
 const helpers = require('./lib/helpers')
-const { jobNames } = require('../../../lib/constants')
-
-const JOB_NAME = jobNames.updateInvoices
-const fork = require('child_process').fork
-
 const { logger } = require('../../../logger')
+
+// Constants
+const { BATCH_ERROR_CODE } = require('../../../lib/models/batch')
+const JOB_NAME = 'billing.update-invoices'
 
 let child
 if (process.env.name === 'service-background') {
@@ -50,14 +49,16 @@ const handler = async job => {
 
 const onComplete = async job => batchJob.logOnComplete(job)
 
-exports.jobName = JOB_NAME
-exports.handler = handler
-exports.createMessage = createMessage
-exports.onComplete = onComplete
-exports.onFailed = helpers.onFailedHandler
-exports.workerOptions = {
-  maxStalledCount: 3,
-  stalledInterval: 120000,
-  lockDuration: 120000,
-  lockRenewTime: 120000 / 2
+module.exports = {
+  jobName: JOB_NAME,
+  createMessage,
+  handler,
+  onFailed: helpers.onFailedHandler,
+  onComplete,
+  workerOptions: {
+    maxStalledCount: 3,
+    stalledInterval: 120000,
+    lockDuration: 120000,
+    lockRenewTime: 120000 / 2
+  }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3745

> We have started this change again because [PR #1766](https://github.com/DEFRA/water-abstraction-service/pull/1766) had gone so far done a possible path that it made merging/rebasing overly complex. Simpler to start again!

We are separating out our background BullMQ tasks so that they run on a background instance. The foreground (existing instance) can then just focus on handling requests from the UI, including adding the initial jobs that kick off background processes.

We had initially looked at splitting out `QueueManager` into a `WorkerManager` (see [PR #1766](https://github.com/DEFRA/water-abstraction-service/pull/1766)). But we then found that the background instance also needs to know about queues. This is because a number of the `onComplete()` worker handlers add new jobs to queues based on the results of the main worker handler.

So, we moved a number of the changes we were making into separate PR's, which focused on refactoring the QueueManager ready to allow us to make the changes we need to support a background instance.

This PR is those changes.