### PR TITLE
Fix pm2 logs for service-background not combining

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -10,6 +10,7 @@
         ".git/index.lock"
       ],
       "script": "index.js",
+      "combine_logs": true,
       "env": {
         "watch": true
       },
@@ -29,6 +30,7 @@
         ".git/index.lock"
       ],
       "script": "index-background.js",
+      "combine_logs": true,
       "instances": 1,
       "exec_mode" : "fork",
       "env": {


### PR DESCRIPTION
We deployed the updated version of this project to production where the `service-background` instance has been kicked off for the first time.

We expected the logs pm2 generates to behave as it does with the other apps, especially as we used the `ecosystem.config.js` file from [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) as our template.

By this, we mean `service-background-error.log` and a `service-background-out.log` files would be generated. Instead, pm2 is suffixing the process ID into the log name, for example, `service-background-out-10.log`.

What this means is, if the process gets stopped and restarted and assigned a different process ID the logs will not follow on. It also means we can't script our AWS CloudWatch logs to pick up the right files across the environments because the log files won't have a consistent name.

This change resolves the issue and ensures the log file name does not include the process ID.