### PR TITLE
Add new SROC test fixture

### DIFF
--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -210,3 +210,99 @@
     purposePrimaryId: $primaryPurpose.purposePrimaryId
     purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
     purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargeVersion06
+  model: ChargeVersion
+  fields:
+    licenceRef: $srocLicence04.licenceRef
+    scheme: sroc
+    versionNumber: 1
+    startDate: '2022-04-01'
+    endDate: null
+    status: current
+    regionCode: $region.naldRegionId
+    source: wrls
+    invoiceAccountId: $invoiceAccount04.invoiceAccountId
+    isTest: true
+    licenceId: $srocLicence04.licenceId
+
+- ref: $chargeElement06
+  model: ChargeElement
+  fields:
+    chargeVersionId: $chargeVersion06.chargeVersionId
+    description: 'SROC Charge Element 06'
+    source: tidal
+    loss: medium
+    isTest: true
+    scheme: sroc
+    isRestrictedSource: false
+    waterModel: 'no model'
+    volume: 100
+    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    eiucRegion: Southern
+
+- ref: $chargePurpose04
+  model: ChargePurpose
+  fields:
+    chargeElementId: $chargeElement06.chargeElementId
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    abstractionPeriodEndDay: 30
+    abstractionPeriodEndMonth: 9
+    authorisedAnnualQuantity: 15.54
+    loss: medium
+    factorsOverridden: false
+    description: 'SROC Charge Purpose 04'
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargePurpose05
+  model: ChargePurpose
+  fields:
+    chargeElementId: $chargeElement06.chargeElementId
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 10
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 10.5
+    loss: medium
+    factorsOverridden: false
+    description: 'SROC Charge Purpose 05'
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId
+
+- ref: $chargeElement07
+  model: ChargeElement
+  fields:
+    chargeVersionId: $chargeVersion06.chargeVersionId
+    description: 'SROC Charge Element 07'
+    source: tidal
+    loss: medium
+    isTest: true
+    scheme: sroc
+    isRestrictedSource: false
+    waterModel: 'no model'
+    volume: 100
+    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    eiucRegion: Southern
+
+- ref: $chargePurpose06
+  model: ChargePurpose
+  fields:
+    chargeElementId: $chargeElement07.chargeElementId
+    abstractionPeriodStartDay: 1
+    abstractionPeriodStartMonth: 4
+    abstractionPeriodEndDay: 31
+    abstractionPeriodEndMonth: 3
+    authorisedAnnualQuantity: 12.5
+    loss: medium
+    factorsOverridden: false
+    description: 'SROC Charge Purpose 06'
+    isTest: true
+    purposePrimaryId: $primaryPurpose.purposePrimaryId
+    purposeSecondaryId: $secondaryPurpose.purposeSecondaryId
+    purposeUseId: $purposeUse.purposeUseId

--- a/integration-tests/billing/fixtures/sroc-crm-v1.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v1.yaml
@@ -26,6 +26,13 @@
     entity_type: 'company'
     source: 'acceptance-test-setup'
 
+- ref: $companyEntity04
+  model: Entity
+  fields:
+    entity_nm: 'Big Farm Co Ltd 04'
+    entity_type: 'company'
+    source: 'acceptance-test-setup'
+
 - model: EntityRole
   fields:
     entityId: $userEntity.entity_id
@@ -44,6 +51,13 @@
   fields:
     entityId: $userEntity.entity_id
     company_entity_id: $companyEntity03.entity_id
+    role: 'primary_user'
+    created_by: 'acceptance-test-setup'
+
+- model: EntityRole
+  fields:
+    entityId: $userEntity.entity_id
+    company_entity_id: $companyEntity04.entity_id
     role: 'primary_user'
     created_by: 'acceptance-test-setup'
 
@@ -83,5 +97,18 @@
     document_name: 'Big Farm 03 permit'
     metadata:
       Name: 'Big Farm 03'
+      dataType: 'acceptance-test-setup'
+      IsCurrent: true
+
+- model: DocumentHeader
+  fields:
+    regime_entity_id: '0434dc31-a34e-7158-5775-4694af7a60cf'
+    system_id: 'permit-repo'
+    system_external_id: 'AT/SROC/SUPB/04'
+    company_entity_id: $companyEntity04.entity_id
+    system_internal_id: $srocPermit04.licence_id
+    document_name: 'Big Farm 04 permit'
+    metadata:
+      Name: 'Big Farm 04'
       dataType: 'acceptance-test-setup'
       IsCurrent: true

--- a/integration-tests/billing/fixtures/sroc-crm-v2.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v2.yaml
@@ -22,6 +22,14 @@
     companyNumber: '1234503'
     isTest: true
 
+- ref: $company04
+  model: Company
+  fields:
+    name: Big Farm Co Ltd 04
+    type: organisation
+    companyNumber: '1234504'
+    isTest: true
+
 - ref: $address1
   model: Address
   fields:
@@ -104,6 +112,24 @@
     endDate: null
     isTest: true
 
