### PR TITLE
Add SROC sup. billing scenario 3 fixture data

### DIFF
--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -127,3 +127,86 @@
     purposePrimaryId: $primaryPurpose.purposePrimaryId
     purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
     purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargeVersion04
+  model: ChargeVersion
+  fields:
+    licenceRef: $srocLicence03.licenceRef
+    scheme: alcs
+    versionNumber: 1
+    startDate: '2015-01-01'
+    endDate: '2022-03-31'
+    status: current
+    regionCode: $region.naldRegionId
+    source: wrls
+    companyId: $company03.companyId
+    invoiceAccountId: $invoiceAccount03.invoiceAccountId
+    isTest: true
+    licenceId: $srocLicence03.licenceId
+
+- ref: $chargeElement04
+  model: ChargeElement
+  fields:
+    chargeVersionId: $chargeVersion04.chargeVersionId
+    factorsOverridden: false
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    description: 'PRESROC Charge Element 03'
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 15.54
+    season: 'all year'
+    seasonDerived: 'all year'
+    source: unsupported
+    loss: medium
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargeVersion05
+  model: ChargeVersion
+  fields:
+    licenceRef: $srocLicence03.licenceRef
+    scheme: sroc
+    versionNumber: 2
+    startDate: '2022-04-01'
+    endDate: null
+    status: current
+    regionCode: $region.naldRegionId
+    source: wrls
+    invoiceAccountId: $invoiceAccount03.invoiceAccountId
+    isTest: true
+    licenceId: $srocLicence03.licenceId
+
+- ref: $chargeElement05
+  model: ChargeElement
+  fields:
+    chargeVersionId: $chargeVersion05.chargeVersionId
+    description: 'SROC Charge Element 03'
+    source: tidal
+    loss: medium
+    isTest: true
+    scheme: sroc
+    isRestrictedSource: false
+    waterModel: 'no model'
+    volume: 100
+    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    eiucRegion: Southern
+
+- ref: $chargePurpose03
+  model: ChargePurpose
+  fields:
+    chargeElementId: $chargeElement05.chargeElementId
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 15.54
+    loss: medium
+    factorsOverridden: false
+    description: 'SROC Charge Purpose 03'
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId

--- a/integration-tests/billing/fixtures/sroc-crm-v1.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v1.yaml
@@ -19,6 +19,13 @@
     entity_type: 'company'
     source: 'acceptance-test-setup'
 
+- ref: $companyEntity03
+  model: Entity
+  fields:
+    entity_nm: 'Big Farm Co Ltd 03'
+    entity_type: 'company'
+    source: 'acceptance-test-setup'
+
 - model: EntityRole
   fields:
     entityId: $userEntity.entity_id
@@ -30,6 +37,13 @@
   fields:
     entityId: $userEntity.entity_id
     company_entity_id: $companyEntity02.entity_id
+    role: 'primary_user'
+    created_by: 'acceptance-test-setup'
+
+- model: EntityRole
+  fields:
+    entityId: $userEntity.entity_id
+    company_entity_id: $companyEntity03.entity_id
     role: 'primary_user'
     created_by: 'acceptance-test-setup'
 
@@ -56,5 +70,18 @@
     document_name: 'Big Farm 02 permit'
     metadata:
       Name: 'Big Farm 02'
+      dataType: 'acceptance-test-setup'
+      IsCurrent: true
+
+- model: DocumentHeader
+  fields:
+    regime_entity_id: '0434dc31-a34e-7158-5775-4694af7a60cf'
+    system_id: 'permit-repo'
+    system_external_id: 'AT/SROC/SUPB/03'
+    company_entity_id: $companyEntity03.entity_id
+    system_internal_id: $srocPermit03.licence_id
+    document_name: 'Big Farm 03 permit'
+    metadata:
+      Name: 'Big Farm 03'
       dataType: 'acceptance-test-setup'
       IsCurrent: true

--- a/integration-tests/billing/fixtures/sroc-crm-v2.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v2.yaml
@@ -14,6 +14,14 @@
     companyNumber: '1234502'
     isTest: true
 
+- ref: $company03
+  model: Company
+  fields:
+    name: Big Farm Co Ltd 03
+    type: organisation
+    companyNumber: '1234503'
+    isTest: true
+
 - ref: $address1
   model: Address
   fields:
@@ -78,6 +86,24 @@
     endDate: null
     isTest: true
 
