### PR TITLE
Fix billing create charge job isReady status check

### DIFF
--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -48,7 +48,7 @@ const isClientError = err => inRange(getStatus(err), 400, 500)
 const updateBatchState = async batchId => {
   const statuses = await batchService.getTransactionStatusCounts(batchId)
 
-  const candidate = statuses.Transaction?.statuses.candidate ?? 0
+  const candidate = statuses[Transaction.statuses.candidate] ?? 0
   const isReady = candidate === 0
 
   if (isReady) {


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

A recent change as part of our efforts to remove the code base's dependency on Lodash has introduced an error. The Lodash `get()` method expects a string which represents the path on the object to find a property.

When we refactored the code away from Lodash it wasn't obvious that the string was being pulled from another module. Instead, it was interpreted as a property on the object we were expecting to find.

For context, this check was being done in the create-charge billing job. Unfortunately (stupidly! 🤬), this job which is created for _every_ transaction that is a candidate in a bill run (so possibly thousands) is also being used to control when to tell the Charging Module API to `/generate` the bill run. This should only be done **once** per bill run.

So, a job which may be queued, and therefore processed, a thousand times is being used to also kick off a one-time-only task. 🤦

How is this handled? Why, by querying the DB _each and every time_ for a count of the transaction statuses in a bill run. Once all report `charge_created`, then `isReady` is true and we kick off the `/generate` task.

1000 hits to the DB to get the transaction data, 1000 hits to the Charging Module, followed by another 1000 hits to see if we have completed talking to the Charging Module. And our bigger bill runs can have transaction lines in the 10's of thousands! 😱😱😱😱😱

Anyway, the refactor meant `isReady` was returning `true` after the first charge was completed. This would mean the Charging Module API `/generate` would be kicked off preventing any more transactions from being added.

This change fixes this issue.