### PR TITLE
Stop passing err to logger

### DIFF
--- a/index-background.js
+++ b/index-background.js
@@ -86,12 +86,12 @@ const start = async function () {
       server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error('Failed to start server', err)
+    logger.error('Failed to start server', err.stack)
   }
 }
 
 const _processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/index.js
+++ b/index.js
@@ -112,12 +112,12 @@ const start = async function () {
       server.log('info', `Service ${name} running at: ${uri}`)
     }
   } catch (err) {
-    logger.error('Failed to start server', err)
+    logger.error('Failed to start server', err.stack)
   }
 }
 
 const _processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/integration-tests/billing/services/connectors/returns.js
+++ b/integration-tests/billing/services/connectors/returns.js
@@ -5,9 +5,9 @@ const { logger } = require('../../../../src/logger')
 
 const createUrl = urlTail => urlJoin(config.services.returns, urlTail)
 
-const createEntity = url => body => serviceRequest.post(url, { body }).catch(err => logger.error(err))
+const createEntity = url => body => serviceRequest.post(url, { body }).catch(err => logger.error(err.stack))
 
-const tearDown = url => () => serviceRequest.delete(url).catch(err => logger.error(err))
+const tearDown = url => () => serviceRequest.delete(url).catch(err => logger.error(err.stack))
 
 exports.createReturn = createEntity(createUrl('returns'))
 exports.createVersions = createEntity(createUrl('versions'))

--- a/src/lib/queue-manager/queue-manager.js
+++ b/src/lib/queue-manager/queue-manager.js
@@ -189,7 +189,7 @@ class QueueManager {
     try {
       await queue.close()
     } catch (err) {
-      logger.error(`Error closing queue ${name}`, err)
+      logger.error(`Error closing queue ${name}`, err.stack)
     }
   }
 
@@ -197,7 +197,7 @@ class QueueManager {
     try {
       await worker.close()
     } catch (err) {
-      logger.error(`Error closing worker ${name}`, err)
+      logger.error(`Error closing worker ${name}`, err.stack)
     }
   }
 

--- a/src/lib/slack.js
+++ b/src/lib/slack.js
@@ -26,7 +26,7 @@ function post (message) {
 
   return rp(options)
     .catch((err) => {
-      logger.error('Slack error', err)
+      logger.error('Slack error', err.stack)
     })
 }
 

--- a/src/modules/acceptance-tests/lib/connectors/returns.js
+++ b/src/modules/acceptance-tests/lib/connectors/returns.js
@@ -5,9 +5,9 @@ const { logger } = require('../../../../logger')
 
 const createUrl = urlTail => urlJoin(config.services.returns, urlTail)
 
-const createEntity = url => body => serviceRequest.post(url, { body }).catch(err => logger.error(err))
+const createEntity = url => body => serviceRequest.post(url, { body }).catch(err => logger.error(err.stack))
 
-const tearDown = url => () => serviceRequest.delete(url).catch(err => logger.error(err))
+const tearDown = url => () => serviceRequest.delete(url).catch(err => logger.error(err.stack))
 
 exports.createReturn = createEntity(createUrl('returns'))
 exports.createVersions = createEntity(createUrl('versions'))

--- a/src/modules/addresses/controller.js
+++ b/src/modules/addresses/controller.js
@@ -11,7 +11,7 @@ const postAddress = async request => {
     const model = addressMapper.uiToModel(request.payload)
     return await addressService.createAddress(model, email)
   } catch (err) {
-    logger.error('Error creating address', err)
+    logger.error('Error creating address', err.stack)
     return mapErrorResponse(err)
   }
 }

--- a/src/modules/ar-analysis/controller.js
+++ b/src/modules/ar-analysis/controller.js
@@ -24,7 +24,7 @@ const getUpdateLicence = async (request, h) => {
     const result = await updateLicence.updateLicenceRow(licenceRef)
     return result
   } catch (error) {
-    logger.error('Failed to update AR licence', error, { licenceRef })
+    logger.error('Failed to update AR licence', error.stack, { licenceRef })
     throw Boom.badImplementation(`Unable to update AR licence analysis row for ${licenceRef}`)
   }
 }

--- a/src/modules/ar-analysis/lib/update-licence-row.js
+++ b/src/modules/ar-analysis/lib/update-licence-row.js
@@ -90,7 +90,7 @@ const updateAllLicences = async () => {
     try {
       await updateLicenceRow(licenceNumber)
     } catch (error) {
-      logger.error('Error updating all licences', error, { row })
+      logger.error('Error updating all licences', error.stack, { row })
     }
   }
 }

--- a/src/modules/batch-notifications/config/water-abstraction-alerts/lib/get-recipients.js
+++ b/src/modules/batch-notifications/config/water-abstraction-alerts/lib/get-recipients.js
@@ -101,7 +101,7 @@ const getRecipients = async eventData => {
 
         licenceNumbers.push(linkage.licenceRef)
       } catch (e) {
-        logger.error(e)
+        logger.error(e.stack)
       }
     }
   }

