### PR TITLE
Remove Lodash 'isString', 'isArray' and 'isEmpty' functions

### DIFF
--- a/integration-tests/billing/services/fixture-loader/FixtureLoader.js
+++ b/integration-tests/billing/services/fixture-loader/FixtureLoader.js
@@ -7,7 +7,7 @@
 
 const YAML = require('yamljs')
 const path = require('path')
-const { mapValues, isString } = require('lodash')
+const { mapValues } = require('lodash')
 const { getFinancialDateRange } = require('../lib/financial-date-range')
 const moment = require('moment')
 const { v4: uuid } = require('uuid')
@@ -21,7 +21,7 @@ const refRegex = /^(\$[^.]+)\.([a-z0-9-_]+)$/i
  * @return {Mixed} value
  */
 const mapValue = (value, refs) => {
-  if (!isString(value)) {
+  if (typeof value !== 'string') {
     return value
   }
 

--- a/src/lib/camel-case-keys.js
+++ b/src/lib/camel-case-keys.js
@@ -1,8 +1,11 @@
-const { reduce, isArray, isPlainObject, camelCase } = require('lodash')
+'use strict'
 
-const camelCaseObjectKeys = data => {
+const { reduce, isPlainObject, camelCase } = require('lodash')
+
+const camelCaseObjectKeys = (data) => {
   return reduce(data, (acc, value, key) => {
     acc[camelCase(key)] = camelCaseKeys(value)
+
     return acc
   }, {})
 }
@@ -12,14 +15,15 @@ const camelCaseObjectKeys = data => {
  * @param {Array|Object} data The array of objects, or object that is to
  * have it's keys camel cased
  */
-const camelCaseKeys = data => {
-  if (isArray(data)) {
+const camelCaseKeys = (data) => {
+  if (Array.isArray(data)) {
     return data.map(camelCaseKeys)
   }
 
   if (isPlainObject(data)) {
     return camelCaseObjectKeys(data)
   }
+
   return data
 }
 

--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const moment = require('moment')
-const { isString } = require('lodash')
 const { assertIsoString } = require('./models/validators')
 
 const DATE_FORMAT = 'YYYY-MM-DD'
@@ -30,7 +29,7 @@ const getDateTimeFromValue = value => {
     return value
   }
 
-  if (isString(value)) {
+  if (typeof value === 'string') {
     assertIsoString(value)
     return moment(value)
   }

--- a/src/lib/licence-transformer/nald-transformer.js
+++ b/src/lib/licence-transformer/nald-transformer.js
@@ -1,8 +1,10 @@
+'use strict'
+
 /**
  * Transforms NALD data into VML native format
  * @module lib/licence-transformer/nald-transformer
  */
-const { find, uniqBy, isArray } = require('lodash')
+const { find, uniqBy } = require('lodash')
 const { sentenceCase } = require('sentence-case')
 
 const BaseTransformer = require('./base-transformer')
@@ -350,8 +352,8 @@ class NALDTransformer extends BaseTransformer {
    * @param {Array|String} subCode - the condition subcode
    */
   filterConditions (conditions, code, subCode) {
-    const arrCode = isArray(code) ? code : [code]
-    const arrSubCode = isArray(subCode) ? subCode : [subCode]
+    const arrCode = Array.isArray(code) ? code : [code]
+    const arrSubCode = Array.isArray(subCode) ? subCode : [subCode]
     return conditions.filter(row => {
       return arrCode.includes(row.code) && arrSubCode.includes(row.subCode)
     })

--- a/src/lib/make-array.js
+++ b/src/lib/make-array.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { isArray } = require('lodash')
-
-const makeArray = value => isArray(value) ? value : [value]
+const makeArray = (value) => {
+  return Array.isArray(value) ? value : [value]
+}
 
 module.exports = makeArray

--- a/src/lib/mappers/change-reason.js
+++ b/src/lib/mappers/change-reason.js
@@ -1,5 +1,6 @@
+'use strict'
+
 const ChangeReason = require('../models/change-reason')
-const { isEmpty } = require('lodash')
 const { createMapper } = require('../object-mapper')
 const { createModel } = require('./lib/helpers')
 
@@ -9,9 +10,10 @@ const { createModel } = require('./lib/helpers')
  * @return {Contact}
  */
 const dbToModel = row => {
-  if (isEmpty(row)) {
+  if (!row || Object.keys(row).length === 0) {
     return null
   }
+
   const model = new ChangeReason(row.changeReasonId)
   return model.pickFrom(row, [
     'description',

--- a/src/lib/mappers/event.js
+++ b/src/lib/mappers/event.js
@@ -1,11 +1,12 @@
 'use strict'
 
-const { isNull, isEmpty } = require('lodash')
+const { isNull } = require('lodash')
 
 const Event = require('../models/event')
 
-const mapStatus = status =>
-  isEmpty(status) ? null : status
+const mapStatus = (status) => {
+  return !status ? null : status
+}
 
 /**
  * Creates Event object model from data received from the repo layer

--- a/src/lib/mappers/invoice.js
+++ b/src/lib/mappers/invoice.js
@@ -12,14 +12,21 @@ const batchMapper = require('../../lib/mappers/batch')
 
 const { createMapper } = require('../object-mapper')
 const { createModel } = require('./lib/helpers')
-const { isEmpty } = require('lodash')
 
 const mapLinkedInvoices = (billingInvoiceId, linkedBillingInvoices = [], originalBillingInvoice = {}) => {
   const invoices = linkedBillingInvoices
     .filter(linkedBillingInvoice => ![billingInvoiceId, originalBillingInvoice.billingInvoiceId].includes(linkedBillingInvoice.billingInvoiceId))
     .map(dbToModel)
 
-  if (!(isEmpty(originalBillingInvoice)) && billingInvoiceId !== originalBillingInvoice.billingInvoiceId) {
+  let isNotEmpty
+
+  if ((originalBillingInvoice === null) || (Object.keys(originalBillingInvoice).length === 0)) {
+    isNotEmpty = false
+  } else {
+    isNotEmpty = true
+  }
+
+  if (isNotEmpty && billingInvoiceId !== originalBillingInvoice.billingInvoiceId) {
     invoices.push(dbToModel(originalBillingInvoice))
   }
   return invoices

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -5,7 +5,6 @@ const FinancialYear = require('./financial-year')
 const Region = require('./region')
 const Totals = require('./totals')
 const { assert } = require('@hapi/hoek')
-const { isArray } = require('lodash')
 const config = require('../../../config')
 
 const validators = require('./validators')
@@ -223,7 +222,7 @@ class Batch extends Totals {
    * @param {Array<Invoice>} invoices
    */
   addInvoices (invoices = []) {
-    assert(isArray(invoices), 'Array expected')
+    assert(Array.isArray(invoices), 'Array expected')
     return invoices.map(invoice => this.addInvoice(invoice))
   }
 

--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { isArray } = require('lodash')
 const hoek = require('@hapi/hoek')
 const Joi = require('joi')
 
@@ -34,14 +33,14 @@ const VALID_OBJECT = Joi.object()
 const VALID_ARRAY = Joi.array()
 
 const assertIsArrayOfType = (values, Type) => {
-  hoek.assert(isArray(values), 'Array expected')
+  hoek.assert(Array.isArray(values), 'Array expected')
   values.forEach((value, i) =>
     hoek.assert(value instanceof Type, `${new Type().constructor.name} expected at position ${i}`)
   )
 }
 
 const assertIsArrayOfNullableStrings = (values) => {
-  hoek.assert(isArray(values), 'Array expected')
+  hoek.assert(Array.isArray(values), 'Array expected')
   values.forEach((value, i) =>
     hoek.assert(typeof value === 'string' || value === null, `String expected at position ${i}`)
   )

--- a/src/lib/object-mapper.js
+++ b/src/lib/object-mapper.js
@@ -6,10 +6,10 @@
  *         by default nulls are mapped, with an option of ignoring them
  */
 
-const { identity, set, isUndefined, isNull, isFunction, isObject, isArray } = require('lodash')
+const { identity, set, isUndefined, isNull, isFunction, isObject } = require('lodash')
 
 const getSourceKeys = value => {
-  if (isArray(value)) {
+  if (Array.isArray(value)) {
     return value
   } else if (isUndefined(value)) {
     return []

--- a/src/modules/billing/jobs/rebilling.js
+++ b/src/modules/billing/jobs/rebilling.js
@@ -6,7 +6,6 @@ const { logger } = require('../../../logger')
 const batchJob = require('./lib/batch-job')
 const helpers = require('./lib/helpers')
 const batchStatus = require('./lib/batch-status')
-const { isEmpty } = require('lodash')
 const { BATCH_ERROR_CODE } = require('../../../lib/models/batch')
 
 // Services
@@ -52,7 +51,7 @@ const handler = async job => {
     await rebillingService.rebillInvoice(batch, invoice.id)
     const changes = {
       rebillingState: 'rebilled',
-      originalBillingInvoiceId: isEmpty(invoice.originalInvoiceId) ? invoice.id : invoice.originalInvoiceId
+      originalBillingInvoiceId: !invoice.originalInvoiceId ? invoice.id : invoice.originalInvoiceId
     }
     await invoiceService.updateInvoice(invoice.id, changes)
   }

--- a/src/modules/companies-house/mappers/companies-house.js
+++ b/src/modules/companies-house/mappers/companies-house.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty, omitBy } = require('lodash')
+const { omitBy } = require('lodash')
 
 const Company = require('../../../lib/models/company')
 const Address = require('../../../lib/models/address')
@@ -33,7 +33,9 @@ const mapAddress = data => {
     source: Address.ADDRESS_SOURCE.companiesHouse
   }
 
-  return address.fromHash(omitBy(obj, isEmpty))
+  return address.fromHash(omitBy(obj, (value) => {
+    return !value
+  }))
 }
 
 /**

--- a/src/modules/licences/controllers/documents.js
+++ b/src/modules/licences/controllers/documents.js
@@ -15,7 +15,6 @@ const LicenceTransformer = require('../../../lib/licence-transformer')
 const queries = require('../lib/queries')
 const { createContacts } = require('../../../lib/models/factory/contact-list')
 const eventHelper = require('../lib/event-helper')
-const { isEmpty } = require('lodash')
 
 const licencesService = require('../../../lib/services/licences')
 
@@ -314,8 +313,12 @@ const postLicenceName = async (request, h) => {
   const { documentId } = request.params
   const { documentName } = request.payload
   const { data: currentDoc } = await documentsClient.findOne(documentId)
-  if (!currentDoc) { return Boom.notFound(`Document ${documentId} not found`) }
-  const rename = !isEmpty(currentDoc.document_name)
+
+  if (!currentDoc) {
+    return Boom.notFound(`Document ${documentId} not found`)
+  }
+
+  const rename = !!currentDoc.document_name
   const { data } = await documentsClient.setLicenceName(documentId, documentName)
   const metadata = { documentId, documentName, rename }
   const eventData = await eventHelper.saveEvent('licence:name', rename ? 'rename' : 'name', [data.system_external_id], 'completed', request.payload.userName, metadata)

--- a/src/modules/notify/connectors/scheduled-notification.js
+++ b/src/modules/notify/connectors/scheduled-notification.js
@@ -1,10 +1,12 @@
+'use strict'
+
 const Boom = require('@hapi/boom')
 const scheduledNotification = require('../../../controllers/notifications').repository
-const { isArray, mapValues } = require('lodash')
+const { mapValues } = require('lodash')
 const snakeCaseKeys = require('snakecase-keys')
 const { findOne } = require('../../../lib/repository-helpers')
 
-const stringifyArray = (value) => isArray(value) ? JSON.stringify(value) : value
+const stringifyArray = (value) => Array.isArray(value) ? JSON.stringify(value) : value
 
 const mapObjectToNotification = (data) => {
   return mapValues(snakeCaseKeys(data), stringifyArray)

--- a/src/modules/returns/lib/csv-adapter/validator.js
+++ b/src/modules/returns/lib/csv-adapter/validator.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty, flatten, compact, isString, times } = require('lodash')
+const { isEmpty, flatten, compact, times } = require('lodash')
 
 const waterHelpers = require('@envage/water-abstraction-helpers')
 const { returnIDRegex, parseReturnId } = waterHelpers.returns
@@ -50,9 +50,11 @@ const createLicenceReturn = column => ({
  * @return {boolean} True if the value meets the expectation
  */
 const validateExpectation = (expectation, val) => {
-  return isString(expectation)
-    ? val === expectation
-    : expectation(val)
+  if (typeof expectation === 'string') {
+    return val === expectation
+  } else {
+    return expectation(val)
+  }
 }
 
 const getHeadingExpectation = expectation => ({

--- a/src/modules/returns/lib/csv-adapter/validator.js
+++ b/src/modules/returns/lib/csv-adapter/validator.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty, flatten, compact, times } = require('lodash')
+const { flatten, compact, times } = require('lodash')
 
 const waterHelpers = require('@envage/water-abstraction-helpers')
 const { returnIDRegex, parseReturnId } = waterHelpers.returns
@@ -153,7 +153,7 @@ const recordsToLicences = records => {
 const validateLicenceNumber = licence => {
   const { value, line } = licence.licenceNumber
 
-  if (isEmpty(value)) {
+  if (!value) {
     return createError(errorMessages.licenceNumber, line)
   }
 }
@@ -164,7 +164,7 @@ const validateLicenceNumber = licence => {
 const validateReturnReference = licence => {
   const { value, line } = licence.returnReference
 
-  if (isEmpty(value) || /^\d{1,}$/g.test(value) === false) {
+  if (!value || /^\d{1,}$/g.test(value) === false) {
     return createError(errorMessages.returnReference, line)
   }
 }

--- a/test/lib/mappers/change-reason.test.js
+++ b/test/lib/mappers/change-reason.test.js
@@ -32,8 +32,13 @@ experiment('modules/billing/mappers/change-reason', () => {
       result = changeReasonMapper.dbToModel(dbRow)
     })
 
-    test('returns null when data is empty', async () => {
+    test('returns null when data is null', async () => {
       const result = changeReasonMapper.dbToModel(null)
+      expect(result).to.equal(null)
+    })
+
+    test('returns null when data is empty', async () => {
+      const result = changeReasonMapper.dbToModel({})
       expect(result).to.equal(null)
     })
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

Lodash is used a lot in our codebase. Although we are not totally removing this module, some of the functions in the code using lodash are unnecessary. Here we are removing the unnecessary ones are replacing it with vanilla js.
This PR is focusing on the  'isString', 'isArray' and 'isEmpty' functions