### PR TITLE
Remove unused getFinancialYears function

### DIFF
--- a/src/lib/models/financial-year.js
+++ b/src/lib/models/financial-year.js
@@ -50,19 +50,6 @@ class FinancialYear {
     validators.assertIsInstanceOf(financialYear, FinancialYear)
     return this.yearEnding === financialYear.yearEnding
   }
-
-  /**
-   * Gets an array of FinancialYear objects for the range required
-   *
-   * @param {Number} from The end year of the financial year for the start of the range
-   * @param {Number} to The end year of the financial year for the end of the range
-   * @returns {Array<FinancialYear>} The FinancialYear objects in the range
-   */
-  static getFinancialYears (from, to) {
-    return range(from, to + 1).reduce((years, year) => {
-      return [...years, new FinancialYear(year)]
-    }, [])
-  }
 }
 
 module.exports = FinancialYear

--- a/src/lib/models/financial-year.js
+++ b/src/lib/models/financial-year.js
@@ -1,4 +1,3 @@
-const { range } = require('lodash')
 const moment = require('moment')
 const validators = require('./validators')
 

--- a/test/lib/models/financial-year.test.js
+++ b/test/lib/models/financial-year.test.js
@@ -27,37 +27,6 @@ experiment('lib/models/financial-year', () => {
     expect(financialYear.end).to.equal(moment('2019-03-31'))
   })
 
-  experiment('.getFinancialYears', () => {
-    test('returns the expected start and end date for a single year', async () => {
-      const financialYears = FinancialYear.getFinancialYears(2019, 2019)
-      expect(financialYears).to.have.length(1)
-      expect(financialYears[0].startYear).to.equal(2018)
-      expect(financialYears[0].endYear).to.equal(2019)
-      expect(financialYears[0].start).to.equal(moment('2018-04-01'))
-      expect(financialYears[0].end).to.equal(moment('2019-03-31'))
-    })
-
-    test('returns the expected start and end date for a multiple years', async () => {
-      const financialYears = FinancialYear.getFinancialYears(2020, 2022)
-      expect(financialYears).to.have.length(3)
-
-      expect(financialYears[0].startYear).to.equal(2019)
-      expect(financialYears[0].endYear).to.equal(2020)
-      expect(financialYears[0].start).to.equal(moment('2019-04-01'))
-      expect(financialYears[0].end).to.equal(moment('2020-03-31'))
-
-      expect(financialYears[1].startYear).to.equal(2020)
-      expect(financialYears[1].endYear).to.equal(2021)
-      expect(financialYears[1].start).to.equal(moment('2020-04-01'))
-      expect(financialYears[1].end).to.equal(moment('2021-03-31'))
-
-      expect(financialYears[2].startYear).to.equal(2021)
-      expect(financialYears[2].endYear).to.equal(2022)
-      expect(financialYears[2].start).to.equal(moment('2021-04-01'))
-      expect(financialYears[2].end).to.equal(moment('2022-03-31'))
-    })
-  })
-
   experiment('.isEqualTo', () => {
     test('returns true if the financial year is the same as the one supplied', async () => {
       const financialYear = new FinancialYear(2019)


### PR DESCRIPTION
Whilst going through the suplementary code we spotted an unused function so we are gong to remove it.