### PR TITLE
Fix broken AccessTokenManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
       TEST_DATABASE_URL: postgres://water_user:password@localhost:5432/wabs_test
       JWT_SECRET: ItsNoSecretBecauseYouToldEverybody
       JWT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwibmFtZSI6InRlc3QiLCJpYXQiOjE1MDMzMTg0NDV9.eWghqjYlPrb8ZjWacYzTCTh1PBtr2BeSv-_ZIwrtmwE
+      COGNITO_HOST: https://mycognitoinstance.amazoncognito.com
+      COGNITO_USERNAME: random5letters6and2numbers7
+      COGNITO_PASSWORD: longer0random9letters1and6numbers8
       # These need to be duplicated in services section for postgres. Unfortunately, there is not a way to reuse them
       PGUSER: water_user
       PGPASSWORD: password

--- a/src/lib/connectors/charge-module/lib/AccessTokenManager.js
+++ b/src/lib/connectors/charge-module/lib/AccessTokenManager.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const moment = require('moment')
 const gotWithProxy = require('./got-with-proxy')
 const urlJoin = require('url-join')
 
@@ -9,26 +8,49 @@ const config = require('../../../../../config.js')
 
 class AccessTokenManager {
   constructor () {
-    this.accessToken = null
-    this.expiresAt = null
+    this._accessToken = null
+    this._expiresAt = null
+  }
+
+  async token (forceRefresh = false) {
+    if (!this._validate() || forceRefresh) {
+      await this._refresh()
+    }
+
+    return this._accessToken
+  }
+
+  /**
+   * Checks whether we have a token, and if so whether it has expired
+   *
+   * @return {Boolean} true if it exists and is not expired, else false
+   */
+  _validate () {
+    if (!this._accessToken) {
+      return false
+    }
+
+    const currentDateTime = new Date()
+    if (this._expiresAt < currentDateTime) {
+      return false
+    }
+
+    return true
   }
 
   /**
    * Fetches a new access token from the cognito API
    * @returns
    */
-  async refreshAccessToken (refDate) {
-    this.tokenCounter()
-    logger.info('Getting a new Cognito token')
+  async _refresh () {
     const uri = urlJoin(config.chargeModule.cognito.host, '/oauth2/token')
-    const buff = Buffer.from(`${config.chargeModule.cognito.username}:${config.chargeModule.cognito.password}`)
     const options = {
       searchParams: {
         grant_type: 'client_credentials'
       },
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
-        authorization: `Basic ${buff.toString('base64')}`
+        authorization: `Basic ${this._encodedCredentials()}`
       }
     }
 
@@ -36,40 +58,27 @@ class AccessTokenManager {
     const { access_token: accessToken, expires_in: expiresIn } = await gotWithProxy.post(uri, options)
 
     // Update this instance with the access token and expiry time
-    this.accessToken = accessToken
-    this.expiresAt = moment(refDate).add(expiresIn, 'second')
-    logger.info(`Obtained a new Cognito token. It expires at ${this.expiresAt.format()}`)
+    this._accessToken = accessToken
+    this._expiresAt = this._expires(expiresIn)
+    logger.info(`Obtained a new Cognito token. It expires at ${this._expiresAt}`)
 
-    return this.accessToken
+    return this._accessToken
   }
 
-  tokenCounter () {
-    if (!global.tokenRequestCount) {
-      global.tokenRequestCount = 0
-    }
+  _encodedCredentials () {
+    const buff = Buffer.from(`${config.chargeModule.cognito.username}:${config.chargeModule.cognito.password}`)
 
-    global.tokenRequestCount += 1
-
-    logger.info(`❗️ Token counter is now ${global.tokenRequestCount}`)
+    return buff.toString('base64')
   }
 
-  /**
-   * Checks whether the current auth token
-   * appears to be valid
-   * @return {Boolean}
-   */
-  isTokenValid () {
-    // Token missing
-    if (!this.accessToken) {
-      logger.info('No cognito token found')
-      return false
-    }
-    // Token expires
-    if (moment().isSameOrAfter(this.expiresAt)) {
-      logger.info('Cognito token expired')
-      return false
-    }
-    return true
+  _expires (expiresIn) {
+    // The expiry time comes to us in seconds so we need to convert it to milliseconds. We also set it to expire 1
+    // minute before the reported expiry time, to avoid cases where the token is retrieved from the cache but expires
+    // before the request can be made
+    const expiresInLessOneMinuteAsMilliseconds = (expiresIn - 60) * 1000
+    const currentDateTime = new Date()
+
+    return new Date(currentDateTime.getTime() + expiresInLessOneMinuteAsMilliseconds)
   }
 }
 

--- a/src/lib/connectors/charge-module/lib/AccessTokenManager.js
+++ b/src/lib/connectors/charge-module/lib/AccessTokenManager.js
@@ -1,9 +1,8 @@
 'use strict'
 
 const gotWithProxy = require('./got-with-proxy')
-const urlJoin = require('url-join')
-
 const { logger } = require('../../../../logger')
+
 const config = require('../../../../../config.js')
 
 class AccessTokenManager {
@@ -43,7 +42,7 @@ class AccessTokenManager {
    * @returns
    */
   async _refresh () {
-    const uri = urlJoin(config.chargeModule.cognito.host, '/oauth2/token')
+    const url = new URL('/oauth2/token', config.chargeModule.cognito.host)
     const options = {
       searchParams: {
         grant_type: 'client_credentials'
@@ -55,7 +54,7 @@ class AccessTokenManager {
     }
 
     // Make got request
-    const { access_token: accessToken, expires_in: expiresIn } = await gotWithProxy.post(uri, options)
+    const { access_token: accessToken, expires_in: expiresIn } = await gotWithProxy.post(url.href, options)
 
     // Update this instance with the access token and expiry time
     this._accessToken = accessToken

--- a/src/lib/connectors/charge-module/lib/AccessTokenManager.js
+++ b/src/lib/connectors/charge-module/lib/AccessTokenManager.js
@@ -18,6 +18,7 @@ class AccessTokenManager {
    * @returns
    */
   async refreshAccessToken (refDate) {
+    this.tokenCounter()
     logger.info('Getting a new Cognito token')
     const uri = urlJoin(config.chargeModule.cognito.host, '/oauth2/token')
     const buff = Buffer.from(`${config.chargeModule.cognito.username}:${config.chargeModule.cognito.password}`)
@@ -40,6 +41,16 @@ class AccessTokenManager {
     logger.info(`Obtained a new Cognito token. It expires at ${this.expiresAt.format()}`)
 
     return this.accessToken
+  }
+
+  tokenCounter () {
+    if (!global.tokenRequestCount) {
+      global.tokenRequestCount = 0
+    }
+
+    global.tokenRequestCount += 1
+
+    logger.info(`❗️ Token counter is now ${global.tokenRequestCount}`)
   }
 
   /**

--- a/src/lib/connectors/charge-module/lib/got-cm.js
+++ b/src/lib/connectors/charge-module/lib/got-cm.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const got = require('got')
-
 const config = require('../../../../../config.js')
 const { logger } = require('../../../../logger.js')
 

--- a/src/lib/connectors/charge-module/lib/got-cm.js
+++ b/src/lib/connectors/charge-module/lib/got-cm.js
@@ -12,27 +12,29 @@ const AccessTokenManager = require('./AccessTokenManager')
 const accessTokenManager = new AccessTokenManager()
 
 /**
- * This hook occurs before the request is made in the lifecycle.
- * It checks if the access token appears to be valid, and if not,
- * requests a new one.
+ * Apply the Charging Module 'authorization' header to the request
  *
- * It then updates the default Authorization header for future
- * requests.
+ * This hook occurs before the request is made in the lifecycle. It uses our `AccessTokenManager` instance to get the
+ * AWS Cognito JWT needed to authenticate with the Charging Module and then uses it to update the Got options
+ * with an 'authorization' header.
  *
- * @param {Object} options - got request options
+ * @param {Object} options The current got request options
  */
-const beforeRequestHook = async () => {
-  if (!accessTokenManager.isTokenValid()) {
-    logger.info('Fetching a new Cognito token')
-    // Save for further requests
-    const accessToken = await accessTokenManager.refreshAccessToken()
-    instance.defaults.options.headers.Authorization = `Bearer ${accessToken}`
+const beforeRequestHook = async (options) => {
+  const token = await accessTokenManager.token()
+
+  options.headers = {
+    authorization: `Bearer ${token}`
   }
 }
 
 /**
- * This hook occurs after the request is made in the lifecycle.
- * It checks if the request failed with a 401 (unauthorized), and
+ * Log errors with responses and retry those failed because of 401 (unauthorized)
+ *
+ * This hook occurs after the request is made in the lifecycle. Any response with a status code of 400 or greater is
+ * logged as an error.
+ *
+ * In the case of a 401 (unauthorized), it forces a refresh of the Charging Module Auth token and tries again
  * if so, it fetches a new access token and retries the request.
  *
  * It also updates the default Authorization header for future
@@ -46,16 +48,13 @@ const afterResponseHook = async (response, retryWithMergedOptions) => {
   }
 
   if (response.statusCode === 401) { // Unauthorized
-    // Refresh the access token
-    const accessToken = await accessTokenManager.refreshAccessToken()
+    // Force a refresh of access token
+    const token = await accessTokenManager.token(true)
     const updatedOptions = {
       headers: {
-        Authorization: `Bearer ${accessToken}`
+        authorization: `Bearer ${token}`
       }
     }
-
-    // Save for further requests
-    instance.defaults.options = got.mergeOptions(instance.defaults.options, updatedOptions)
 
     // Make a new retry
     return retryWithMergedOptions(updatedOptions)


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/74

Whilst digging into an issue with the bill run process we spotted a a number of log messages about the access token being invalid when trying to authenticate. So, we started digging into that and found it is not working on first use.

The previous team chose to take advantage of [Got's hooks](https://github.com/sindresorhus/got/blob/main/documentation/9-hooks.md) to add the authentication header. So, we have this [beforeRequest() hook](https://github.com/sindresorhus/got/blob/main/documentation/9-hooks.md#beforerequest).

```javascript
const beforeRequestHook = async () => {
  if (!accessTokenManager.isTokenValid()) {
    logger.info('Fetching a new Cognito token')
    // Save for further requests
    const accessToken = await accessTokenManager.refreshAccessToken()
    instance.defaults.options.headers.Authorization = `Bearer ${accessToken}`
  }
}
```

The problem is that they are using `instance.defaults.options.` to update the default options for the instance of Got in use. TBH we found little documentation on this property of the Got instance. But it appears in this case it does update, but not for the request in hand. So, on first use the CHA returns a `401` because the auth header is missing.

When the CHA returns [401 Unauthorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) an [afterReponse() hook](https://github.com/sindresorhus/got/blob/main/documentation/9-hooks.md#afterresponse) steps in. It requests another access token from the [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api), amends the `Authorization` header and tries again.

```javascript
const afterResponseHook = async (response, retryWithMergedOptions) => {
  // ...

  if (response.statusCode === 401) { // Unauthorized
    // Refresh the access token
    const accessToken = await accessTokenManager.refreshAccessToken()
    const updatedOptions = {
      headers: {
        Authorization: `Bearer ${accessToken}`
      }
    }

    // Save for further requests
    instance.defaults.options = got.mergeOptions(instance.defaults.options, updatedOptions)

    // Make a new retry
    return retryWithMergedOptions(updatedOptions)
  }

  // No changes otherwise
  return response
}
```

Note we are both updating `instance.defaults.options.` ready for future use and passing the auth header directly to `retryWithMergedOptions()`. This is another indication that updating `instance.defaults.options.` in the `beforeRequestHook()` hook is too late.

The documentation shows an `options` object is passed in, and it's that which needs to be updated.

```javascript
// Edited from the original documentation slightly to be not be an inline function
function beforeRequest (options) {
  options.body = JSON.stringify({payload: 'new'});
	options.headers['content-length'] = options.body.length.toString();
};
```

That's also how we deal with `options` in `src/lib/connectors/charge-module/lib/got-with-proxy.js`. Our testing with the existing code demonstrated this lifecycle for the initial request

- beforeHook()
  - sees the token is invalid
  - *REQUEST* sends request to AWS Cognito for a token
  - fails to add auth header
- *REQUEST* send our request to the Charging Module API
- `401` response
- afterResponseHook()
  - sees the 401 response
  - *REQUEST* sends an additional request to AWS Cognito for another token
  - succeeds in adding auth header
- *REQUEST* retry the original request to the Charging Module API
- `2xx` response

This means each worker (create a bill run, create charges, approve and send etc) is making 4 requests not 2 initially, which doubles the chance of a network failure. For reference, because Got is only used in the BulLMQ workers, each worker is creating it's own instance of Got and the `AccessTokenManager`. There is no easy way to share them across the workers.

So, this change fixes the issues with the `beforeRequestHook()`. Whilst we're at it, we also believe that `AccessTokenManager` can be refactored to simplify its API, removing the need for calling code to decide if a new token is needed. Basically, have the `AccessTokenManager` _manage the token_ 😈

<details><summary>Cleaned logs showing interaction with the Charging Module</summary>
<p>

```bash
-- Create the bill run
2023-02-07T17:59:11.761Z - info: Handling: billing.create-bill-run.ab94be29-5d81-4415-ac3a-a7604eb656d0
2023-02-07T17:59:11.808Z - info: No cognito token found
2023-02-07T17:59:11.808Z - info: Fetching a new Cognito token
2023-02-07T17:59:11.808Z - info: ❗️ Token counter is now 1
2023-02-07T17:59:11.808Z - info: Getting a new Cognito token
2023-02-07T17:59:11.950Z - info: Obtained a new Cognito token. It expires at 2023-02-07T18:59:11+00:00
2023-02-07T17:59:11.959Z - error: Charging Module API error: 401 statusCode=401, error=Unauthorized, message=authorization not found in request headers, error=authorization not found in request headers, component=/lib/connectors/charge-module/lib/got-cm.js:45:12,
2023-02-07T17:59:11.967Z - info: ❗️ Token counter is now 2
2023-02-07T17:59:11.967Z - info: Getting a new Cognito token
2023-02-07T17:59:12.108Z - info: Obtained a new Cognito token. It expires at 2023-02-07T18:59:12+00:00
2023-02-07T17:59:12.155Z - info: onComplete: billing.create-bill-run.ab94be29-5d81-4415-ac3a-a7604eb656d0

2023-02-07T17:59:22.846Z - info: 4 transactions produced for batch ab94be29-5d81-4415-ac3a-a7604eb656d0 - creating charges

-- First transaction to be added to the charging module
2023-02-07T17:59:22.848Z - info: Handling: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.53f8bc8b-162d-46ab-ad42-ac3cf815e470
2023-02-07T17:59:22.879Z - info: No cognito token found
2023-02-07T17:59:22.879Z - info: Fetching a new Cognito token
2023-02-07T17:59:22.880Z - info: ❗️ Token counter is now 1
2023-02-07T17:59:22.880Z - info: Getting a new Cognito token
2023-02-07T17:59:23.006Z - info: Obtained a new Cognito token. It expires at 2023-02-07T18:59:23+00:00
2023-02-07T17:59:23.013Z - error: Charging Module API error: 401 statusCode=401, error=Unauthorized, message=authorization not found in request headers, error=authorization not found in request headers, component=/lib/connectors/charge-module/lib/got-cm.js:45:12,
2023-02-07T17:59:23.021Z - info: ❗️ Token counter is now 2
2023-02-07T17:59:23.021Z - info: Getting a new Cognito token
2023-02-07T17:59:23.148Z - info: Obtained a new Cognito token. It expires at 2023-02-07T18:59:23+00:00
2023-02-07T17:59:23.365Z - info: onComplete: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.53f8bc8b-162d-46ab-ad42-ac3cf815e470

-- Second transaction
2023-02-07T17:59:23.366Z - info: Handling: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.433d4f30-9662-45f4-83dc-0f8af521c87a
2023-02-07T17:59:23.596Z - info: onComplete: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.433d4f30-9662-45f4-83dc-0f8af521c87a

-- Third transaction
2023-02-07T17:59:22.850Z - info: Handling: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.4c512aaa-a112-4ab3-bd48-f6b6f35ce70c
2023-02-07T17:59:23.175Z - info: onComplete: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.4c512aaa-a112-4ab3-bd48-f6b6f35ce70c

-- Fourth transaction
2023-02-07T17:59:23.176Z - info: Handling: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.31e9abcf-c2b0-41aa-a055-1f701c38fb9e
2023-02-07T17:59:23.394Z - info: onComplete: billing.create-charge.ab94be29-5d81-4415-ac3a-a7604eb656d0.31e9abcf-c2b0-41aa-a055-1f701c38fb9e

-- Refresh WRLS from CM invoice data
2023-02-07T17:59:29.415Z - info: Update-invoices child process:  Started updating invoices
2023-02-07T17:59:29.420Z - info: No cognito token found
2023-02-07T17:59:29.421Z - info: Fetching a new Cognito token
2023-02-07T17:59:29.421Z - info: ❗️ Token counter is now 1
2023-02-07T17:59:29.421Z - info: Getting a new Cognito token
2023-02-07T17:59:29.603Z - info: Obtained a new Cognito token. It expires at 2023-02-07T18:59:29+00:00
2023-02-07T17:59:29.611Z - error: Charging Module API error: 401 statusCode=401, error=Unauthorized, message=authorization not found in request headers, error=authorization not found in request headers, component=/lib/connectors/charge-module/lib/got-cm.js:45:12,
2023-02-07T17:59:29.621Z - info: ❗️ Token counter is now 2
2023-02-07T17:59:29.621Z - info: Getting a new Cognito token
2023-02-07T17:59:29.667Z - info: Obtained a new Cognito token. It expires at 2023-02-07T18:59:29+00:00
2023-02-07T17:59:29.747Z - info: Update-invoices child process:  Found 4 transactions to process from the CM for invoice bee6aceb-db25-4f84-aadc-29399290e0ef
```

</p>
</details>