### PR TITLE
Data migration fix for leap year charge purposes

### DIFF
--- a/migrations/20221122000155-fix-leap-year-charge-purposes.js
+++ b/migrations/20221122000155-fix-leap-year-charge-purposes.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20221122000155-fix-leap-year-charge-purposes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20221122000155-fix-leap-year-charge-purposes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20221122000155-fix-leap-year-charge-purposes-down.sql
+++ b/migrations/sqls/20221122000155-fix-leap-year-charge-purposes-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to remove bad data from the db. We don't want that bad data put back in!!!! */

--- a/migrations/sqls/20221122000155-fix-leap-year-charge-purposes-up.sql
+++ b/migrations/sqls/20221122000155-fix-leap-year-charge-purposes-up.sql
@@ -1,0 +1,16 @@
+/* This query updates leap year end abstraction period values. Some SROC charge versions were imported with abstraction
+periods that ended on 29-Feb. The issue is this applies each year so we don't record a year. Instead that gets added
+when we come to display the date in the UI. The problem is not all years are leap years. When the service tries
+to create a date of `02-FEB-2022` it errors because that date never happened.
+
+The accepted fix is to update the date to 28-FEB */
+
+BEGIN;
+UPDATE
+  water.charge_purposes
+SET
+  abstraction_period_end_day = 28
+WHERE
+  abstraction_period_end_day = 29
+  AND abstraction_period_end_month = 2;
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3827

> Users can search for and find `7/35/01/*S/001`2 without issue and see the charge versions screen. But when the select 'View' in the first charge information record they get a "Sorry, the requested URL was rejected error".

We've investigated the issue and identified the cause. The charge version has been set up with 2 `charge_purposes`:

- Spray irrigation at Marsh Dykes at Frostenden - 1-Apr to 30-Sep
- Spray irrigation storage at Marsh Dykes at Frostenden - 1-Nov to 29-Feb

When the UI attempts to show this information it makes a 'date' out of the abstraction period by bolting the current year onto the `start` and `end` days and months.

In this case, it means it's trying to make a 'date' of **29-Feb-2022**, which doesn't exist hence things blow up. This is another example of an unhandled exception leaking through so users get the SilverLine WAF error page rather than our standard one. We found 3 other licences affected by this.

When we played around with it if we changed the abstraction period to 1-Nov to 28-Feb the UI no longer errored. We've discussed this with the users and they agree, an abstraction end date of **29-Feb** is a data error and should be fixed. The error only seems to apply to SROC charge versions so we think these records got in through the charge upload process.

As the business team is now finished with it, we don't expect any more problem records. Hence this change just creates a data migration to fix the problem records.