--- a/src/modules/batch-notifications/controller.js
+++ b/src/modules/batch-notifications/controller.js
@@ -47,7 +47,7 @@ const postPrepare = async (request, h) => {
     }
   } catch (err) {
     const code = get(err, 'output.statusCode', 500)
-    logger.error('Batch notification preparation error', err, { messageType, issuer, data })
+    logger.error('Batch notification preparation error', err.stack, { messageType, issuer, data })
     return h.response({
       error: err.message,
       data: null
@@ -70,7 +70,7 @@ const postSend = async request => {
 
     return { error: null, data: event }
   } catch (err) {
-    logger.error('Batch notification send error', err, { eventId })
+    logger.error('Batch notification send error', err.stack, { eventId })
     return mapErrorResponse(err)
   }
 }

--- a/src/modules/batch-notifications/lib/jobs/check-status.js
+++ b/src/modules/batch-notifications/lib/jobs/check-status.js
@@ -45,7 +45,7 @@ const handleCheckStatus = async messageId => {
 
     await scheduledNotifications.repository.update({ id: messageId }, data)
   } catch (err) {
-    logger.error('Error checking notify status', err, { messageId })
+    logger.error('Error checking notify status', err.stack, { messageId })
   }
 }
 
@@ -56,12 +56,12 @@ const handler = async job => {
     logger.info(`Checking notify statuses - ${batch.length} item(s) found`)
     await Promise.all((batch.map(({ id }) => handleCheckStatus(id))))
   } catch (err) {
-    logger.error(`Error handling: ${job.id}`, err, job.data)
+    logger.error(`Error handling: ${job.id}`, err.stack, job.data)
   }
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/batch-notifications/lib/jobs/get-recipients.js
+++ b/src/modules/batch-notifications/lib/jobs/get-recipients.js
@@ -28,13 +28,13 @@ const handleGetRecipients = async job => {
     // Use config.getRecipients to get recipient list for this notification
     await data.config.getRecipients(data)
   } catch (err) {
-    logger.error('Batch notifications handleGetRecipients error', err, { eventId })
+    logger.error('Batch notifications handleGetRecipients error', err.stack, { eventId })
     await eventsService.updateStatus(eventId, EVENT_STATUS_ERROR)
   }
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/batch-notifications/lib/jobs/refresh-event.js
+++ b/src/modules/batch-notifications/lib/jobs/refresh-event.js
@@ -25,7 +25,7 @@ const handleRefreshEvent = async eventId => {
   try {
     await eventHelpers.refreshEventStatus(eventId)
   } catch (err) {
-    logger.error('Error refreshing batch message event', err, { eventId })
+    logger.error('Error refreshing batch message event', err.stack, { eventId })
   }
 }
 
@@ -36,12 +36,12 @@ const handler = async job => {
     logger.info(`Refreshing notify message events - ${batch.length} item(s) found`)
     await Promise.all((batch.map(({ event_id: id }) => handleRefreshEvent(id))))
   } catch (err) {
-    logger.error(`Error handling: ${job.id}`, err)
+    logger.error(`Error handling: ${job.id}`, err.stack)
   }
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/batch-notifications/lib/jobs/send-message.js
+++ b/src/modules/batch-notifications/lib/jobs/send-message.js
@@ -39,7 +39,7 @@ const handleSendMessage = async messageId => {
     const notifyResponse = await notify.send(scheduledNotification)
     await scheduledNotificationService.updateScheduledNotificationWithNotifyResponse(messageId, notifyResponse)
   } catch (err) {
-    logger.error('Error sending batch message', err, { messageId })
+    logger.error('Error sending batch message', err.stack, { messageId })
     await messageHelpers.markMessageAsErrored(messageId, err)
   }
 }
@@ -51,12 +51,12 @@ const handler = async job => {
     logger.info(`Sending notify messages - ${batch.length} item(s) found`)
     await Promise.all((batch.map(({ id }) => handleSendMessage(id))))
   } catch (err) {
-    logger.error(`Error handling: ${job.id}`, err, job.data)
+    logger.error(`Error handling: ${job.id}`, err.stack, job.data)
   }
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -185,7 +185,7 @@ const deleteAllBillingData = async (request, h) => {
     await importConnector.postImportChargeVersions()
     return h.response().code(204)
   } catch (err) {
-    logger.error('Error deleting all billing data', err)
+    logger.error('Error deleting all billing data', err.stack)
     return mapErrorResponse(err)
   }
 }

--- a/src/modules/billing/jobs/check-for-updated-invoice-accounts.js
+++ b/src/modules/billing/jobs/check-for-updated-invoice-accounts.js
@@ -43,7 +43,7 @@ const handler = async (job) => {
 }
 
 const onFailed = (job, err) => {
-  logger.error(`Job ${job.name} ${job.id} failed`, err)
+  logger.error(`Job ${job.name} ${job.id} failed`, err.stack)
 }
 
 exports.jobName = JOB_NAME

