### PR TITLE
Rename health status endpoint

### DIFF
--- a/src/modules/health/controller.js
+++ b/src/modules/health/controller.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // We use promisify to wrap exec in a promise. This allows us to await it without resorting to using callbacks.
 const util = require('util')
 const exec = util.promisify(require('child_process').exec)
@@ -13,11 +15,11 @@ const _getCommitHash = async () => {
   }
 }
 
-const getStatus = async () => {
+const getInfo = async () => {
   return {
     version: pkg.version,
     commit: await _getCommitHash()
   }
 }
 
-exports.getStatus = getStatus
+exports.getInfo = getInfo

--- a/src/modules/health/routes.js
+++ b/src/modules/health/routes.js
@@ -1,10 +1,12 @@
+'use strict'
+
 const controller = require('./controller')
 
 module.exports = {
-  getStatus: {
+  getInfo: {
     method: 'GET',
-    path: '/health/status',
-    handler: controller.getStatus,
+    path: '/health/info',
+    handler: controller.getInfo,
     config: {
       auth: false
     }

--- a/test/modules/health/controller.test.js
+++ b/test/modules/health/controller.test.js
@@ -1,23 +1,29 @@
+'use strict'
+
+// Test framework dependencies
 const { test, experiment, before } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-const controller = require('../../../src/modules/health/controller')
+// Test helpers
 const pkg = require('../../../package.json')
 
-experiment('modules/service-status/controller', () => {
-  experiment('.getStatus', () => {
-    let status
+// Thing under test
+const controller = require('../../../src/modules/health/controller')
+
+experiment('modules/health/controller', () => {
+  experiment('.getInfo', () => {
+    let info
 
     before(async () => {
-      status = await controller.getStatus()
+      info = await controller.getInfo()
     })
 
     test('contains the expected water service version', async () => {
-      expect(status.version).to.equal(pkg.version)
+      expect(info.version).to.equal(pkg.version)
     })
 
     test('contains the git commit hash', async () => {
-      expect(status.commit).to.exist()
+      expect(info.commit).to.exist()
     })
   })
 })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-service/pull/1862

We are going to rename the endpoint from status to info to avoid confusion with other such endpoints.