### PR TITLE
Add new queued batch status

### DIFF
--- a/migrations/20230120140933-queued-batch-status.js
+++ b/migrations/20230120140933-queued-batch-status.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230120140933-queued-batch-status-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230120140933-queued-batch-status-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20230120140933-queued-batch-status-down.sql
+++ b/migrations/sqls/20230120140933-queued-batch-status-down.sql
@@ -1,0 +1,21 @@
+ALTER TYPE water.batch_status
+  RENAME to batch_status_old;
+
+CREATE TYPE water.batch_status AS ENUM (
+	'processing',
+	'review',
+	'ready',
+	'error',
+	'sent',
+	'empty',
+	'cancel',
+	'sending'
+);
+
+ALTER TABLE water.billing_batches
+  ALTER COLUMN status TYPE water.batch_status USING status::text::water.batch_status;
+
+ALTER TABLE water.billing_batch_charge_version_years
+  ALTER COLUMN status TYPE water.batch_status USING status::text::water.batch_status;
+
+DROP TYPE water.batch_status_old;

--- a/migrations/sqls/20230120140933-queued-batch-status-up.sql
+++ b/migrations/sqls/20230120140933-queued-batch-status-up.sql
@@ -1,0 +1,22 @@
+ALTER TYPE water.batch_status
+  RENAME to batch_status_old;
+
+CREATE TYPE water.batch_status AS ENUM (
+	'processing',
+	'review',
+	'ready',
+	'error',
+	'sent',
+	'empty',
+	'cancel',
+	'sending',
+  'queued'
+);
+
+ALTER TABLE water.billing_batches
+  ALTER COLUMN status TYPE water.batch_status USING status::text::water.batch_status;
+
+ALTER TABLE water.billing_batch_charge_version_years
+  ALTER COLUMN status TYPE water.batch_status USING status::text::water.batch_status;
+
+DROP TYPE water.batch_status_old;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -25,7 +25,9 @@ const BATCH_STATUS = {
   cancel: 'cancel',
   // if there are no charge versions, or all billing has already happened
   // in earlier run, or all customers have been removed from the batch
-  empty: 'empty'
+  empty: 'empty',
+  // Initial state of all new bill runs. Once picked up for processing the status is then updated to `processing`
+  queued: 'queued'
 }
 
 const BATCH_ERROR_CODE = {

--- a/src/modules/billing/jobs/create-bill-run.js
+++ b/src/modules/billing/jobs/create-bill-run.js
@@ -5,7 +5,7 @@ const { get, partial } = require('lodash')
 const JOB_NAME = 'billing.create-bill-run'
 
 const batchService = require('../services/batch-service')
-const { BATCH_ERROR_CODE, BATCH_TYPE } = require('../../../lib/models/batch')
+const { BATCH_ERROR_CODE, BATCH_STATUS, BATCH_TYPE } = require('../../../lib/models/batch')
 const batchJob = require('./lib/batch-job')
 const helpers = require('./lib/helpers')
 
@@ -23,6 +23,7 @@ const handler = async job => {
   const batchId = get(job, 'data.batchId')
 
   try {
+    await batchService.setStatus(batchId, BATCH_STATUS.processing)
     const batch = await batchService.createChargeModuleBillRun(batchId)
     return { type: batch.type }
   } catch (err) {

--- a/src/modules/billing/jobs/lib/batch-status.js
+++ b/src/modules/billing/jobs/lib/batch-status.js
@@ -21,7 +21,10 @@ const assertCmBatchIsGeneratedOrBilled = cmBatch => {
   }
 }
 
-const assertBatchIsProcessing = partialRight(assertBatchIsStatus, [Batch.BATCH_STATUS.processing, Batch.BATCH_STATUS.sending])
+const assertBatchIsProcessing = partialRight(
+  assertBatchIsStatus,
+  [Batch.BATCH_STATUS.queued, Batch.BATCH_STATUS.processing, Batch.BATCH_STATUS.sending]
+)
 const assertBatchIsInReview = partialRight(assertBatchIsStatus, [Batch.BATCH_STATUS.review])
 
 exports.assertCmBatchIsGeneratedOrBilled = assertCmBatchIsGeneratedOrBilled

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -295,7 +295,7 @@ const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
   }
 
   const { billingBatchId } = await newRepos.billingBatches.create({
-    status: Batch.BATCH_STATUS.processing,
+    status: Batch.BATCH_STATUS.queued,
     regionId,
     batchType,
     fromFinancialYearEnding,

--- a/test/modules/billing/jobs/create-bill-run.test.js
+++ b/test/modules/billing/jobs/create-bill-run.test.js
@@ -45,6 +45,7 @@ experiment('modules/billing/jobs/create-bill-run', () => {
 
     sandbox.stub(batchService, 'createChargeModuleBillRun').resolves(batch)
     sandbox.stub(batchService, 'setErrorStatus').resolves(batch)
+    sandbox.stub(batchService, 'setStatus').resolves({ ...batch, status: 'processing' })
 
     queueManager = {
       add: sandbox.stub()

--- a/test/modules/billing/jobs/process-charge-versions.test.js
+++ b/test/modules/billing/jobs/process-charge-versions.test.js
@@ -121,7 +121,7 @@ experiment('modules/billing/jobs/process-charge-versions', () => {
       test('an error is logged and rethrown', async () => {
         const func = () => processChargeVersionsJob.handler(message)
         const err = await expect(func()).to.reject()
-        expect(err.message).to.equal(`Expected processing,sending batch status, but got ${Batch.BATCH_STATUS.ready}`)
+        expect(err.message).to.equal(`Expected queued,processing,sending batch status, but got ${Batch.BATCH_STATUS.ready}`)
         expect(batchJob.logHandlingErrorAndSetBatchStatus.calledWith(message, err, Batch.BATCH_ERROR_CODE.failedToProcessChargeVersions)).to.be.true()
       })
     })

--- a/test/modules/billing/jobs/two-part-tariff-matching.test.js
+++ b/test/modules/billing/jobs/two-part-tariff-matching.test.js
@@ -103,7 +103,7 @@ experiment('modules/billing/jobs/two-part-tariff-matching', () => {
           err,
           Batch.BATCH_ERROR_CODE.failedToProcessTwoPartTariff
         )).to.be.true()
-        expect(err.message).to.equal(`Expected processing,sending batch status, but got ${Batch.BATCH_STATUS.ready}`)
+        expect(err.message).to.equal(`Expected queued,processing,sending batch status, but got ${Batch.BATCH_STATUS.ready}`)
       })
     })
 

--- a/test/modules/billing/services/batch-service.test.js
+++ b/test/modules/billing/services/batch-service.test.js
@@ -1051,10 +1051,10 @@ experiment('modules/billing/services/batch-service', () => {
           result = await batchService.create(regionId, 'annual', 2023, 'all-year')
         })
 
-        test('a batch is created processing 1 financial year', async () => {
+        test('a batch is created queued 1 financial year', async () => {
           const args = newRepos.billingBatches.create.lastCall.args[0]
           expect(args).to.equal({
-            status: 'processing',
+            status: 'queued',
             regionId,
             batchType: 'annual',
             fromFinancialYearEnding: 2023,
@@ -1074,10 +1074,10 @@ experiment('modules/billing/services/batch-service', () => {
           result = await batchService.create(regionId, 'supplementary', 2022, 'all-year')
         })
 
-        test('a batch is created processing the number of years specified in config.billing.supplementaryYears', async () => {
+        test('a batch is created queued the number of years specified in config.billing.supplementaryYears', async () => {
           const args = newRepos.billingBatches.create.lastCall.args[0]
           expect(args).to.equal({
-            status: 'processing',
+            status: 'queued',
             regionId,
             batchType: 'supplementary',
             fromFinancialYearEnding: 2017,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3877

When a supplementary bill run is started, we'll be creating both a PRESROC and SROC one at the same time.

The PRESROC one will then begin `processing` (labelled as BUILDING in the UI) whilst the SROC one is `queued` waiting to be processed.

At the moment though, all we can do is initialise the SROC bill run with a status of processing as that is all that is available to us. In the UI this will give the impression both are building when their not.

So, we need to add a new `queued` status to the code and DB. We'll make it so all new bill runs are given this status initially. Then, once processing starts the status will be updated. This is what happens at the moment. The bill run is created and then a job is added to a 'queue' for it to be processed.