--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -129,7 +129,7 @@ const onFailedHandler = async (job, err) => {
       logger.error(`Transaction with id ${transactionId} not generated in CM after ${job.attemptsMade} attempts, marking batch as errored ${batchId}`)
       await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToCreateCharge)
     } catch (error) {
-      logger.error(`Unable to set batch status ${batchId}`, error)
+      logger.error(`Unable to set batch status ${batchId}`, error.stack)
     }
   } else {
     // Do normal error logging

--- a/src/modules/billing/jobs/customer-file-refresh.js
+++ b/src/modules/billing/jobs/customer-file-refresh.js
@@ -33,7 +33,7 @@ const handler = async job => {
 }
 
 const onFailedHandler = async (job, err) =>
-  logger.error('Failed to fetch customer file data from the charging module', err)
+  logger.error('Failed to fetch customer file data from the charging module', err.stack)
 
 const onComplete = async () => {
   logger.info(`${JOB_NAME}: Job has completed`)

--- a/src/modules/billing/jobs/lib/batch-job.js
+++ b/src/modules/billing/jobs/lib/batch-job.js
@@ -14,11 +14,11 @@ const logOnComplete = job => {
 }
 
 const logOnCompleteError = (job, error) => {
-  logger.error(`Error handling onComplete: ${job.id}`, error, job.data)
+  logger.error(`Error handling onComplete: ${job.id}`, error.stack, job.data)
 }
 
 const logHandlingError = (job, error) => {
-  logger.error(`Error handling: ${job.id}`, error, job.data)
+  logger.error(`Error handling: ${job.id}`, error.stack, job.data)
 }
 
 /**

--- a/src/modules/billing/jobs/lib/helpers.js
+++ b/src/modules/billing/jobs/lib/helpers.js
@@ -13,7 +13,7 @@ const createMessage = (jobName, batchId) => {
 }
 
 const onFailedHandler = (job, err) => {
-  logger.error(`Job ${job.name} ${job.id} failed`, err)
+  logger.error(`Job ${job.name} ${job.id} failed`, err.stack)
 }
 
 const isFinalAttempt = job => job.attemptsMade >= job.opts.attempts

--- a/src/modules/billing/jobs/rebilling.js
+++ b/src/modules/billing/jobs/rebilling.js
@@ -81,7 +81,7 @@ const onFailedHandler = async (job, err) => {
       logger.error(`Rebilling failed ${batchId}`)
       await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToProcessRebilling)
     } catch (error) {
-      logger.error(`Unable to set batch status ${batchId}`, error)
+      logger.error(`Unable to set batch status ${batchId}`, error.stack)
     }
   } else {
     // Do normal error logging

--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -70,7 +70,7 @@ const onFailedHandler = async (job, err) => {
       logger.error(`CM bill run summary not generated after ${job.attemptsMade} attempts, marking batch as errored ${batchId}`)
       await batchService.setErrorStatus(batchId, BATCH_ERROR_CODE.failedToGetChargeModuleBillRunSummary)
     } catch (error) {
-      logger.error(`Unable to set batch status ${batchId}`, error)
+      logger.error(`Unable to set batch status ${batchId}`, error.stack)
     }
   } else if (err.name === 'StateError') {
     // Only logger an info message if we the CM has not generated bill run summary - this is expected

--- a/src/modules/billing/jobs/sync-charge-categories.js
+++ b/src/modules/billing/jobs/sync-charge-categories.js
@@ -78,7 +78,7 @@ const handler = async () => {
 }
 
 const onFailedHandler = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/billing/jobs/update-customer.js
+++ b/src/modules/billing/jobs/update-customer.js
@@ -30,7 +30,7 @@ const handler = async job => {
     const invoiceAccountMappedData = await chargeModuleMappers.mapInvoiceAccountToChargeModuleCustomer(invoiceAccountData)
     return chargeModuleCustomersConnector.updateCustomer(invoiceAccountMappedData)
   } catch (e) {
-    logger.error(new Error('Could not update CM with customer details.', e))
+    logger.error(new Error('Could not update CM with customer details.', e.stack))
     return new Error('Could not update CM with customer details.')
   }
 }
@@ -40,7 +40,7 @@ const onComplete = job => {
 }
 
 const onFailedHandler = (job, err) => {
-  logger.error(`onFailed: Job ${job.name} ${job.id} failed`, err)
+  logger.error(`onFailed: Job ${job.name} ${job.id} failed`, err.stack)
 }
 
 exports.jobName = JOB_NAME

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -141,7 +141,7 @@ const deleteBatch = async (batch, internalCallingUser) => {
 
     await saveEvent('billing-batch:cancel', 'delete', internalCallingUser, batch)
   } catch (err) {
-    logger.error('Failed to delete the batch', err, batch)
+    logger.error('Failed to delete the batch', err.stack, batch)
     await saveEvent('billing-batch:cancel', 'error', internalCallingUser, batch)
     await setStatus(batch.id, BATCH_STATUS.error)
     throw err
@@ -193,7 +193,7 @@ const approveBatch = async (batch, internalCallingUser) => {
 
     return batch
   } catch (err) {
-    logger.error('Failed to approve the batch', err, batch)
+    logger.error('Failed to approve the batch', err.stack, batch)
     // set the status back to ready so the user can retry
     await setStatus(batch.id, BATCH_STATUS.ready)
     await saveEvent('billing-batch:approve', 'error', internalCallingUser, batch)
@@ -453,7 +453,7 @@ const deleteAllBillingData = async () => {
       logger.info(`Deleting Charge Module batch ${externalId}`)
       await chargeModuleBillRunConnector.delete(externalId)
     } catch (err) {
-      logger.error(`Unable to delete Charge Module batch ${externalId}`, err)
+      logger.error(`Unable to delete Charge Module batch ${externalId}`, err.stack)
     }
   }
   // Delete all data in water.billing_* tables

--- a/src/modules/billing/services/invoice-licences-service.js
+++ b/src/modules/billing/services/invoice-licences-service.js
@@ -72,7 +72,7 @@ const deleteByInvoiceLicenceId = async invoiceLicenceId => {
     // Publish refresh totals job
     return queueManager.getQueueManager().add(refreshTotalsJob.jobName, batchId)
   } catch (err) {
-    logger.error(`Failed to delete invoice licence ${invoiceLicenceId} in batch ${batchId}`, err)
+    logger.error(`Failed to delete invoice licence ${invoiceLicenceId} in batch ${batchId}`, err.stack)
     // Set batch to "error" status
     await batchService.setStatus(batchId, Batch.BATCH_STATUS.error)
     throw err

--- a/src/modules/billing/services/supplementary-billing-service/index.js
+++ b/src/modules/billing/services/supplementary-billing-service/index.js
@@ -16,7 +16,7 @@ const processBatch = async batchId => {
 
     return await dataService.persistChanges(batchId, processedTransactions)
   } catch (err) {
-    logger.error(`Supplementary processing error for batch ${batchId}`, err)
+    logger.error(`Supplementary processing error for batch ${batchId}`, err.stack)
     throw err
   }
 }

--- a/src/modules/billing/services/transactions-service.js
+++ b/src/modules/billing/services/transactions-service.js
@@ -74,7 +74,7 @@ const updateTransactionWithChargeModuleResponse = (transactionId, response) => {
   }
 
   const err = new Error('Charge module error')
-  logger.error('Unexpected create transaction response from charge module', err, { transactionId, response })
+  logger.error('Unexpected create transaction response from charge module', err.stack, { transactionId, response })
   throw err
 }
 

--- a/src/modules/charge-versions-upload/jobs/update-charge-information-save.js
+++ b/src/modules/charge-versions-upload/jobs/update-charge-information-save.js
@@ -89,7 +89,7 @@ const handleUpdateChargeInformation = async job => {
     set(event, 'status', chargeInformationUpload.uploadStatus.READY)
     return await eventsService.update(event)
   } catch (error) {
-    logger.error('Creation and Update of Charge versions failed', error, { eventId })
+    logger.error('Creation and Update of Charge versions failed', error.stack, { eventId })
     await errorEvent.setEventError(event, error)
     throw error
   }
@@ -97,7 +97,7 @@ const handleUpdateChargeInformation = async job => {
 
 const onFailed = async (_job, err) => {
   helpers.clearCache()
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/charge-versions-upload/jobs/update-charge-information-start.js
+++ b/src/modules/charge-versions-upload/jobs/update-charge-information-start.js
@@ -83,7 +83,7 @@ const handleChargeInformationUploadStart = async job => {
     await validateS3Object(s3Object, event)
     await helpers.updateEventStatus(event, 'validation complete', JOB_NAME)
   } catch (error) {
-    logger.error('Charge information upload failure', error, { job })
+    logger.error('Charge information upload failure', error.stack, { job })
     if (error.key === errorEvent.keys.csv.INVALID_ROWS) {
       await uploadErrorFile(event, error)
       error.validationErrors = ['Invalid row data']
@@ -95,7 +95,7 @@ const handleChargeInformationUploadStart = async job => {
 
 const onFailed = async (_job, err) => {
   helpers.clearCache()
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async (job, queueManager) => {

--- a/src/modules/charge-versions-upload/jobs/update-charge-information-to-json.js
+++ b/src/modules/charge-versions-upload/jobs/update-charge-information-to-json.js
@@ -79,7 +79,7 @@ const handleChargeInformationMapToJsonStart = async job => {
     event.status = uploadStatus.VALIDATED
     return await eventsService.update(event)
   } catch (error) {
-    logger.error(`Failed to convert ${filename} to JSON`, error, { job })
+    logger.error(`Failed to convert ${filename} to JSON`, error.stack, { job })
     await errorEvent.setEventError(event, error)
     throw error
   }
@@ -100,7 +100,7 @@ const uploadJsonToS3 = (event, json) => {
 
 const onFailed = async (_job, err) => {
   helpers.clearCache()
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async (job, queueManager) => {

--- a/src/modules/charge-versions/controllers/charge-version-workflow.js
+++ b/src/modules/charge-versions/controllers/charge-version-workflow.js
@@ -72,7 +72,7 @@ const patchChargeVersionWorkflow = async (request, h) => {
     try {
       changes.createdBy = userMapper.pojoToModel(createdBy)
     } catch (err) {
-      logger.error('Error mapping user', err)
+      logger.error('Error mapping user', err.stack)
       return Boom.badData('Invalid user in charge version data')
     }
   }

--- a/src/modules/charge-versions/controllers/charge-versions.js
+++ b/src/modules/charge-versions/controllers/charge-versions.js
@@ -78,7 +78,7 @@ const postCreateFromWorkflow = async request => {
     const approvedBy = userMapper.pojoToModel(request.defra.internalCallingUser)
     return chargeVersionWorkflowService.approve(chargeVersionWorkflow, approvedBy)
   } catch (err) {
-    logger.error(`Error creating charge version from workflow ${chargeVersionWorkflowId}`, err)
+    logger.error(`Error creating charge version from workflow ${chargeVersionWorkflowId}`, err.stack)
     return mapErrorResponse(err)
   }
 }
@@ -114,7 +114,7 @@ const postUpload = async (request, h) => {
       error: null
     }).code(202)
   } catch (error) {
-    logger.error('Failed to upload charge information', error)
+    logger.error('Failed to upload charge information', error.stack)
     if (event.id) {
       event.status = uploadStatus.ERROR
       await eventsService.update(event)

--- a/src/modules/charge-versions/controllers/pre-handlers.js
+++ b/src/modules/charge-versions/controllers/pre-handlers.js
@@ -12,7 +12,7 @@ const mapOrThrowBoom = (entityName, data, mapper) => {
   try {
     return mapper.pojoToModel(data)
   } catch (err) {
-    logger.error(`Error mapping ${entityName}`, err)
+    logger.error(`Error mapping ${entityName}`, err.stack)
     return Boom.badData('Invalid charge version data')
   }
 }

--- a/src/modules/charge-versions/jobs/create-charge-version-workflows.js
+++ b/src/modules/charge-versions/jobs/create-charge-version-workflows.js
@@ -31,13 +31,13 @@ const handler = async job => {
     const chargeVersionWorkflow = await chargeVersionWorkflowService.create(licence, null, null, CHARGE_VERSION_WORKFLOW_STATUS.toSetup, licenceVersionId)
     return { chargeVersionWorkflowId: chargeVersionWorkflow.id }
   } catch (err) {
-    logger.error(`Error handling: ${job.id}`, err, job.data)
+    logger.error(`Error handling: ${job.id}`, err.stack, job.data)
     throw err
   }
 }
 
 const onFailed = (job, err) => {
-  logger.error(`Job ${job.name} ${job.id} failed`, err)
+  logger.error(`Job ${job.name} ${job.id} failed`, err.stack)
 }
 
 exports.handler = handler

--- a/src/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.js
+++ b/src/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.js
@@ -40,7 +40,7 @@ const onComplete = async (job, queueManager) => {
 }
 
 const onFailed = (job, err) => {
-  logger.error(`Job ${job.name} ${job.id} failed`, err)
+  logger.error(`Job ${job.name} ${job.id} failed`, err.stack)
 }
 
 exports.jobName = JOB_NAME

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -126,7 +126,7 @@ const setOrThrowInvalidEntityError = (chargeVersionWorkflow, changes) => {
   try {
     return chargeVersionWorkflow.fromHash(changes)
   } catch (err) {
-    logger.error(err)
+    logger.error(err.stack)
     throw new InvalidEntityError(`Invalid data for charge version workflow ${chargeVersionWorkflow.id}`)
   }
 }

--- a/src/modules/companies-house/services/companies-house-service.js
+++ b/src/modules/companies-house/services/companies-house-service.js
@@ -43,7 +43,7 @@ const getCompany = async companyNumber => {
       address: companiesHouseMapper.mapAddress(data.registered_office_address)
     }
   } catch (err) {
-    logger.error('Companies house API error', err)
+    logger.error('Companies house API error', err.stack)
     return null
   }
 }

--- a/src/modules/companies/controller.js
+++ b/src/modules/companies/controller.js
@@ -109,7 +109,7 @@ const createCompanyInvoiceAccount = async (request, h) => {
 
     return h.response(created).code(201)
   } catch (err) {
-    logger.error('Error saving invoice account', err)
+    logger.error('Error saving invoice account', err.stack)
     return mapErrorResponse(err)
   }
 }

--- a/src/modules/gauging-stations/controller.js
+++ b/src/modules/gauging-stations/controller.js
@@ -75,7 +75,7 @@ const createLicenceGaugingStationLink = async request => {
     const {
       licenceId
     } = request.payload
-    logger.error(`Something went wrong when attempting to link licence ${licenceId} to station ${gaugingStationId}`, e)
+    logger.error(`Something went wrong when attempting to link licence ${licenceId} to station ${gaugingStationId}`, e.stack)
     return e
   }
 }
@@ -89,7 +89,7 @@ const deleteLicenceGaugingStationLink = async request => {
     }
     return licenceGaugingStationsService.deleteLicenceLink(licenceGaugingStationId)
   } catch (e) {
-    logger.error(`Something went wrong when attempting to destroy the linkage with ID ${licenceGaugingStationId}`, e)
+    logger.error(`Something went wrong when attempting to destroy the linkage with ID ${licenceGaugingStationId}`, e.stack)
     return e
   }
 }

--- a/src/modules/gauging-stations/jobs/sync-gauging-stations.js
+++ b/src/modules/gauging-stations/jobs/sync-gauging-stations.js
@@ -65,7 +65,7 @@ const handler = async () => {
 }
 
 const onFailedHandler = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/gauging-stations/jobs/sync-licence-gauging-stations-from-digitise.js
+++ b/src/modules/gauging-stations/jobs/sync-licence-gauging-stations-from-digitise.js
@@ -136,7 +136,7 @@ const handler = async () => {
 }
 
 const onFailedHandler = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
+++ b/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
@@ -86,7 +86,7 @@ const handler = async () => {
 }
 
 const onFailedHandler = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/import/lib/db.js
+++ b/src/modules/import/lib/db.js
@@ -16,7 +16,7 @@ const dbQuery = async (query, params = []) => {
     }
     return rows
   } catch (error) {
-    logger.error('dbQuery error', error)
+    logger.error('dbQuery error', error.stack)
     throw error
   }
 }

--- a/src/modules/internal-search/controller.js
+++ b/src/modules/internal-search/controller.js
@@ -51,7 +51,7 @@ const getInternalSearch = async (request) => {
   try {
     response = await buildInternalSearchResponse(request, response)
   } catch (err) {
-    logger.error('Internal search error', err)
+    logger.error('Internal search error', err.stack)
   }
 
   return response

--- a/src/modules/licences/controllers/documents.js
+++ b/src/modules/licences/controllers/documents.js
@@ -87,7 +87,7 @@ const handleUnexpectedError = (error, documentId) => {
     return Boom.notFound('Not found', error)
   }
 
-  logger.error('Failed to get licence data for document', error, { documentId })
+  logger.error('Failed to get licence data for document', error.stack, { documentId })
   return Boom.boomify(error)
 }
 

--- a/src/modules/licences/controllers/invoices.js
+++ b/src/modules/licences/controllers/invoices.js
@@ -9,7 +9,7 @@ const getLicenceInvoices = async request => {
   try {
     return licencesService.getLicenceInvoices(licenceId, page, perPage)
   } catch (error) {
-    logger.error('Failed to get bills for licence', error, { licenceId })
+    logger.error('Failed to get bills for licence', error.stack, { licenceId })
     return mapErrorResponse(error)
   }
 }

--- a/src/modules/notifications/lib/index.js
+++ b/src/modules/notifications/lib/index.js
@@ -80,7 +80,7 @@ async function sendNotification (queueManager, taskConfig, issuer, contactData, 
     try {
       await enqueue(queueManager, n)
     } catch (error) {
-      logger.error('Error sending notification', error)
+      logger.error('Error sending notification', error.stack)
     }
   }
 

--- a/src/modules/notifications/lib/notification-factory.js
+++ b/src/modules/notifications/lib/notification-factory.js
@@ -74,7 +74,7 @@ async function notificationFactory (contactData, taskConfig, event) {
 
     return options
   } catch (error) {
-    logger.error('Notification Factory error', error)
+    logger.error('Notification Factory error', error.stack)
     return { error }
   }
 }

--- a/src/modules/notify/lib/notify-send.js
+++ b/src/modules/notify/lib/notify-send.js
@@ -102,14 +102,14 @@ const handleNotifySend = async job => {
   try {
     await sendAndRetry(id)
   } catch (err) {
-    logger.error('Failed to send', err)
+    logger.error('Failed to send', err.stack)
     throw err
   }
 }
 
 const onComplete = async () => logger.info(`${JOB_NAME}: Job has completed`)
 
-const onFailed = async (job, err) => logger.error(`${JOB_NAME}: Job has failed`, err)
+const onFailed = async (job, err) => logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 
 exports.send = send
 exports.createMessage = createMessage

--- a/src/modules/returns-notifications/lib/returns-notification-send.js
+++ b/src/modules/returns-notifications/lib/returns-notification-send.js
@@ -30,7 +30,7 @@ const onComplete = async (job, queueManager) => {
   logger.info(`${JOB_NAME}: Job has completed`)
 }
 
-const onFailed = async (job, err) => logger.error(`${JOB_NAME}: Job has failed`, err)
+const onFailed = async (job, err) => logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 
 exports.createMessage = createMessage
 exports.handler = handleReturnsNotificationSend

--- a/src/modules/returns/controllers/csv-upload.js
+++ b/src/modules/returns/controllers/csv-upload.js
@@ -53,7 +53,7 @@ const postUpload = async (request, h) => {
       error: null
     }).code(202)
   } catch (error) {
-    logger.error('Failed to upload bulk returns', error)
+    logger.error('Failed to upload bulk returns', error.stack)
     if (event.id) {
       event.status = uploadStatus.ERROR
       await eventsService.update(event)
@@ -95,7 +95,7 @@ const getUploadPreviewReturn = async (request, h) => {
       }
     }
   } catch (error) {
-    logger.error('Return upload preview failed', error, request.params)
+    logger.error('Return upload preview failed', error.stack, request.params)
     throw error
   }
 }
@@ -156,7 +156,7 @@ const postUploadSubmit = async (request, h) => {
 
     return { data: request.jsonData, error: null }
   } catch (error) {
-    logger.error('Return upload preview failed', error, { eventId, companyId })
+    logger.error('Return upload preview failed', error.stack, { eventId, companyId })
     throw error
   }
 }

--- a/src/modules/returns/lib/api-connector.js
+++ b/src/modules/returns/lib/api-connector.js
@@ -125,7 +125,7 @@ const fetchLines = async (returnId, versionId) => {
   const { data, error } = await lines.findMany(filter, sort, pagination)
   if (error) {
     const params = { returnId, versionId }
-    logger.error('Failed to fetch lines for return', error, params)
+    logger.error('Failed to fetch lines for return', error.stack, params)
     throw Boom.boomify(error)
   }
   return data

--- a/src/modules/returns/lib/jobs/map-to-json.js
+++ b/src/modules/returns/lib/jobs/map-to-json.js
@@ -76,7 +76,7 @@ const handleReturnsMapToJsonStart = async job => {
 
     await eventsService.updateStatus(event.id, uploadStatus.VALIDATED)
   } catch (error) {
-    logger.error(`Failed to convert ${event.subtype} to JSON`, error, { job })
+    logger.error(`Failed to convert ${event.subtype} to JSON`, error.stack, { job })
     await errorEvent.setEventError(event, error)
     throw error
   }
@@ -96,7 +96,7 @@ const uploadJsonToS3 = (eventId, json) => {
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async (job, queueManager) => {

--- a/src/modules/returns/lib/jobs/persist-returns.js
+++ b/src/modules/returns/lib/jobs/persist-returns.js
@@ -121,14 +121,14 @@ const handlePersistReturns = async job => {
     const updatedReturns = await persistReturns(validatedReturns, returns)
     await updateEvent(event, updatedReturns)
   } catch (err) {
-    logger.error('Failed to persist bulk returns upload', err, { job })
+    logger.error('Failed to persist bulk returns upload', err.stack, { job })
     await errorEvent.setEventError(event, err)
     throw err
   }
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/returns/lib/jobs/start-upload.js
+++ b/src/modules/returns/lib/jobs/start-upload.js
@@ -75,7 +75,7 @@ const handleReturnsUploadStart = async job => {
     // returns an array of objects containing error messages and lines
     await validateS3Object(event, s3Object)
   } catch (error) {
-    logger.error('Returns upload failure', error, { job })
+    logger.error('Returns upload failure', error.stack, { job })
 
     await errorEvent.setEventError(event, error)
     throw error
@@ -83,7 +83,7 @@ const handleReturnsUploadStart = async job => {
 }
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async (job, queueManager) => {

--- a/src/modules/returns/lib/jobs/validate-returns.js
+++ b/src/modules/returns/lib/jobs/validate-returns.js
@@ -66,7 +66,7 @@ const handleValidateReturnsStart = async job => {
 
     await eventsService.update(event)
   } catch (error) {
-    logger.error('Return upload preview failed', error, { eventId, companyId })
+    logger.error('Return upload preview failed', error.stack, { eventId, companyId })
     await errorEvent.setEventError(event, error)
     throw error
   }
@@ -96,7 +96,7 @@ const getEventReturnData = data =>
   }))
 
 const onFailed = async (job, err) => {
-  logger.error(`${JOB_NAME}: Job has failed`, err)
+  logger.error(`${JOB_NAME}: Job has failed`, err.stack)
 }
 
 const onComplete = async () => {

--- a/src/modules/returns/lib/route-helpers.js
+++ b/src/modules/returns/lib/route-helpers.js
@@ -6,7 +6,7 @@ const { logger } = require('../../../logger')
  */
 const failAction = async (request, h, err) => {
   const params = { path: request.path, payload: request.payload }
-  logger.error(err.message, err, params)
+  logger.error(err.message, err.stack, params)
   throw Boom.badRequest('Invalid request payload input')
 }
 

--- a/src/modules/unlink-licence/controller.js
+++ b/src/modules/unlink-licence/controller.js
@@ -58,7 +58,7 @@ const patchUnlinkLicence = async (request, h) => {
     await createUnlinkLicenceEvent(callingUser, documentId)
     return h.response({ data, error: null }).code(200)
   } catch (err) {
-    logger.error('Failed to unlink licence', err, { callingUserId, documentId })
+    logger.error('Failed to unlink licence', err.stack, { callingUserId, documentId })
     if (err.isBoom) {
       return h.response({ data: null, error: err }).code(err.output.statusCode)
     }

--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -196,7 +196,7 @@ const createOrEnableUser = async (emailAddress, callingUser) => {
 }
 
 const errorHandler = (err, message, params = {}) => {
-  logger.error(message, err, params)
+  logger.error(message, err.stack, params)
   if (err.isBoom) {
     return err
   }

--- a/test/lib/queue-manager/queue-manager.test.js
+++ b/test/lib/queue-manager/queue-manager.test.js
@@ -228,7 +228,7 @@ experiment('lib/queue-manager/queue-manager', () => {
           })
 
           test('an error is logged', async () => {
-            expect(logger.error.calledWith(`Error closing queue ${job.jobName}`, err)).to.be.true()
+            expect(logger.error.calledWith(`Error closing queue ${job.jobName}`, err.stack)).to.be.true()
           })
         })
       })