+- model: CompanyAddress
+  fields:
+    roleName: billing
+    companyId: $company03.companyId
+    addressId: $address1.addressId
+    startDate: '2015-01-01'
+    endDate: null
+    isTest: true
+
+- model: CompanyAddress
+  fields:
+    roleName: billing
+    companyId: $company03.companyId
+    addressId: $address2.addressId
+    startDate: '2015-01-01'
+    endDate: null
+    isTest: true
+
 - ref: $contact
   model: Contact
   fields:
@@ -107,6 +133,15 @@
     startDate: '2019-01-01'
     isTest: true
 
+- model: CompanyContact
+  fields:
+    companyId: $company03.companyId
+    contactId: $contact.contactId
+    roleName: 'licenceHolder'
+    emailAddress: 'acceptance-test.external@example.com'
+    startDate: '2015-01-01'
+    isTest: true
+
 - ref: $invoiceAccount01
   model: InvoiceAccount
   fields:
@@ -123,6 +158,15 @@
     startDate: '2019-01-01'
     endDate: null
     companyId: $company02.companyId
+    isTest: true
+
+- ref: $invoiceAccount03
+  model: InvoiceAccount
+  fields:
+    invoiceAccountNumber: A00000003A
+    startDate: '2015-01-01'
+    endDate: null
+    companyId: $company03.companyId
     isTest: true
 
 - model: InvoiceAccountAddress
@@ -142,6 +186,16 @@
     agentCompanyId: null
     contactId: null
     startDate: '2019-01-01'
+    endDate: null
+    isTest: true
+
+- model: InvoiceAccountAddress
+  fields:
+    invoiceAccountId: $invoiceAccount03.invoiceAccountId
+    addressId: $address1.addressId
+    agentCompanyId: null
+    contactId: null
+    startDate: '2015-01-01'
     endDate: null
     isTest: true
 
@@ -165,6 +219,16 @@
     documentRef: 'AT/SROC/SUPB/02'
     isTest: true
 
+- ref: $documentDaily03
+  model: Document
+  fields:
+    startDate: '2015-01-01'
+    endDate: null
+    regime: water
+    documentType: abstraction_licence
+    documentRef: 'AT/SROC/SUPB/03'
+    isTest: true
+
 - model: DocumentRole
   fields:
     documentId: $documentDaily01.documentId
@@ -183,6 +247,17 @@
     startDate: '2019-01-01'
     endDate: null
     companyId: $company02.companyId
+    addressId: $address1.addressId
+    contactId: $contact.contactId
+    isTest: true
+
+- model: DocumentRole
+  fields:
+    documentId: $documentDaily03.documentId
+    role: licenceHolder
+    startDate: '2015-01-01'
+    endDate: null
+    companyId: $company03.companyId
     addressId: $address1.addressId
     contactId: $contact.contactId
     isTest: true

--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -31,6 +31,18 @@
     startDate: '2019-01-01'
     isTest: true
 
+- ref: $srocLicence03
+  model: Licence
+  fields:
+    regionId: $region.regionId
+    licenceRef: 'AT/SROC/SUPB/03'
+    regions:
+      historicalAreaCode: 'SAAR'
+      regionalChargeArea: 'Southern'
+    isWaterUndertaker: true
+    startDate: '2015-01-01'
+    isTest: true
+
 - ref: $srocLicenceVersion01
   model: LicenceVersion
   fields:
@@ -53,4 +65,16 @@
     startDate: '2019-01-01'
     endDate: null
     externalId: 6:1234:2:0
+    isTest: true
+
+- ref: $srocLicenceVersion03
+  model: LicenceVersion
+  fields:
+    licenceId: $srocLicence03.licenceId
+    issue : 1
+    increment: 0
+    status: 'current'
+    startDate: '2015-01-01'
+    endDate: null
+    externalId: 6:1234:3:0
     isTest: true

--- a/integration-tests/billing/fixtures/sroc-permits.yaml
+++ b/integration-tests/billing/fixtures/sroc-permits.yaml
@@ -9,3 +9,9 @@
   fields:
     licenceRef: 'AT/SROC/SUPB/02'
     startDate: '2019-01-01'
+
+- ref: $srocPermit03
+  model: Licence
+  fields:
+    licenceRef: 'AT/SROC/SUPB/03'
+    startDate: '2015-01-01'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3787

This adds the fixture data for our 3rd scenario; a licence with a PRESROC and SROC charge version. Only in our test for this, the PRESROC charge version is beyond the 5-year window. So, when the change is made it should _not_ be included in a PRESROC bill run.

The SROC charge version should still be though!