### PR TITLE
Fix column "calculated_volume" does not exist

### DIFF
--- a/src/modules/billing/services/supplementary-billing-service/data-service.js
+++ b/src/modules/billing/services/supplementary-billing-service/data-service.js
@@ -20,37 +20,33 @@ const { actions } = require('./constants')
  */
 const getReversedTransaction = (invoiceLicence, sourceTransaction) => {
   return {
+    billingInvoiceLicenceId: invoiceLicence.id,
     chargeElementId: sourceTransaction.chargeElementId,
     startDate: sourceTransaction.startDate,
     endDate: sourceTransaction.endDate,
     abstractionPeriod: sourceTransaction.abstractionPeriod,
+    source: sourceTransaction.source,
+    season: sourceTransaction.season,
+    loss: sourceTransaction.loss,
     netAmount: sourceTransaction.netAmount,
+    isCredit: !sourceTransaction.isCredit,
+    chargeType: sourceTransaction.chargeType,
     authorisedQuantity: sourceTransaction.authorisedQuantity,
     billableQuantity: sourceTransaction.billableQuantity,
     authorisedDays: sourceTransaction.authorisedDays,
     billableDays: sourceTransaction.billableDays,
+    status: Transaction.statuses.candidate,
     description: sourceTransaction.description,
-    source: sourceTransaction.source,
-    season: sourceTransaction.season,
-    loss: sourceTransaction.loss,
-    chargeType: sourceTransaction.chargeType,
+    externalId: null,
     volume: sourceTransaction.volume,
     section126Factor: sourceTransaction.section126Factor,
     section127Agreement: sourceTransaction.section127Agreement,
     section130Agreement: sourceTransaction.section130Agreement,
-    isTwoPartSecondPartCharge: sourceTransaction.isTwoPartSecondPartCharge,
-    calculatedVolume: sourceTransaction.calculatedVolume,
-    twoPartTariffError: sourceTransaction.twoPartTariffError,
-    twoPartTariffStatus: sourceTransaction.twoPartTariffStatus,
-    twoPartTariffReview: sourceTransaction.twoPartTariffReview,
     isDeMinimis: sourceTransaction.isDeMinimis,
     isNewLicence: sourceTransaction.isNewLicence,
-    billingInvoiceLicenceId: invoiceLicence.id,
-    sourceTransactionId: sourceTransaction.billingTransactionId,
-    status: Transaction.statuses.candidate,
     legacyId: null,
-    externalId: null,
-    isCredit: !sourceTransaction.isCredit
+    sourceTransactionId: sourceTransaction.billingTransactionId,
+    isTwoPartSecondPartCharge: sourceTransaction.isTwoPartSecondPartCharge
   }
 }
 

--- a/test/modules/billing/services/supplementary-billing-service/data-service.test.js
+++ b/test/modules/billing/services/supplementary-billing-service/data-service.test.js
@@ -249,29 +249,28 @@ experiment('modules/billing/services/supplementary-billing-service/data-service'
           'startDate',
           'endDate',
           'abstractionPeriod',
+          'source',
+          'season',
+          'loss',
           'netAmount',
+          'chargeType',
           'authorisedQuantity',
           'billableQuantity',
           'authorisedDays',
           'billableDays',
           'description',
-          'source',
-          'season',
-          'loss',
-          'chargeType',
           'volume',
           'section126Factor',
           'section127Agreement',
           'section130Agreement',
-          'isTwoPartSecondPartCharge',
-          'calculatedVolume',
-          'twoPartTariffError',
-          'twoPartTariffStatus',
-          'twoPartTariffReview',
           'isDeMinimis',
-          'isNewLicence'
+          'isNewLicence',
+          'isTwoPartSecondPartCharge'
         ]
 
+        // NOTE: This is comparing the values passed when creating the transaction, not a direct comparison of the old
+        // and new transaction. Some values will be different which is why `matchingKeys` is a subset of all the
+        // properties on a transaction
         for (const key of matchingKeys) {
           expect(transactions[0][key]).to.equal(createdTransaction[key])
         }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

A recent change as part of our efforts to remove the code base's dependency on Lodash has introduced an error. The Lodash `pick()` method will only 'pick' properties on the provided object if they exist.

We replaced its use `src/modules/billing/services/supplementary-billing-service/data-service.js` with direct calls to the properties thinking the list of keys previously being provided to `pick()` was valid.

It turns out the previous team [moved fields specific to 2 part tariff](https://github.com/DEFRA/water-abstraction-service/pull/932) to a different table (`billing_volumes`) and dropped them from `billing_transactions`. But they didn't update the list of keys being used in `getReversedTransaction()`.

So, we're not assigning properties to the transaction object which don't exist in the table causing an error to be thrown.

```
error: Supplementary processing error for batch 1a48aa9a-e18b-4894-a202-ccc2c86f5974 stack=error: insert into "water"."billing_transactions" ("abstraction_period", "authorised_days", "authorised_quantity", "billable_days", "billable_quantity", "billing_invoice_licence_id", "calculated_volume", "charge_element_id", "charge_type", "date_created", "date_updated", "description", "end_date", "external_id", "is_credit", "is_de_minimis", "is_new_licence", "is_two_part_second_part_charge", "legacy_id", "loss", "net_amount", "season", "section_126_factor", "section_127_agreement", "section_130_agreement", "source", "source_transaction_id", "start_date", "status", "two_part_tariff_error", "two_part_tariff_review", "two_part_tariff_status", "volume") values ($1, $2, $3, $4, $5, $6, DEFAULT, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, DEFAULT, DEFAULT, DEFAULT, $29) returning * - column "calculated_volume" of relation "billing_transactions" does not exist
```

This change updates the list of properties to ensure they match what is in the table. To make it clearer in future it also re-orders them to match their position in the `billing_transactions` table.