### PR TITLE
Remove pm2 watch config from ecosystem file

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -2,42 +2,20 @@
   "apps": [
     {
       "name": "water-api",
-      "ignore_watch": [
-        "node_modules",
-        "src/lib/temp",
-        "temp",
-        ".git",
-        ".git/index.lock"
-      ],
       "script": "index.js",
       "combine_logs": true,
-      "env": {
-        "watch": true
-      },
       "env_production": {
-        "watch": false,
         "instances" : "max",
         "exec_mode" : "cluster"
       }
     },
     {
       "name": "service-background",
-      "ignore_watch": [
-        "node_modules",
-        "src/lib/temp",
-        "temp",
-        ".git",
-        ".git/index.lock"
-      ],
       "script": "index-background.js",
       "combine_logs": true,
       "instances": 1,
       "exec_mode" : "fork",
-      "env": {
-        "watch": true
-      },
       "env_production": {
-        "watch": false,
         "node_args": ["--max-old-space-size=4000"]
       }
     }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/10

Here we have removed the watch config for pm2. This is due to using nodemon instead. Having both in the application is causing too many files to be registered, making it problematic to watch.