+- model: CompanyAddress
+  fields:
+    roleName: billing
+    companyId: $company04.companyId
+    addressId: $address1.addressId
+    startDate: '2022-04-01'
+    endDate: null
+    isTest: true
+
+- model: CompanyAddress
+  fields:
+    roleName: billing
+    companyId: $company04.companyId
+    addressId: $address2.addressId
+    startDate: '2022-04-01'
+    endDate: null
+    isTest: true
+
 - ref: $contact
   model: Contact
   fields:
@@ -142,6 +168,15 @@
     startDate: '2015-01-01'
     isTest: true
 
+- model: CompanyContact
+  fields:
+    companyId: $company04.companyId
+    contactId: $contact.contactId
+    roleName: 'licenceHolder'
+    emailAddress: 'acceptance-test.external@example.com'
+    startDate: '2022-04-01'
+    isTest: true
+
 - ref: $invoiceAccount01
   model: InvoiceAccount
   fields:
@@ -167,6 +202,15 @@
     startDate: '2015-01-01'
     endDate: null
     companyId: $company03.companyId
+    isTest: true
+
+- ref: $invoiceAccount04
+  model: InvoiceAccount
+  fields:
+    invoiceAccountNumber: A00000004A
+    startDate: '2022-04-01'
+    endDate: null
+    companyId: $company04.companyId
     isTest: true
 
 - model: InvoiceAccountAddress
@@ -196,6 +240,16 @@
     agentCompanyId: null
     contactId: null
     startDate: '2015-01-01'
+    endDate: null
+    isTest: true
+
+- model: InvoiceAccountAddress
+  fields:
+    invoiceAccountId: $invoiceAccount04.invoiceAccountId
+    addressId: $address1.addressId
+    agentCompanyId: null
+    contactId: null
+    startDate: '2022-04-01'
     endDate: null
     isTest: true
 
@@ -229,6 +283,16 @@
     documentRef: 'AT/SROC/SUPB/03'
     isTest: true
 
+- ref: $documentDaily04
+  model: Document
+  fields:
+    startDate: '2022-04-01'
+    endDate: null
+    regime: water
+    documentType: abstraction_licence
+    documentRef: 'AT/SROC/SUPB/04'
+    isTest: true
+
 - model: DocumentRole
   fields:
     documentId: $documentDaily01.documentId
@@ -258,6 +322,17 @@
     startDate: '2015-01-01'
     endDate: null
     companyId: $company03.companyId
+    addressId: $address1.addressId
+    contactId: $contact.contactId
+    isTest: true
+
+- model: DocumentRole
+  fields:
+    documentId: $documentDaily04.documentId
+    role: licenceHolder
+    startDate: '2022-04-01'
+    endDate: null
+    companyId: $company04.companyId
     addressId: $address1.addressId
     contactId: $contact.contactId
     isTest: true

--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -43,6 +43,18 @@
     startDate: '2015-01-01'
     isTest: true
 
+- ref: $srocLicence04
+  model: Licence
+  fields:
+    regionId: $region.regionId
+    licenceRef: 'AT/SROC/SUPB/04'
+    regions:
+      historicalAreaCode: 'SAAR'
+      regionalChargeArea: 'Southern'
+    isWaterUndertaker: true
+    startDate: '2015-01-01'
+    isTest: true
+
 - ref: $srocLicenceVersion01
   model: LicenceVersion
   fields:
@@ -77,4 +89,16 @@
     startDate: '2015-01-01'
     endDate: null
     externalId: 6:1234:3:0
+    isTest: true
+
+- ref: $srocLicenceVersion04
+  model: LicenceVersion
+  fields:
+    licenceId: $srocLicence04.licenceId
+    issue : 1
+    increment: 0
+    status: 'current'
+    startDate: '2022-04-01'
+    endDate: null
+    externalId: 6:1234:4:0
     isTest: true

--- a/integration-tests/billing/fixtures/sroc-permits.yaml
+++ b/integration-tests/billing/fixtures/sroc-permits.yaml
@@ -15,3 +15,9 @@
   fields:
     licenceRef: 'AT/SROC/SUPB/03'
     startDate: '2015-01-01'
+
+- ref: $srocPermit04
+  model: Licence
+  fields:
+    licenceRef: 'AT/SROC/SUPB/04'
+    startDate: '2022-04-01'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3834

We need to create a scenario where we have a licence with a charge version that has multiple charge categories (elements). Then linked to those categories are multiple charge purposes with different abstraction dates.

The intent is to help us confirm we are calculating the abstraction period for each category (element) in a charge version correctly. In this change, we are currently able to generate a new SROC licence with multiple categories, and one of those categories has multiple purposes (the other just has one).

It's a start but doesn't actually represent a real-life scenario. This is because the category is not defined through fixtures but via the logic in the fixture loader. That's going to take a bit more unpicking so we'll tackle that in another PR and update this fixture accordingly.

The key thing is this gets us started (and doesn't break when loaded!) as the structure is correct.