### PR TITLE
Fix Cannot read property 'triggersMinimumCharge'

### DIFF
--- a/src/modules/billing/services/charge-processor-service/transactions-processor.js
+++ b/src/modules/billing/services/charge-processor-service/transactions-processor.js
@@ -173,7 +173,8 @@ const doesMinimumChargeApply = (chargePeriod, chargeVersion) => {
   }
 
   const isSharedStartDate = chargePeriodStartDate.isSame(moment(dateRange.startDate), 'day')
-  const isFirstChargeOnNewLicence = isSharedStartDate && changeReason.triggersMinimumCharge ? changeReason.triggersMinimumCharge : false
+  const triggersMinimumCharge = changeReason?.triggersMinimumCharge ?? false
+  const isFirstChargeOnNewLicence = isSharedStartDate && triggersMinimumCharge
 
   return doesChargePeriodStartOnFirstApril(chargePeriodStartDate) || isFirstChargeOnNewLicence
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

A recent change as part of our efforts to remove the code base's dependency on Lodash has introduced an error. The Lodash `get()` method doesn't care if the object you are getting a property from is undefined. It will just return whatever default value you provide.

Our issue is that the existing code nor the tests gave any clue this might be the case. So, though we test for the property `triggersMinimumCharge` we were assuming `changeReason` was defined.

Turns out this is not the case. So, this change fixes the issue and prevents an error from being thrown.