### PR TITLE
Fix cancelling billing batch error

### DIFF
--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -127,7 +127,7 @@ const deleteBatch = async (batch, internalCallingUser) => {
   }
 
   try {
-    await chargeModuleBillRunConnector.delete(batch.externalId)
+    await deleteChargingModuleBillRun(batch.externalId)
 
     // These are populated at every stage in the bill run
     await newRepos.billingBatchChargeVersionYears.deleteByBatchId(batch.id, false)
@@ -141,10 +141,18 @@ const deleteBatch = async (batch, internalCallingUser) => {
 
     await saveEvent('billing-batch:cancel', 'delete', internalCallingUser, batch)
   } catch (err) {
-    logger.error('Failed to delete the batch', err.stack, batch)
+    logger.error('Failed to delete the batch', err, batch)
     await saveEvent('billing-batch:cancel', 'error', internalCallingUser, batch)
     await setStatus(batch.id, BATCH_STATUS.error)
     throw err
+  }
+}
+
+async function deleteChargingModuleBillRun (billRunId) {
+  try {
+    await chargeModuleBillRunConnector.delete(billRunId)
+  } catch (err) {
+    logger.error('Failed to delete Charging Module Bill Run', err, { billRunId })
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3845

This week the users tried to cancel a bill run only to see the error page. When they went back to the bill runs tab it was still listed as ready.

When we looked into the logs from both WRLS and the [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) we could see

- then a request to delete the bill run in the CHA API had first failed `401`
- a new Cognito token was grabbed and then the `DELETE` request was sent again
- this time it succeeded
- it was followed by more `DELETE` requests for the same bill run

Based on the timings, some could be down to users trying again. But a number were milliseconds after the first and each other. Our suspicion is that the initial auth failure causes the WRLS service to go into a retry loop, spamming the CHA API when we should be backing off after the initial `409` response.

Anyway, the result appears to be that the call throws an exception in the `deleteBatch()` method.

```javascript
 const deleteBatch = async (batch, internalCallingUser) => {
  if (!batch.canBeDeleted()) {
    throw new BatchStatusError(`Batch ${batch.id} cannot be deleted - status is ${batch.status}`)
  }

  try {
    await chargeModuleBillRunConnector.delete(batch.externalId)

    // These are populated at every stage in the bill run
    await newRepos.billingBatchChargeVersionYears.deleteByBatchId(batch.id, false)
    await newRepos.billingVolumes.deleteByBatchId(batch.id)

    // These tables are not yet populated at review stage in TPT
    await newRepos.billingTransactions.deleteByBatchId(batch.id)
    await newRepos.billingInvoiceLicences.deleteByBatchId(batch.id)
    await newRepos.billingInvoices.deleteByBatchId(batch.id, false)
    await newRepos.billingBatches.delete(batch.id)

    await saveEvent('billing-batch:cancel', 'delete', internalCallingUser, batch)
  } catch (err) {
    logger.error('Failed to delete the batch', err.stack, batch)
    await saveEvent('billing-batch:cancel', 'error', internalCallingUser, batch)
    await setStatus(batch.id, BATCH_STATUS.error)
    throw err
  }
}
```

If this happened previously, it wasn't so bad because at least the bill run's status got updated and another bill run could be attempted. But a [recent change](https://github.com/DEFRA/water-abstraction-service/pull/1885) has unearthed an issue in the logger. In this case, the logger is expecting an `Error()` instance. When the stack trace is sent instead it causes an error which is not handled. The user ends up seeing an error page and the changes to the billing batch status and the event never happens.

We had intended for this change to be updating to a fixed version of [water-abstraction-helpers](https://github.com/DEFRA/water-abstraction-helpers/pull/200). But it's late on a Friday, publishing to npm isn't working, and we _really_ need this fix! 😳😰

So, instead, we are

- wrapping the call to the charge module API in its own try/catch
  - if it fails in the same way it won't stop the rest of the data from being deleted properly and the status being correctly set to `cancel`
- switching back to sending the error instance in this case
  - the existing version of water-abstraction-helpers will work without error again when an instance is passed through