### PR TITLE
Use new `url-join` helper

### DIFF
--- a/integration-tests/billing/services/connectors/crm.js
+++ b/integration-tests/billing/services/connectors/crm.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
-const urlJoin = require('url-join')
 
 const createCrmUrl = (...parts) => {
   return urlJoin(config.services.crm_v2, ...parts)

--- a/integration-tests/billing/services/connectors/returns.js
+++ b/integration-tests/billing/services/connectors/returns.js
@@ -1,6 +1,5 @@
 const config = require('../../../../config')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
-const urlJoin = require('url-join')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const { logger } = require('../../../../src/logger')
 
 const createUrl = urlTail => urlJoin(config.services.returns, urlTail)

--- a/integration-tests/billing/services/crm-v1-loader.js
+++ b/integration-tests/billing/services/crm-v1-loader.js
@@ -3,9 +3,8 @@
 const FixtureLoader = require('./fixture-loader/FixtureLoader')
 const AsyncAdapter = require('./fixture-loader/adapters/AsyncAdapter')
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
-const urlJoin = require('url-join')
 const { omit } = require('lodash')
 
 const createCrmV1Url = (...parts) => urlJoin(config.services.crm, ...parts)

--- a/integration-tests/billing/services/crm-v2-loader.js
+++ b/integration-tests/billing/services/crm-v2-loader.js
@@ -3,9 +3,8 @@
 const FixtureLoader = require('./fixture-loader/FixtureLoader')
 const AsyncAdapter = require('./fixture-loader/adapters/AsyncAdapter')
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
-const urlJoin = require('url-join')
 const createCrmV2Url = (...parts) => urlJoin(config.services.crm_v2, ...parts)
 
 // Resolve path to fixtures directory

--- a/integration-tests/billing/services/idm-loader.js
+++ b/integration-tests/billing/services/idm-loader.js
@@ -3,9 +3,8 @@
 const FixtureLoader = require('./fixture-loader/FixtureLoader')
 const AsyncAdapter = require('./fixture-loader/adapters/AsyncAdapter')
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
-const urlJoin = require('url-join')
 const createIdmUrl = (...parts) => urlJoin(config.services.idm, ...parts)
 
 // Resolve path to fixtures directory

--- a/integration-tests/billing/services/permits-loader.js
+++ b/integration-tests/billing/services/permits-loader.js
@@ -3,9 +3,8 @@
 const FixtureLoader = require('./fixture-loader/FixtureLoader')
 const AsyncAdapter = require('./fixture-loader/adapters/AsyncAdapter')
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
-const urlJoin = require('url-join')
 const createPermitsUrl = (...parts) => urlJoin(config.services.permits, ...parts)
 const { getLicenceData } = require('./permit-helpers')
 // Resolve path to fixtures directory

--- a/integration-tests/billing/services/returns-loader.js
+++ b/integration-tests/billing/services/returns-loader.js
@@ -3,9 +3,8 @@
 const FixtureLoader = require('./fixture-loader/FixtureLoader')
 const AsyncAdapter = require('./fixture-loader/adapters/AsyncAdapter')
 
-const { serviceRequest, returns } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin, returns } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
-const urlJoin = require('url-join')
 const createReturnsUrl = (...parts) => urlJoin(config.services.returns, ...parts)
 const moment = require('moment')
 const { last } = require('lodash')

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@envage/hapi-pg-rest-api": "^7.0.0",
-        "@envage/water-abstraction-helpers": "4.8.1",
+        "@envage/water-abstraction-helpers": "DEFRA/water-abstraction-helpers#create-url-join-helper",
         "@hapi/boom": "^7.4.11",
         "@hapi/good": "^8.2.4",
         "@hapi/hapi": "^18.4.1",
@@ -60,7 +60,6 @@
         "snakecase-keys": "^1.1.1",
         "title-case": "^3.0.2",
         "tunnel": "0.0.6",
-        "url-join": "^4.0.1",
         "uuid": "^3.4.0",
         "yamljs": "^0.3.0"
       },
