### PR TITLE
Add health route to background service

### DIFF
--- a/src/routes/background.js
+++ b/src/routes/background.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const healthRoutes = require('../modules/health/routes')
+
 const pkg = require('../../package.json')
 const { version } = pkg
 
@@ -9,5 +11,6 @@ module.exports = [
     path: '/status',
     handler: () => ({ version }),
     config: { auth: false, description: 'Check service status' }
-  }
+  },
+  ...Object.values(healthRoutes)
 ]


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-system/pull/8

Add the health/info route to the background service as previously it was only accessible from the foreground service.