### PR TITLE
Fix port conflict with test

### DIFF
--- a/test/routes/background.test.js
+++ b/test/routes/background.test.js
@@ -3,7 +3,7 @@ const { server, start } = require('../../index-background')
 const { experiment, test, beforeEach, before } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-experiment('/status', () => {
+experiment('/status (background)', () => {
   let response
 
   before(async () => {

--- a/test/routes/water.test.js
+++ b/test/routes/water.test.js
@@ -1,13 +1,13 @@
-const { server } = require('../../index')
+const { server, start } = require('../../index')
 
 const { experiment, test, beforeEach, before } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-experiment('/status', () => {
+experiment('/status (water)', () => {
   let response
 
   before(async () => {
-    await server.start()
+    await start()
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
water.test is erroring with a port conflict if the tests are run while the service is running locally.