### PR TITLE
Make more charge categories available in fixtures

### DIFF
--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -286,8 +286,8 @@
     scheme: sroc
     isRestrictedSource: false
     waterModel: 'no model'
-    volume: 100
-    billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
+    volume: 750
+    billingChargeCategoryId: $chargeCategory4210.billing_charge_category_id
     eiucRegion: Southern
 
 - ref: $chargePurpose06

--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -25,7 +25,7 @@
     isRestrictedSource: false
     waterModel: 'no model'
     volume: 100
-    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
 
 - ref: $chargePurpose01
@@ -108,7 +108,7 @@
     isRestrictedSource: false
     waterModel: 'no model'
     volume: 100
-    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
 
 - ref: $chargePurpose02
@@ -191,7 +191,7 @@
     isRestrictedSource: false
     waterModel: 'no model'
     volume: 100
-    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
 
 - ref: $chargePurpose03
@@ -238,7 +238,7 @@
     isRestrictedSource: false
     waterModel: 'no model'
     volume: 100
-    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
 
 - ref: $chargePurpose04
@@ -287,7 +287,7 @@
     isRestrictedSource: false
     waterModel: 'no model'
     volume: 100
-    billingChargeCategoryId: $chargeCategory.billing_charge_category_id
+    billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
 
 - ref: $chargePurpose06

--- a/integration-tests/billing/services/bookshelf-loader.js
+++ b/integration-tests/billing/services/bookshelf-loader.js
@@ -38,8 +38,8 @@ const dir = path.resolve(__dirname, '../fixtures')
 // how all that works just to support `create()` becoming async. 😩
 //
 // So, instead we mix up async/await with some old fashioned promise callbacks. We wrap our call to the DB with the
-// async method `getChargeCategory()`. It's going to return a promise when called from a non-async method. So, we use
-// `then()` to add a callback to the promise. In the callback we can get the returned value and assign it to the
+// async method `getChargeCategories()`. It's going to return a promise when called from a non-async method. So, we use
+// `then()` to add a callback to the promise. In the callback we can get the returned values and assign them to the
 // loader.
 //
 // That brings us to what is going on here. Unlike the other loaders we declare `loader` at the top level of the module
@@ -47,20 +47,32 @@ const dir = path.resolve(__dirname, '../fixtures')
 // access the same object. This allows us to set the charge category as a 'ref', which can be referred to in
 // fixtures like `sroc-charge-info.yaml`.
 //
-// It isn't pretty, it is ridiculously complex, and its all for one weird edge case. But it solves this specific problem
-// without resorting to re-writing how integration-tests works.
+// It isn't pretty, it is ridiculously complex, and it's all for one weird edge case. But it solves this specific
+// problem without resorting to re-writing how integration-tests works.
 //
 // ¯\_(ツ)_/¯
 const bookshelfAdapter = new BookshelfAdapter(bookshelf)
 const loader = new FixtureLoader(bookshelfAdapter, dir)
 
-const getChargeCategory = async () => {
-  const { rows } = await bookshelf.knex.raw("SELECT * FROM water.billing_charge_categories WHERE reference = '4.2.1'")
+const getChargeCategories = async () => {
+  const { rows } = await bookshelf.knex.raw(
+    "SELECT * FROM water.billing_charge_categories WHERE reference IN ('4.1.1', '4.2.1', '4.2.10') ORDER BY reference"
+  )
 
-  return {
-    name: '$chargeCategory',
-    obj: { ...rows[0] }
-  }
+  return [
+    {
+      name: '$chargeCategory411',
+      obj: { ...rows[0] }
+    },
+    {
+      name: '$chargeCategory421',
+      obj: { ...rows[1] }
+    },
+    {
+      name: '$chargeCategory4210',
+      obj: { ...rows[2] }
+    }
+  ]
 }
 
 const getChargeVersionStartDate = () => {
@@ -84,8 +96,10 @@ const create = () => {
   }
   loader.setRef(refDates.name, refDates.obj)
 
-  getChargeCategory().then((chargeVersion) => {
-    loader.setRef(chargeVersion.name, chargeVersion.obj)
+  getChargeCategories().then((chargeVersions) => {
+    for (const chargeVersion of chargeVersions) {
+      loader.setRef(chargeVersion.name, chargeVersion.obj)
+    }
   })
 
   return loader


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3834

When working on the various scenarios needed to calculate the abstraction period for a charge version in a given billing period we realised there is one we could not cover.

A `charge_version` can be linked to multiple `charge_elements` and each charge element can be linked to different `billing_charge_categories`. But the current fixture logic only makes one  `billing_charge_category` available to use.

This change makes it possible to pick from 3 different `billing_charge_categories` in our fixtures.

<details>
<summary>Result after change</summary>

<img width="500" alt="Screenshot 2023-01-06 at 09 14 36" src="https://user-images.githubusercontent.com/1789650/210970457-d555a91b-74d9-4b4a-a5a3-069df413cda3.png">

</details>