@@ -419,8 +418,8 @@
     },
     "node_modules/@envage/water-abstraction-helpers": {
       "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.8.1.tgz",
-      "integrity": "sha512-JRqwaPK/4pOGf6TUnayk3FDFDNmMuf+g55YktFyZDNYbU9vE8IKuFqM1Z+CGpy5+WsAr1QgWzQEsVVDubtitIA==",
+      "resolved": "git+ssh://git@github.com/DEFRA/water-abstraction-helpers.git#813460c97c94af7455e2c7b8c681542f5d105996",
+      "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/code": "^6.0.0",
         "@hapi/hapi": "^18.4.1",
@@ -11632,11 +11631,6 @@
         "querystring": "0.2.0"
       }
     },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -12430,9 +12424,8 @@
       }
     },
     "@envage/water-abstraction-helpers": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.8.1.tgz",
-      "integrity": "sha512-JRqwaPK/4pOGf6TUnayk3FDFDNmMuf+g55YktFyZDNYbU9vE8IKuFqM1Z+CGpy5+WsAr1QgWzQEsVVDubtitIA==",
+      "version": "git+ssh://git@github.com/DEFRA/water-abstraction-helpers.git#813460c97c94af7455e2c7b8c681542f5d105996",
+      "from": "@envage/water-abstraction-helpers@DEFRA/water-abstraction-helpers#create-url-join-helper",
       "requires": {
         "@hapi/code": "^6.0.0",
         "@hapi/hapi": "^18.4.1",
@@ -21193,11 +21186,6 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
-    },
-    "url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^7.0.0",
-    "@envage/water-abstraction-helpers": "4.8.1",
+    "@envage/water-abstraction-helpers": "DEFRA/water-abstraction-helpers#create-url-join-helper",
     "@hapi/boom": "^7.4.11",
     "@hapi/good": "^8.2.4",
     "@hapi/hapi": "^18.4.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "snakecase-keys": "^1.1.1",
     "title-case": "^3.0.2",
     "tunnel": "0.0.6",
-    "url-join": "^4.0.1",
     "uuid": "^3.4.0",
     "yamljs": "^0.3.0"
   },

--- a/src/lib/connectors/charge-module/lib/AccessTokenManager.js
+++ b/src/lib/connectors/charge-module/lib/AccessTokenManager.js
@@ -2,7 +2,7 @@
 
 const moment = require('moment')
 const gotWithProxy = require('./got-with-proxy')
-const urlJoin = require('url-join')
+const { urlJoin } = require('@envage/water-abstraction-helpers')
 
 const { logger } = require('../../../../logger')
 const config = require('../../../../../config.js')

--- a/src/lib/connectors/crm-v2/addresses.js
+++ b/src/lib/connectors/crm-v2/addresses.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const getUri = (...tail) => urlJoin(config.services.crm_v2, 'addresses', ...tail)

--- a/src/lib/connectors/crm-v2/companies.js
+++ b/src/lib/connectors/crm-v2/companies.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const moment = require('moment')
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const getUri = (...tail) => urlJoin(config.services.crm_v2, 'companies', ...tail)

--- a/src/lib/connectors/crm-v2/contacts.js
+++ b/src/lib/connectors/crm-v2/contacts.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const getUri = (...tail) => urlJoin(config.services.crm_v2, 'contacts', ...tail)

--- a/src/lib/connectors/crm-v2/documents.js
+++ b/src/lib/connectors/crm-v2/documents.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const urlJoin = require('url-join')
 const Joi = require('joi')
 const moment = require('moment')
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const VALID_LICENCE_NUMBER = Joi.string().required().example('01/123/R01')

--- a/src/lib/connectors/crm-v2/invoice-account-addresses.js
+++ b/src/lib/connectors/crm-v2/invoice-account-addresses.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const getUri = (...tail) => urlJoin(config.services.crm_v2, 'invoice-account-addresses', ...tail)

--- a/src/lib/connectors/crm-v2/invoice-accounts.js
+++ b/src/lib/connectors/crm-v2/invoice-accounts.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const { chunk, flatMap } = require('lodash')
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const getPluralisedUri = (...tail) => urlJoin(config.services.crm_v2, 'invoice-accounts', ...tail)

