### PR TITLE
Add new presroc billing acc. change to fixture

### DIFF
--- a/integration-tests/billing/fixtures/sets.json
+++ b/integration-tests/billing/fixtures/sets.json
@@ -409,6 +409,10 @@
       "file": "sroc-users.yaml"
     },
     {
+      "service": "water",
+      "file": "sroc-purposes.yaml"
+    },
+    {
       "service": "permits",
       "file": "sroc-permits.yaml"
     },

--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -1,4 +1,4 @@
-- ref: $chargeVersion
+- ref: $chargeVersion01
   model: ChargeVersion
   fields:
     licenceRef: $srocLicence01.licenceRef
@@ -13,10 +13,10 @@
     isTest: true
     licenceId: $srocLicence01.licenceId
 
-- ref: $chargeElement
+- ref: $chargeElement01
   model: ChargeElement
   fields:
-    chargeVersionId: $chargeVersion.chargeVersionId
+    chargeVersionId: $chargeVersion01.chargeVersionId
     description: 'SROC Test Charge Element'
     source: tidal
     loss: medium
@@ -27,3 +27,20 @@
     volume: 100
     billingChargeCategoryId: $chargeCategory.billing_charge_category_id
     eiucRegion: Southern
+
+- ref: $chargePurpose01
+  model: ChargePurpose
+  fields:
+    chargeElementId: $chargeElement01.chargeElementId
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 15.54
+    loss: medium
+    factorsOverridden: false
+    description: 'Test'
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId

--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -9,7 +9,7 @@
     status: current
     regionCode: $region.naldRegionId
     source: wrls
-    invoiceAccountId: $invoiceAccount.invoiceAccountId
+    invoiceAccountId: $invoiceAccount01.invoiceAccountId
     isTest: true
     licenceId: $srocLicence01.licenceId
 
@@ -17,7 +17,7 @@
   model: ChargeElement
   fields:
     chargeVersionId: $chargeVersion01.chargeVersionId
-    description: 'SROC Test Charge Element'
+    description: 'SROC Charge Element 01'
     source: tidal
     loss: medium
     isTest: true
@@ -39,7 +39,90 @@
     authorisedAnnualQuantity: 15.54
     loss: medium
     factorsOverridden: false
-    description: 'Test'
+    description: 'SROC CHarge Purpose 01'
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargeVersion02
+  model: ChargeVersion
+  fields:
+    licenceRef: $srocLicence02.licenceRef
+    scheme: alcs
+    versionNumber: 1
+    startDate: '2019-01-01'
+    endDate: '2022-03-31'
+    status: current
+    regionCode: $region.naldRegionId
+    source: wrls
+    companyId: $company02.companyId
+    invoiceAccountId: $invoiceAccount02.invoiceAccountId
+    isTest: true
+    licenceId: $srocLicence02.licenceId
+
+- ref: $chargeElement02
+  model: ChargeElement
+  fields:
+    chargeVersionId: $chargeVersion02.chargeVersionId
+    factorsOverridden: false
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    description: 'PRESROC Charge Element 02'
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 15.54
+    season: 'all year'
+    seasonDerived: 'all year'
+    source: unsupported
+    loss: medium
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargeVersion03
+  model: ChargeVersion
+  fields:
+    licenceRef: $srocLicence02.licenceRef
+    scheme: sroc
+    versionNumber: 2
+    startDate: '2022-04-01'
+    endDate: null
+    status: current
+    regionCode: $region.naldRegionId
+    source: wrls
+    invoiceAccountId: $invoiceAccount02.invoiceAccountId
+    isTest: true
+    licenceId: $srocLicence02.licenceId
+
+- ref: $chargeElement03
+  model: ChargeElement
+  fields:
+    chargeVersionId: $chargeVersion03.chargeVersionId
+    description: 'SROC Charge Element 02'
+    source: tidal
+    loss: medium
+    isTest: true
+    scheme: sroc
+    isRestrictedSource: false
+    waterModel: 'no model'
+    volume: 100
+    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    eiucRegion: Southern
+
+- ref: $chargePurpose02
+  model: ChargePurpose
+  fields:
+    chargeElementId: $chargeElement03.chargeElementId
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 15.54
+    loss: medium
+    factorsOverridden: false
+    description: 'SROC Charge Purpose 02'
     isTest: true
     purposePrimaryId: $primaryPurpose.purposePrimaryId
     purposeSecondaryId: $secondaryPurpose.purposeSecondaryId

--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -1,7 +1,7 @@
 - ref: $chargeVersion
   model: ChargeVersion
   fields:
-    licenceRef: $srocLicence.licenceRef
+    licenceRef: $srocLicence01.licenceRef
     scheme: sroc
     versionNumber: 1
     startDate: '2022-04-01'
@@ -11,7 +11,7 @@
     source: wrls
     invoiceAccountId: $invoiceAccount.invoiceAccountId
     isTest: true
-    licenceId: $srocLicence.licenceId
+    licenceId: $srocLicence01.licenceId
 
 - ref: $chargeElement
   model: ChargeElement

--- a/integration-tests/billing/fixtures/sroc-crm-v1.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v1.yaml
@@ -25,7 +25,7 @@
   fields:
     regime_entity_id: '0434dc31-a34e-7158-5775-4694af7a60cf'
     system_id: 'permit-repo'
-    system_external_id: 'AT/SROC/DAILY/01'
+    system_external_id: 'AT/SROC/SUPB/01'
     company_entity_id: $companyEntity.entity_id
     system_internal_id: $srocLicence.licence_id
     document_name: 'the daily cupcake licence'

--- a/integration-tests/billing/fixtures/sroc-crm-v1.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v1.yaml
@@ -5,31 +5,56 @@
     entity_type: 'individual'
     source: 'acceptance-test-setup'
 
-- ref: $companyEntity
+- ref: $companyEntity01
   model: Entity
   fields:
-    entity_nm: 'Big Farm Co Ltd'
+    entity_nm: 'Big Farm Co Ltd 01'
     entity_type: 'company'
     source: 'acceptance-test-setup'
 
-- ref: $entityRole
-  model: EntityRole
+- ref: $companyEntity02
+  model: Entity
+  fields:
+    entity_nm: 'Big Farm Co Ltd 02'
+    entity_type: 'company'
+    source: 'acceptance-test-setup'
+
+- model: EntityRole
   fields:
     entityId: $userEntity.entity_id
-    company_entity_id: $companyEntity.entity_id
+    company_entity_id: $companyEntity01.entity_id
     role: 'primary_user'
     created_by: 'acceptance-test-setup'
 
-- ref: $dailyDocumentHeader
-  model: DocumentHeader
+- model: EntityRole
+  fields:
+    entityId: $userEntity.entity_id
+    company_entity_id: $companyEntity02.entity_id
+    role: 'primary_user'
+    created_by: 'acceptance-test-setup'
+
+- model: DocumentHeader
   fields:
     regime_entity_id: '0434dc31-a34e-7158-5775-4694af7a60cf'
     system_id: 'permit-repo'
     system_external_id: 'AT/SROC/SUPB/01'
-    company_entity_id: $companyEntity.entity_id
-    system_internal_id: $srocLicence01.licence_id
-    document_name: 'the daily cupcake licence'
+    company_entity_id: $companyEntity01.entity_id
+    system_internal_id: $srocPermit01.licence_id
+    document_name: 'Big Farm 01 permit'
     metadata:
-      Name: 'cupcake factory'
+      Name: 'Big Farm 01'
+      dataType: 'acceptance-test-setup'
+      IsCurrent: true
+
+- model: DocumentHeader
+  fields:
+    regime_entity_id: '0434dc31-a34e-7158-5775-4694af7a60cf'
+    system_id: 'permit-repo'
+    system_external_id: 'AT/SROC/SUPB/02'
+    company_entity_id: $companyEntity02.entity_id
+    system_internal_id: $srocPermit02.licence_id
+    document_name: 'Big Farm 02 permit'
+    metadata:
+      Name: 'Big Farm 02'
       dataType: 'acceptance-test-setup'
       IsCurrent: true

--- a/integration-tests/billing/fixtures/sroc-crm-v1.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v1.yaml
@@ -27,7 +27,7 @@
     system_id: 'permit-repo'
     system_external_id: 'AT/SROC/SUPB/01'
     company_entity_id: $companyEntity.entity_id
-    system_internal_id: $srocLicence.licence_id
+    system_internal_id: $srocLicence01.licence_id
     document_name: 'the daily cupcake licence'
     metadata:
       Name: 'cupcake factory'

--- a/integration-tests/billing/fixtures/sroc-crm-v2.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v2.yaml
@@ -98,7 +98,7 @@
     endDate: null
     regime: water
     documentType: abstraction_licence
-    documentRef: 'AT/SROC/DAILY/01'
+    documentRef: 'AT/SROC/SUPB/01'
     isTest: true
 
 - model: DocumentRole

--- a/integration-tests/billing/fixtures/sroc-crm-v2.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v2.yaml
@@ -1,9 +1,17 @@
-- ref: $company
+- ref: $company01
   model: Company
   fields:
-    name: Big Farm Co Ltd
+    name: Big Farm Co Ltd 01
     type: organisation
-    companyNumber: '12345'
+    companyNumber: '1234501'
+    isTest: true
+
+- ref: $company02
+  model: Company
+  fields:
+    name: Big Farm Co Ltd 02
+    type: organisation
+    companyNumber: '1234502'
     isTest: true
 
 - ref: $address1
@@ -37,7 +45,7 @@
 - model: CompanyAddress
   fields:
     roleName: billing
-    companyId: $company.companyId
+    companyId: $company01.companyId
     addressId: $address1.addressId
     startDate: '2022-04-01'
     endDate: null
@@ -46,9 +54,27 @@
 - model: CompanyAddress
   fields:
     roleName: billing
-    companyId: $company.companyId
+    companyId: $company01.companyId
     addressId: $address2.addressId
     startDate: '2022-04-01'
+    endDate: null
+    isTest: true
+
+- model: CompanyAddress
+  fields:
+    roleName: billing
+    companyId: $company02.companyId
+    addressId: $address1.addressId
+    startDate: '2019-01-01'
+    endDate: null
+    isTest: true
+
+- model: CompanyAddress
+  fields:
+    roleName: billing
+    companyId: $company02.companyId
+    addressId: $address2.addressId
+    startDate: '2019-01-01'
     endDate: null
     isTest: true
 
@@ -65,25 +91,43 @@
 
 - model: CompanyContact
   fields:
-    companyId: $company.companyId
+    companyId: $company01.companyId
     contactId: $contact.contactId
     roleName: 'licenceHolder'
     emailAddress: 'acceptance-test.external@example.com'
     startDate: '2022-04-01'
     isTest: true
 
-- ref: $invoiceAccount
+- model: CompanyContact
+  fields:
+    companyId: $company02.companyId
+    contactId: $contact.contactId
+    roleName: 'licenceHolder'
+    emailAddress: 'acceptance-test.external@example.com'
+    startDate: '2019-01-01'
+    isTest: true
+
+- ref: $invoiceAccount01
   model: InvoiceAccount
   fields:
-    invoiceAccountNumber: A99999999A
+    invoiceAccountNumber: A00000001A
     startDate: '2022-04-01'
     endDate: null
-    companyId: $company.companyId
+    companyId: $company01.companyId
+    isTest: true
+
+- ref: $invoiceAccount02
+  model: InvoiceAccount
+  fields:
+    invoiceAccountNumber: A00000002A
+    startDate: '2019-01-01'
+    endDate: null
+    companyId: $company02.companyId
     isTest: true
 
 - model: InvoiceAccountAddress
   fields:
-    invoiceAccountId: $invoiceAccount.invoiceAccountId
+    invoiceAccountId: $invoiceAccount01.invoiceAccountId
     addressId: $address1.addressId
     agentCompanyId: null
     contactId: null
@@ -91,7 +135,17 @@
     endDate: null
     isTest: true
 
-- ref: $documentDaily
+- model: InvoiceAccountAddress
+  fields:
+    invoiceAccountId: $invoiceAccount02.invoiceAccountId
+    addressId: $address1.addressId
+    agentCompanyId: null
+    contactId: null
+    startDate: '2019-01-01'
+    endDate: null
+    isTest: true
+
+- ref: $documentDaily01
   model: Document
   fields:
     startDate: '2022-04-01'
@@ -101,13 +155,34 @@
     documentRef: 'AT/SROC/SUPB/01'
     isTest: true
 
+- ref: $documentDaily02
+  model: Document
+  fields:
+    startDate: '2019-01-01'
+    endDate: null
+    regime: water
+    documentType: abstraction_licence
+    documentRef: 'AT/SROC/SUPB/02'
+    isTest: true
+
 - model: DocumentRole
   fields:
-    documentId: $documentDaily.documentId
+    documentId: $documentDaily01.documentId
     role: licenceHolder
     startDate: '2022-04-01'
     endDate: null
-    companyId: $company.companyId
+    companyId: $company01.companyId
+    addressId: $address1.addressId
+    contactId: $contact.contactId
+    isTest: true
+
+- model: DocumentRole
+  fields:
+    documentId: $documentDaily02.documentId
+    role: licenceHolder
+    startDate: '2019-01-01'
+    endDate: null
+    companyId: $company02.companyId
     addressId: $address1.addressId
     contactId: $contact.contactId
     isTest: true

--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -11,7 +11,7 @@
   model: Licence
   fields:
     regionId: $region.regionId
-    licenceRef: 'AT/SROC/DAILY/01'
+    licenceRef: 'AT/SROC/SUPB/01'
     regions:
       historicalAreaCode: 'SAAR'
       regionalChargeArea: 'Southern'

