### PR TITLE
Fix problem licence data

### DIFF
--- a/migrations/20221017134036-remove-problem-licences.js
+++ b/migrations/20221017134036-remove-problem-licences.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20221017134036-remove-problem-licences-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20221017134036-remove-problem-licences-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20221017134036-remove-problem-licences-down.sql
+++ b/migrations/sqls/20221017134036-remove-problem-licences-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to remove bad data from the db. We don't want that bad data put back in!!!! */

--- a/migrations/sqls/20221017134036-remove-problem-licences-up.sql
+++ b/migrations/sqls/20221017134036-remove-problem-licences-up.sql
@@ -1,0 +1,35 @@
+/* This query is deleting bad data that was transfered over from NALD. Due to
+the database being relational and therefore the tables being joined multiple
+record id's had to be searched and deleted*/
+
+BEGIN;
+DELETE FROM water.return_requirement_purposes WHERE return_requirement_purpose_id IN (
+SELECT rp.return_requirement_purpose_id FROM water.licences l
+INNER JOIN water.return_versions rv ON rv.licence_id = l.licence_id
+INNER JOIN water.return_requirements rr ON rr.return_version_id = rv.return_version_id
+INNER JOIN water.return_requirement_purposes rp ON rp.return_requirement_id = rr.return_requirement_id
+WHERE licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
+
+DELETE FROM water.return_requirements WHERE return_requirement_id IN (
+SELECT rr.return_requirement_id FROM water.licences l
+INNER JOIN water.return_versions rv ON rv.licence_id = l.licence_id
+INNER JOIN water.return_requirements rr ON rr.return_version_id = rv.return_version_id
+WHERE licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
+
+DELETE FROM water.return_versions WHERE return_version_id IN (
+SELECT rv.return_version_id FROM water.licences l
+INNER JOIN water.return_versions rv ON rv.licence_id = l.licence_id
+WHERE licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
+
+DELETE FROM water.charge_versions WHERE charge_version_id IN (
+SELECT cv.charge_version_id FROM water.licences l
+INNER JOIN water.charge_versions cv ON cv.licence_id = l.licence_id
+WHERE l.licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
+
+DELETE FROM water.licences WHERE licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G');
+COMMIT;

--- a/migrations/sqls/20221017134036-remove-problem-licences-up.sql
+++ b/migrations/sqls/20221017134036-remove-problem-licences-up.sql
@@ -30,6 +30,17 @@ INNER JOIN water.charge_versions cv ON cv.licence_id = l.licence_id
 WHERE l.licence_ref
 IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
 
+DELETE FROM water.licence_version_purposes  WHERE licence_version_id  IN (
+SELECT lv.licence_version_id FROM water.licences l
+INNER JOIN water.licence_versions lv ON lv.licence_id = l.licence_id
+WHERE l.licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
+
+DELETE FROM water.licence_versions  WHERE licence_id  IN (
+SELECT l.licence_id FROM water.licences l
+WHERE l.licence_ref
+IN ('`MD/054/0021/030', '03/28/27/0005 S/G'));
+
 DELETE FROM water.licences WHERE licence_ref
 IN ('`MD/054/0021/030', '03/28/27/0005 S/G');
 COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/WATER/boards/96?modal=detail&selectedIssue=WATER-3710 https://eaflood.atlassian.net/jira/software/c/projects/WATER/boards/96?modal=detail&selectedIssue=WATER-3756

We have two licences that hold problematic data currently in the water schema in the database. Here we are creating a migration script for both to remove these records.