--- a/src/lib/connectors/crm-v2/test-data.js
+++ b/src/lib/connectors/crm-v2/test-data.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 /**

--- a/src/lib/connectors/crm/documents.js
+++ b/src/lib/connectors/crm/documents.js
@@ -7,9 +7,8 @@ const rp = require('request-promise-native').defaults({
   proxy: null,
   strictSSL: false
 })
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
-const urlJoin = require('url-join')
 const { isArray, flatMap, chunk } = require('lodash')
 
 // Create API client

--- a/src/lib/connectors/crm/entities.js
+++ b/src/lib/connectors/crm/entities.js
@@ -1,6 +1,5 @@
-const urlJoin = require('url-join')
 const { get, partialRight } = require('lodash')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 const helpers = require('@envage/water-abstraction-helpers')
 

--- a/src/lib/connectors/crm/kpis.js
+++ b/src/lib/connectors/crm/kpis.js
@@ -1,5 +1,5 @@
 const apiClientFactory = require('../api-client-factory')
-const urlJoin = require('url-join')
+const { urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const kpiClient = apiClientFactory.create(urlJoin(config.services.crm, 'kpi'))

--- a/src/lib/connectors/crm/verifications.js
+++ b/src/lib/connectors/crm/verifications.js
@@ -1,5 +1,5 @@
 const apiClientFactory = require('../api-client-factory')
-const urlJoin = require('url-join')
+const { urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const verificationsClient = apiClientFactory.create(urlJoin(config.services.crm, 'verification'))

--- a/src/lib/connectors/ea-address-facade.js
+++ b/src/lib/connectors/ea-address-facade.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const { http } = require('@envage/water-abstraction-helpers')
+const { http, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../config')
 const { set } = require('lodash')
-const urlJoin = require('url-join')
 
 /**
  * Makes a request to the EA address facade

--- a/src/lib/connectors/idm.js
+++ b/src/lib/connectors/idm.js
@@ -2,10 +2,9 @@ const Joi = require('joi')
 const { head, partialRight } = require('lodash')
 const { throwIfError } = require('@envage/hapi-pg-rest-api')
 const apiClientFactory = require('./api-client-factory')
-const urlJoin = require('url-join')
 const config = require('../../../config')
 const factory = require('./service-version-factory')
-const helpers = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const uuid = require('uuid/v4')
 
 const usersClient = apiClientFactory.create(urlJoin(config.services.idm, 'user'))
@@ -63,7 +62,7 @@ const startEmailChange = (userId, email) => {
       email
     }
   }
-  return helpers.serviceRequest.post(url, options)
+  return serviceRequest.post(url, options)
 }
 
 /**
@@ -79,7 +78,7 @@ const verifySecurityCode = (userId, securityCode) => {
       securityCode
     }
   }
-  return helpers.serviceRequest.post(url, options)
+  return serviceRequest.post(url, options)
 }
 
 /**
@@ -89,7 +88,7 @@ const verifySecurityCode = (userId, securityCode) => {
  */
 const getEmailChangeStatus = userId => {
   const url = `${config.services.idm}/user/${userId}/change-email-address`
-  return helpers.serviceRequest.get(url)
+  return serviceRequest.get(url)
 }
 
 /** Creates a new user in the IDM for the given application

--- a/src/lib/connectors/idm/acceptance-tests.js
+++ b/src/lib/connectors/idm/acceptance-tests.js
@@ -1,6 +1,5 @@
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
-const urlJoin = require('url-join')
 
 const deleteAcceptanceTestData = () => {
   const url = urlJoin(config.services.idm, 'acceptance-tests')

--- a/src/lib/connectors/import/index.js
+++ b/src/lib/connectors/import/index.js
@@ -2,8 +2,7 @@
 
 const factory = require('../service-version-factory')
 const config = require('../../../../config')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
-const urlJoin = require('url-join')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 
 /**
  * Posts to import module to re-import charging data

--- a/src/lib/connectors/import/jobs.js
+++ b/src/lib/connectors/import/jobs.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const urlJoin = require('url-join')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../config')
 
 const getUri = (...tail) => urlJoin(config.services.import, 'jobs', ...tail)

--- a/src/lib/connectors/permit.js
+++ b/src/lib/connectors/permit.js
@@ -1,16 +1,15 @@
 'use strict'
 
 const { get } = require('lodash')
-const urlJoin = require('url-join')
 const moment = require('moment')
 
-const helpers = require('@envage/water-abstraction-helpers')
+const { nald, serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const apiClientFactory = require('./api-client-factory')
 const config = require('../../../config')
 const { licence: { regimeId, typeId } } = config
 
 const factory = require('./service-version-factory')
-const calendarToIso = helpers.nald.dates.calendarToIso
+const calendarToIso = nald.dates.calendarToIso
 
 const licences = apiClientFactory.create(`${config.services.permits}licence`)
 
@@ -126,7 +125,7 @@ licences.getWaterLicencesThatHaveGaugingStationLinkagesThatNeedToBeCopiedFromDig
 
 const deleteAcceptanceTestData = () => {
   const url = urlJoin(config.services.permits, 'acceptance-tests')
-  return helpers.serviceRequest.delete(url)
+  return serviceRequest.delete(url)
 }
 
 exports.licences = licences

--- a/src/lib/connectors/reporting/index.js
+++ b/src/lib/connectors/reporting/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const config = require('../../../../config')
-const urlJoin = require('url-join')
+const { urlJoin } = require('@envage/water-abstraction-helpers')
 const got = require('got')
 
 /**

--- a/src/lib/connectors/returns.js
+++ b/src/lib/connectors/returns.js
@@ -1,7 +1,6 @@
 const apiClientFactory = require('./api-client-factory')
 const moment = require('moment')
-const helpers = require('@envage/water-abstraction-helpers')
-const urlJoin = require('url-join')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const { URL } = require('url')
 const { chunk, flatMap } = require('lodash')
 
@@ -86,13 +85,13 @@ const getCurrentDueReturns = async (excludeLicences, returnCycle) => {
 const getServiceVersion = async () => {
   const urlParts = new URL(config.services.returns)
   const url = urlJoin(urlParts.protocol, urlParts.host, 'status')
-  const response = await helpers.serviceRequest.get(url)
+  const response = await serviceRequest.get(url)
   return response.version
 }
 
 const deleteAcceptanceTestData = () => {
   const url = urlJoin(config.services.returns, 'acceptance-tests')
-  return helpers.serviceRequest.delete(url)
+  return serviceRequest.delete(url)
 }
 
 const getReturnsForLicence = async (licenceNumber, startDate, endDate) => {
@@ -136,7 +135,7 @@ const getReturnsCyclesReport = async startDate => {
       startDate
     }
   }
-  return helpers.serviceRequest.get(url, options)
+  return serviceRequest.get(url, options)
 }
 
 /**
@@ -147,7 +146,7 @@ const getReturnsCyclesReport = async startDate => {
  */
 const getReturnCycleById = async returnCycleId => {
   const url = urlJoin(config.services.returns, 'return-cycles', returnCycleId)
-  return helpers.serviceRequest.get(url)
+  return serviceRequest.get(url)
 }
 
 /**
@@ -158,7 +157,7 @@ const getReturnCycleById = async returnCycleId => {
  */
 const getReturnCycleReturns = async returnCycleId => {
   const url = urlJoin(config.services.returns, 'return-cycles', returnCycleId, 'returns')
-  return helpers.serviceRequest.get(url)
+  return serviceRequest.get(url)
 }
 
 exports.returns = returnsClient