@@ -266,7 +266,7 @@ experiment('lib/queue-manager/queue-manager', () => {
           test('an error is logged', async () => {
             await bgQueueManager.closeAll()
 
-            expect(logger.error.calledWith(`Error closing queue ${job.jobName}`, err)).to.be.true()
+            expect(logger.error.calledWith(`Error closing queue ${job.jobName}`, err.stack)).to.be.true()
           })
         })
 
@@ -278,7 +278,7 @@ experiment('lib/queue-manager/queue-manager', () => {
           test('an error is logged', async () => {
             await bgQueueManager.closeAll()
 
-            expect(logger.error.calledWith(`Error closing worker ${job.jobName}`, err)).to.be.true()
+            expect(logger.error.calledWith(`Error closing worker ${job.jobName}`, err.stack)).to.be.true()
           })
         })
       })

--- a/test/modules/ar-analysis/controller.test.js
+++ b/test/modules/ar-analysis/controller.test.js
@@ -35,8 +35,9 @@ experiment('controller', () => {
   })
 
   experiment('when updateLicenceRow errors', () => {
+    const err = new Error('Opps')
     beforeEach(async () => {
-      updateLicence.updateLicenceRow.rejects({ name: 'nasty error' })
+      updateLicence.updateLicenceRow.rejects(err)
     })
 
     afterEach(async () => sandbox.restore())
@@ -47,7 +48,7 @@ experiment('controller', () => {
       } catch (e) {
         const [message, error, params] = logger.error.lastCall.args
         expect(message).to.equal('Failed to update AR licence')
-        expect(error.name).to.equal('nasty error')
+        expect(error).to.equal(err.stack)
         expect(params.licenceRef).to.equal('123')
       }
     })

--- a/test/modules/batch-notifications/controller.test.js
+++ b/test/modules/batch-notifications/controller.test.js
@@ -174,7 +174,7 @@ experiment('batch notifications controller', () => {
       test('the error is logged', async () => {
         expect(logger.error.calledWith(
           'Batch notification send error',
-          err,
+          err.stack,
           { eventId: request.params.eventId }
         )).to.be.true()
       })

--- a/test/modules/batch-notifications/lib/jobs/check-status.test.js
+++ b/test/modules/batch-notifications/lib/jobs/check-status.test.js
@@ -73,7 +73,7 @@ experiment('checkStatus job', () => {
         await checkStatus.handler({ id: jobId, data: jobParams })
         const [msg, error] = logger.error.lastCall.args
         expect(msg).to.equal(`Error handling: ${jobId}`)
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
       })
 
       test('Should handle refreshing an event failure correctly', async () => {
@@ -82,7 +82,7 @@ experiment('checkStatus job', () => {
         await checkStatus.handler({ id: jobId })
         const [msg, error, params] = logger.error.lastCall.args
         expect(msg).to.equal('Error checking notify status')
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
         expect(params).to.equal({ messageId })
       })
     })
@@ -121,7 +121,7 @@ experiment('checkStatus job', () => {
       await checkStatus.onFailed({}, err)
       const [msg, error] = logger.error.lastCall.args
       expect(msg).to.equal('notifications.checkStatus: Job has failed')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
   })
 

--- a/test/modules/batch-notifications/lib/jobs/get-recipients.test.js
+++ b/test/modules/batch-notifications/lib/jobs/get-recipients.test.js
@@ -70,7 +70,7 @@ experiment('getRecipients job', () => {
       test('logs the error', async () => {
         const [msg, error, params] = logger.error.lastCall.args
         expect(msg).to.equal('Batch notifications handleGetRecipients error')
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
         expect(params).to.equal({ eventId })
       })
 
@@ -120,7 +120,7 @@ experiment('getRecipients job', () => {
       await getRecipients.onFailed({}, err)
       const [msg, error] = logger.error.lastCall.args
       expect(msg).to.equal('notifications.getRecipients: Job has failed')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
   })
 

--- a/test/modules/batch-notifications/lib/jobs/refresh-event.test.js
+++ b/test/modules/batch-notifications/lib/jobs/refresh-event.test.js
@@ -67,7 +67,7 @@ experiment('refreshEvent job', () => {
         await refreshEvent.handler({ id: jobId, data: jobParams })
         const [msg, error] = logger.error.lastCall.args
         expect(msg).to.equal(`Error handling: ${jobId}`)
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
       })
 
       test('logs the error refreshing the event', async () => {
@@ -76,7 +76,7 @@ experiment('refreshEvent job', () => {
         await refreshEvent.handler({ id: jobId })
         const [msg, error] = logger.error.lastCall.args
         expect(msg).to.equal('Error refreshing batch message event')
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
       })
     })
 
@@ -97,7 +97,7 @@ experiment('refreshEvent job', () => {
       await refreshEvent.onFailed({}, err)
       const [msg, error] = logger.error.lastCall.args
       expect(msg).to.equal('notifications.refreshEvent: Job has failed')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
   })
 

--- a/test/modules/batch-notifications/lib/jobs/send-message.test.js
+++ b/test/modules/batch-notifications/lib/jobs/send-message.test.js
@@ -100,7 +100,7 @@ experiment('sendMessage job', () => {
         await sendMessage.handler({ id: jobId })
         const [msg, error] = logger.error.lastCall.args
         expect(msg).to.equal(`Error handling: ${jobId}`)
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
       })
 
       test('sets the scheduled_notification status to MESSAGE_STATUS_ERROR', async () => {
@@ -156,7 +156,7 @@ experiment('sendMessage job', () => {
       await sendMessage.onFailed({}, err)
       const [msg, error] = logger.error.lastCall.args
       expect(msg).to.equal('notifications.sendMessage: Job has failed')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
   })
 

--- a/test/modules/billing/controllers/batches.test.js
+++ b/test/modules/billing/controllers/batches.test.js
@@ -1088,7 +1088,7 @@ experiment('modules/billing/controller', () => {
         const func = () => controller.deleteAllBillingData()
         const result = await expect(func()).to.reject()
         expect(logger.error.calledWith(
-          'Error deleting all billing data', err
+          'Error deleting all billing data', err.stack
         )).to.be.true()
         expect(result).to.equal(err)
       })

--- a/test/modules/billing/jobs/check-for-updated-invoice-accounts.test.js
+++ b/test/modules/billing/jobs/check-for-updated-invoice-accounts.test.js
@@ -81,7 +81,7 @@ experiment('modules/billing/jobs/check-for-updated-invoice-accounts', () => {
 
       expect(logger.error.calledWith(
         `Job ${job.name} ${job.id} failed`,
-        err
+        err.stack
       )).to.be.true()
     })
   })

--- a/test/modules/billing/jobs/lib/batch-job.test.js
+++ b/test/modules/billing/jobs/lib/batch-job.test.js
@@ -63,7 +63,7 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
 
     test('passes the error', async () => {
       const [, err] = logger.error.lastCall.args
-      expect(err).to.equal(error)
+      expect(err).to.equal(error.stack)
     })
 
     test('logs the data', async () => {
@@ -110,7 +110,7 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
 
     test('passes the error', async () => {
       const [, err] = logger.error.lastCall.args
-      expect(err).to.equal(error)
+      expect(err).to.equal(error.stack)
     })
 
     test('passes the request data', async () => {
@@ -140,7 +140,7 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
 
     test('passes the error', async () => {
       const [, err] = logger.error.lastCall.args
-      expect(err).to.equal(error)
+      expect(err).to.equal(error.stack)
     })
 
     test('logs the data', async () => {

--- a/test/modules/billing/jobs/sync-charge-categories.test.js
+++ b/test/modules/billing/jobs/sync-charge-categories.test.js
@@ -147,7 +147,7 @@ experiment('modules/billing/jobs/sync-charge-categories', () => {
     })
 
     test('an error message is logged', async () => {
-      expect(logger.error.calledWith('billing.charge-categories.sync-from-csv: Job has failed', error)).to.be.true()
+      expect(logger.error.calledWith('billing.charge-categories.sync-from-csv: Job has failed', error.stack)).to.be.true()
     })
   })
 })

--- a/test/modules/billing/services/batch-service.test.js
+++ b/test/modules/billing/services/batch-service.test.js
@@ -402,7 +402,7 @@ experiment('modules/billing/services/batch-service', () => {
       test('the error is logged', async () => {
         const [message, error, batch] = logger.error.lastCall.args
         expect(message).to.equal('Failed to delete the batch')
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
         expect(batch).to.equal(batch)
       })
 
@@ -513,7 +513,7 @@ experiment('modules/billing/services/batch-service', () => {
       test('the error is logged', async () => {
         const [message, error, batch] = logger.error.lastCall.args
         expect(message).to.equal('Failed to approve the batch')
-        expect(error).to.equal(err)
+        expect(error).to.equal(err.stack)
         expect(batch).to.equal(batch)
       })
 
@@ -1528,7 +1528,7 @@ experiment('modules/billing/services/batch-service', () => {
       test('an error is logged for the failed call', async () => {
         expect(logger.error.callCount).to.equal(1)
         expect(logger.error.calledWith(
-          'Unable to delete Charge Module batch test-external-id-2', err
+          'Unable to delete Charge Module batch test-external-id-2', err.stack
         )).to.be.true()
       })
 

--- a/test/modules/billing/services/transactions-service.test.js
+++ b/test/modules/billing/services/transactions-service.test.js
@@ -185,7 +185,7 @@ experiment('modules/billing/services/transactions-service', () => {
         } catch (err) {
           const [message, error, params] = logger.error.lastCall.args
           expect(message).to.be.a.string()
-          expect(error instanceof Error).to.be.true()
+          expect(error).to.equal(err.stack)
           expect(params).to.equal({
             transactionId,
             response

--- a/test/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.test.js
+++ b/test/modules/charge-versions/jobs/licence-not-in-charge-version-workflow.test.js
@@ -101,7 +101,7 @@ experiment('modules/charge-versions/jobs/licence-not-in-charge-version-workflow'
 
       expect(logger.error.calledWith(
         `Job ${job.name} ${job.id} failed`,
-        err
+        err.stack
       )).to.be.true()
     })
   })

--- a/test/modules/notify/lib/notify-send.test.js
+++ b/test/modules/notify/lib/notify-send.test.js
@@ -118,7 +118,7 @@ experiment('notify-send', () => {
       await notifySendJob.onFailed({}, err)
       const [msg, error] = logger.error.lastCall.args
       expect(msg).to.equal('notify.send: Job has failed')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
   })
 

--- a/test/modules/returns-notifications/lib/returns-notification-send.test.js
+++ b/test/modules/returns-notifications/lib/returns-notification-send.test.js
@@ -61,7 +61,7 @@ experiment('returns-notification-send', () => {
       await returnsNotificationSendJob.onFailed({}, err)
       const [msg, error] = logger.error.lastCall.args
       expect(msg).to.equal('returnsNotification.send: Job has failed')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
   })
 

--- a/test/modules/returns/lib/jobs/persist-returns.test.js
+++ b/test/modules/returns/lib/jobs/persist-returns.test.js
@@ -148,7 +148,7 @@ experiment('persist-returns', () => {
       test('the error is logged', async () => {
         const [message, error, params] = logger.error.lastCall.args
         expect(message).to.equal('Failed to persist bulk returns upload')
-        expect(error).to.equal(testError)
+        expect(error).to.equal(testError.stack)
         expect(params.job).to.equal(job)
       })
 

--- a/test/modules/unlink-licence/controller.test.js
+++ b/test/modules/unlink-licence/controller.test.js
@@ -70,7 +70,7 @@ experiment('modules/unlink-licence/controller', () => {
         const [{ error: thrownError }] = h.response.lastCall.args
         const [message, err, body] = logger.error.lastCall.args
         expect(message).to.equal('Failed to unlink licence')
-        expect(err).to.equal(thrownError)
+        expect(err).to.equal(thrownError.stack)
         expect(body).to.equal({ callingUserId, documentId: request.params.documentId })
       })
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.