--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -7,7 +7,7 @@
     displayName: Southern (Test replica)
     isTest: true
 
-- ref: $srocLicence
+- ref: $srocLicence01
   model: Licence
   fields:
     regionId: $region.regionId
@@ -19,10 +19,10 @@
     startDate: '2022-04-01'
     isTest: true
 
-- ref: $srocLicenceVersion
+- ref: $srocLicenceVersion01
   model: LicenceVersion
   fields:
-    licenceId: $srocLicence.licenceId
+    licenceId: $srocLicence01.licenceId
     issue : 1
     increment: 0
     status: 'current'

--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -19,6 +19,18 @@
     startDate: '2022-04-01'
     isTest: true
 
+- ref: $srocLicence02
+  model: Licence
+  fields:
+    regionId: $region.regionId
+    licenceRef: 'AT/SROC/SUPB/02'
+    regions:
+      historicalAreaCode: 'SAAR'
+      regionalChargeArea: 'Southern'
+    isWaterUndertaker: true
+    startDate: '2019-01-01'
+    isTest: true
+
 - ref: $srocLicenceVersion01
   model: LicenceVersion
   fields:
@@ -29,4 +41,16 @@
     startDate: '2022-01-01'
     endDate: null
     externalId: 6:1234:1:0
+    isTest: true
+
+- ref: $srocLicenceVersion02
+  model: LicenceVersion
+  fields:
+    licenceId: $srocLicence02.licenceId
+    issue : 1
+    increment: 0
+    status: 'current'
+    startDate: '2019-01-01'
+    endDate: null
+    externalId: 6:1234:2:0
     isTest: true

--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -3,8 +3,8 @@
   fields:
     chargeRegionId: S
     naldRegionId: 9
-    name: Southern (Test replica)
-    displayName: Southern (Test replica)
+    name: Sroc Supplementary Bill (Test)
+    displayName: Sroc Supplementary Bill (Test)
     isTest: true
 
 - ref: $srocLicence01

--- a/integration-tests/billing/fixtures/sroc-permits.yaml
+++ b/integration-tests/billing/fixtures/sroc-permits.yaml
@@ -1,4 +1,4 @@
-- ref: $srocLicence
+- ref: $srocLicence01
   model: Licence
   fields:
     licenceRef: 'AT/SROC/SUPB/01'

--- a/integration-tests/billing/fixtures/sroc-permits.yaml
+++ b/integration-tests/billing/fixtures/sroc-permits.yaml
@@ -1,5 +1,11 @@
-- ref: $srocLicence01
+- ref: $srocPermit01
   model: Licence
   fields:
     licenceRef: 'AT/SROC/SUPB/01'
     startDate: '2022-04-01'
+
+- ref: $srocPermit02
+  model: Licence
+  fields:
+    licenceRef: 'AT/SROC/SUPB/02'
+    startDate: '2019-01-01'

--- a/integration-tests/billing/fixtures/sroc-permits.yaml
+++ b/integration-tests/billing/fixtures/sroc-permits.yaml
@@ -1,5 +1,5 @@
 - ref: $srocLicence
   model: Licence
   fields:
-    licenceRef: 'AT/SROC/DAILY/01'
+    licenceRef: 'AT/SROC/SUPB/01'
     startDate: '2022-04-01'

--- a/integration-tests/billing/fixtures/sroc-purposes.yaml
+++ b/integration-tests/billing/fixtures/sroc-purposes.yaml
@@ -1,0 +1,28 @@
+- ref: $primaryPurpose
+  model: PurposePrimary
+  fields:
+    legacy_id: A
+    description: Agriculture
+  constraints:
+    purposes_primary_unq_legacy_id:
+      - legacyId
+
+- ref: $secondaryPurpose
+  model: PurposeSecondary
+  fields:
+    legacy_id: AGR
+    description: General Agriculture
+  constraints:
+    purposes_secondary_unq_legacy_id:
+      - legacyId
+
+- ref: $purposeUse
+  model: PurposeUse
+  fields:
+    legacy_id: 140
+    description: 'General Farming & Domestic'
+    lossFactor: 'medium'
+    isTwoPartTariff: false
+  constraints:
+    purposes_uses_unq_legacy_id:
+      - legacyId


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3787

We're adding to our new SROC fixture set a pres-roc licence that we will then update the billing account on.

In the UI this would mean updating both pre-sroc and sroc charge versions. In this scenario, the 'licence' would be picked up for SROC supplementary billing because we added a new SROC charge version. But the new presroc charge version would be ignored.