--- a/src/lib/connectors/service-version-factory.js
+++ b/src/lib/connectors/service-version-factory.js
@@ -1,5 +1,4 @@
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
-const urlJoin = require('url-join')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const { URL } = require('url')
 
 /**

--- a/src/modules/acceptance-tests/lib/connectors/crm.js
+++ b/src/modules/acceptance-tests/lib/connectors/crm.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const config = require('../../../../../config')
-const urlJoin = require('url-join')
 
 const createCrmUrl = (...parts) => urlJoin(config.services.crm_v2, ...parts)
 

--- a/src/modules/acceptance-tests/lib/connectors/returns.js
+++ b/src/modules/acceptance-tests/lib/connectors/returns.js
@@ -1,6 +1,5 @@
 const config = require('../../../../../config')
-const { serviceRequest } = require('@envage/water-abstraction-helpers')
-const urlJoin = require('url-join')
+const { serviceRequest, urlJoin } = require('@envage/water-abstraction-helpers')
 const { logger } = require('../../../../logger')
 
 const createUrl = urlTail => urlJoin(config.services.returns, urlTail)


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-helpers/pull/183

To cut down our reliance on external dependencies where possible, we are rewriting the `url-join` dependency to use more standard JS url handling instead of custom regexes. This PR replaces all uses of `url-join` with the one in the new helper.

