### PR TITLE
Remove 'isObject', 'first', 'isUndefined', and 'find' lodash function

### DIFF
--- a/src/lib/contact-list.js
+++ b/src/lib/contact-list.js
@@ -27,7 +27,7 @@ function getPreferredContact (contacts, rolePriority) {
       return acc
     }
 
-    return contacts.find(o => o.role === role)
+    return contacts.find((o) => o.role === role)
   }, null)
 }
 
@@ -41,7 +41,7 @@ function createSendList (licences, rolePriority) {
 
   licences.forEach(licence => {
     // Get relevant contacts
-    const licenceHolder = licence.contacts.find(o => o.role === 'licence_holder')
+    const licenceHolder = licence.contacts.find((o) => o.role === 'licence_holder')
 
     // Get preferred notification contact
     // In future this may need to support sending specific messages to differnet

--- a/src/lib/contact-list.js
+++ b/src/lib/contact-list.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * Gets a filtered list of licences together with all
  * attached contacts, from the CRM.
@@ -10,7 +12,6 @@
  */
 
 const Boom = require('@hapi/boom')
-const { find } = require('lodash')
 const sha1 = require('sha1')
 const { getDocumentContacts } = require('./connectors/crm/documents')
 
@@ -25,7 +26,8 @@ function getPreferredContact (contacts, rolePriority) {
     if (acc) {
       return acc
     }
-    return find(contacts, { role })
+
+    return contacts.find(o => o.role === role)
   }, null)
 }
 
@@ -39,7 +41,7 @@ function createSendList (licences, rolePriority) {
 
   licences.forEach(licence => {
     // Get relevant contacts
-    const licenceHolder = find(licence.contacts, { role: 'licence_holder' })
+    const licenceHolder = licence.contacts.find(o => o.role === 'licence_holder')
 
     // Get preferred notification contact
     // In future this may need to support sending specific messages to differnet

--- a/src/lib/licence-transformer/csv-transformer.js
+++ b/src/lib/licence-transformer/csv-transformer.js
@@ -2,7 +2,7 @@
  * Transforms NALD data into VML native format
  * @module lib/licence-transformer/nald-transformer
  */
-const { find, uniqBy } = require('lodash')
+const { uniqBy } = require('lodash')
 const BaseTransformer = require('./base-transformer')
 const LicenceTitleLoader = require('./licence-title-loader')
 const licenceTitleLoader = new LicenceTitleLoader()
@@ -140,7 +140,7 @@ class CSVTransformer extends BaseTransformer {
      * @param {String} code - the condition code
      * @param {String} subCode - the sub-condition code
      * @param {String} purpose - the tertiary purpose description
-     * @return {Function} returns a predicate that can be used in lodash/find
+     * @return {Function} returns a predicate that can be used in find
      */
     const conditionMatcher = (code, subCode, purpose) => {
       return (item) => (code === item.code) && (subCode === item.subCode) && (purpose === item.purpose)
@@ -150,7 +150,7 @@ class CSVTransformer extends BaseTransformer {
      * Match a title within the display titles array
      * @param {String} code - the condition code
      * @param {String} subCode - the sub-condition code
-     * @return {Function} returns a predicate that can be used in lodash/find
+     * @return {Function} returns a predicate that can be used in find
      */
     const titleMatcher = (code, subCode) => {
       return (item) => (code === item.code) && (subCode === item.subCode)
@@ -159,7 +159,7 @@ class CSVTransformer extends BaseTransformer {
     /**
      * Match a point within the condition points array
      * @param {Object} point
-     * @return {Function} returns a predicate that can be used in lodash/find
+     * @return {Function} returns a predicate that can be used in find
      */
     const pointMatcher = (points) => {
       return (item) => item.points.join(',') === points.join(',')
@@ -179,15 +179,15 @@ class CSVTransformer extends BaseTransformer {
         }
 
         // Condition wrapper
-        let cWrapper = find(conditionsArr, conditionMatcher(code, subCode, purposeText))
+        let cWrapper = conditionsArr.find(conditionMatcher(code, subCode, purposeText))
         if (!cWrapper) {
-          const titles = find(titleData, titleMatcher(code, subCode))
+          const titles = titleData.find(titleMatcher(code, subCode))
           cWrapper = { ...titles, code, subCode, points: [], purpose: purposeText }
           conditionsArr.push(cWrapper)
         }
 
         // Points wrapper
-        let pWrapper = find(cWrapper.points, pointMatcher(points))
+        let pWrapper = cWrapper.points.find(pointMatcher(points))
         if (!pWrapper) {
           pWrapper = { points, conditions: [] }
           cWrapper.points.push(pWrapper)

--- a/src/lib/licence-transformer/nald-transformer.js
+++ b/src/lib/licence-transformer/nald-transformer.js
@@ -4,7 +4,7 @@
  * Transforms NALD data into VML native format
  * @module lib/licence-transformer/nald-transformer
  */
-const { find, uniqBy } = require('lodash')
+const { uniqBy } = require('lodash')
 const { sentenceCase } = require('sentence-case')
 
 const BaseTransformer = require('./base-transformer')
@@ -27,7 +27,7 @@ class NALDTransformer extends BaseTransformer {
 
     const mostRecentVersionPurposes = data.data.purposes.filter(purpose => purpose.AABV_INCR_NO !== data.data.versions.sort((a, b) => parseInt(b.INCR_NO) - parseInt(a.INCR_NO)))
 
-    const licenceHolderParty = find(currentVersion.parties, (party) => {
+    const licenceHolderParty = currentVersion.parties.find((party) => {
       return party.ID === currentVersion.ACON_APAR_ID
     })
 
@@ -124,11 +124,11 @@ class NALDTransformer extends BaseTransformer {
   contactsFormatter (currentVersion, roles) {
     const contacts = []
 
-    const licenceHolderParty = find(currentVersion.parties, (party) => {
+    const licenceHolderParty = currentVersion.parties.find((party) => {
       return party.ID === currentVersion.ACON_APAR_ID
     })
 
-    const licenceHolderAddress = find(licenceHolderParty.contacts, (contact) => {
+    const licenceHolderAddress = licenceHolderParty.contacts.find((contact) => {
       return contact.AADD_ID === currentVersion.ACON_AADD_ID
     })
 
@@ -208,7 +208,8 @@ class NALDTransformer extends BaseTransformer {
       const periodStart = purpose.PERIOD_ST_DAY + '/' + purpose.PERIOD_ST_MONTH
       const periodEnd = purpose.PERIOD_END_DAY + '/' + purpose.PERIOD_END_MONTH
       // Find existing period
-      let period = find(periods, (item) => item.periodStart === periodStart && item.periodEnd === periodEnd)
+      let period = periods.find((item) => item.periodStart === periodStart && item.periodEnd === periodEnd)
+
       if (period) {
         if (!period.purposes.includes(purpose.purpose[0].purpose_tertiary.DESCR)) {
           period.purposes.push(purpose.purpose[0].purpose_tertiary.DESCR)
@@ -259,7 +260,7 @@ class NALDTransformer extends BaseTransformer {
      * @param {String} code - the condition code
      * @param {String} subCode - the sub-condition code
      * @param {String} purpose - the tertiary purpose description
-     * @return {Function} returns a predicate that can be used in lodash/find
+     * @return {Function} returns a predicate that can be used in find
      */
     const conditionMatcher = (code, subCode, purpose) => {
       return (item) => (code === item.code) && (subCode === item.subCode) && (purpose === item.purpose)
@@ -269,7 +270,7 @@ class NALDTransformer extends BaseTransformer {
      * Match a title within the display titles array
      * @param {String} code - the condition code
      * @param {String} subCode - the sub-condition code
-     * @return {Function} returns a predicate that can be used in lodash/find
+     * @return {Function} returns a predicate that can be used in find
      */
     const titleMatcher = (code, subCode) => {
       return (item) => (code === item.code) && (subCode === item.subCode)
@@ -278,7 +279,7 @@ class NALDTransformer extends BaseTransformer {
     /**
      * Match a point within the condition points array
      * @param {Object} point
-     * @return {Function} returns a predicate that can be used in lodash/find
+     * @return {Function} returns a predicate that can be used in find
      */
     const pointMatcher = (points) => {
       return (item) => item.points.join(',') === points.join(',')
@@ -306,9 +307,10 @@ class NALDTransformer extends BaseTransformer {
         } = purpose.purpose[0].purpose_tertiary
 
         // Condition wrapper
-        let cWrapper = find(conditionsArr, conditionMatcher(code, subCode, purposeText))
+        let cWrapper = conditionsArr.find(conditionMatcher(code, subCode, purposeText))
+
         if (!cWrapper) {
-          const titles = find(titleData, titleMatcher(code, subCode))
+          const titles = titleData.find(titleMatcher(code, subCode))
           cWrapper = {
             ...titles,
             code,
@@ -320,7 +322,7 @@ class NALDTransformer extends BaseTransformer {
         }
 
         // Points wrapper
-        let pWrapper = find(cWrapper.points, pointMatcher(points))
+        let pWrapper = cWrapper.points.find(pointMatcher(points))
         if (!pWrapper) {
           pWrapper = {
             points,

--- a/src/lib/licence-transformer/nald-transformer.js
+++ b/src/lib/licence-transformer/nald-transformer.js
@@ -27,9 +27,7 @@ class NALDTransformer extends BaseTransformer {
 
     const mostRecentVersionPurposes = data.data.purposes.filter(purpose => purpose.AABV_INCR_NO !== data.data.versions.sort((a, b) => parseInt(b.INCR_NO) - parseInt(a.INCR_NO)))
 
-    const licenceHolderParty = currentVersion.parties.find((party) => {
-      return party.ID === currentVersion.ACON_APAR_ID
-    })
+    const licenceHolderParty = currentVersion.parties.find((party) => party.ID === currentVersion.ACON_APAR_ID)
 
     const purposes = data.data.current_version
       ? data.data.current_version.purposes

--- a/src/lib/mappers/company.js
+++ b/src/lib/mappers/company.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { isObject } = require('lodash')
 const Company = require('../models/company')
 
 const { createMapper } = require('../object-mapper')
@@ -48,7 +47,7 @@ const modelToCrm = company => {
 }
 
 const pojoToModel = object => {
-  if (!isObject(object)) {
+  if (!(object instanceof Object)) {
     return null
   }
   const company = new Company()

--- a/src/lib/mappers/contact.js
+++ b/src/lib/mappers/contact.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit, isObject } = require('lodash')
+const { omit } = require('lodash')
 const Contact = require('../models/contact-v2')
 
 const { createMapper } = require('../object-mapper')
@@ -57,7 +57,7 @@ const modelToCrm = contact => {
 }
 
 const pojoToModel = object => {
-  if (!isObject(object)) {
+  if (!(object instanceof Object)) {
     return null
   }
   const model = new Contact()

--- a/src/lib/mappers/user.js
+++ b/src/lib/mappers/user.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { isObject } = require('lodash')
 const User = require('../models/user')
 
 /**
@@ -16,7 +15,9 @@ const dbToModel = data => {
 
 const pojoToModel = dbToModel
 
-const modelToDb = model => isObject(model) ? model.toJSON() : null
+const modelToDb = (model) => {
+  return model instanceof Object ? model.toJSON() : null
+}
 
 exports.dbToModel = dbToModel
 exports.pojoToModel = pojoToModel

--- a/src/lib/models/contact-list.js
+++ b/src/lib/models/contact-list.js
@@ -1,4 +1,4 @@
-const { find } = require('lodash')
+'use strict'
 
 const normaliseString = str => (str || '').trim().toLowerCase()
 
@@ -24,7 +24,7 @@ class ContactList {
    * @return {Contact}      - the contact (if found)
    */
   getByRole (role) {
-    return find(this.contacts, contact => compareRoles(contact.role, role))
+    return this.contacts.find(contact => compareRoles(contact.role, role))
   }
 
   /**

--- a/src/lib/models/contact-list.js
+++ b/src/lib/models/contact-list.js
@@ -24,7 +24,7 @@ class ContactList {
    * @return {Contact}      - the contact (if found)
    */
   getByRole (role) {
-    return this.contacts.find(contact => compareRoles(contact.role, role))
+    return this.contacts.find((contact) => compareRoles(contact.role, role))
   }
 
   /**

--- a/src/lib/models/factory/contact-list.js
+++ b/src/lib/models/factory/contact-list.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { sentenceCase } = require('sentence-case')
-const { find } = require('lodash')
 
 // Import models
 const Contact = require('../contact')
@@ -16,9 +15,11 @@ const { createContact } = require('./contact')
  * @return {Object} the party for the current licence holder
  */
 const getLicenceHolderParty = currentVersion => {
-  return find(currentVersion.parties, (party) => {
+  const result = currentVersion.parties.find((party) => {
     return party.ID === currentVersion.ACON_APAR_ID
   })
+
+  return result
 }
 
 /**
@@ -28,9 +29,11 @@ const getLicenceHolderParty = currentVersion => {
  * @return {Object} the address for the current licence holder
  */
 const getLicenceHolderAddress = (currentVersion, licenceHolderParty) => {
-  return find(licenceHolderParty.contacts, (contact) => {
+  const result = licenceHolderParty.contacts.find((contact) => {
     return contact.AADD_ID === currentVersion.ACON_AADD_ID
   })
+
+  return result
 }
 
 const mapRole = role => sentenceCase(role.role_type.DESCR)

--- a/src/lib/models/model.js
+++ b/src/lib/models/model.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { isObject } = require('lodash')
-
 const { assertId } = require('./validators')
 const { getDateTimeFromValue } = require('../dates')
 
@@ -70,7 +68,7 @@ class Model {
     return Object.keys(this).reduce((acc, key) => {
       const externalKey = key.replace('_', '')
       const value = this[externalKey]
-      acc[externalKey] = isObject(value) && value.toJSON ? value.toJSON() : value
+      acc[externalKey] = value instanceof Object && value.toJSON ? value.toJSON() : value
       return acc
     }, {})
   }

--- a/src/lib/object-mapper.js
+++ b/src/lib/object-mapper.js
@@ -6,7 +6,7 @@
  *         by default nulls are mapped, with an option of ignoring them
  */
 
-const { identity, set, isUndefined, isNull, isFunction, isObject } = require('lodash')
+const { identity, set, isUndefined, isNull, isFunction } = require('lodash')
 
 const getSourceKeys = value => {
   if (Array.isArray(value)) {
@@ -41,7 +41,7 @@ class Mapper {
    */
   to (targetKey, ...args) {
     const mapper = isFunction(args[0]) ? args[0] : null
-    const options = isObject(args[args.length - 1]) ? args[args.length - 1] : {}
+    const options = args[args.length - 1] instanceof Object ? args[args.length - 1] : {}
 
     if (this._sourceKeys.length > 1 && !mapper) {
       throw new Error(`error mapping to .${targetKey}: when >1 source key, a mapper is required`)

--- a/src/lib/object-mapper.js
+++ b/src/lib/object-mapper.js
@@ -6,12 +6,12 @@
  *         by default nulls are mapped, with an option of ignoring them
  */
 
-const { identity, set, isUndefined, isNull, isFunction } = require('lodash')
+const { identity, set, isNull, isFunction } = require('lodash')
 
 const getSourceKeys = value => {
   if (Array.isArray(value)) {
     return value
-  } else if (isUndefined(value)) {
+  } else if (value === undefined) {
     return []
   }
   return [value]
@@ -90,7 +90,7 @@ class Mapper {
       }
 
       // Undefined values in the source are skipped
-      if (values.every(isUndefined)) {
+      if (values.every(val => val === undefined)) {
         return acc
       }
 

--- a/src/lib/object-mapper.js
+++ b/src/lib/object-mapper.js
@@ -89,7 +89,7 @@ class Mapper {
       }
 
       // Undefined values in the source are skipped
-      if (values.every(val => val === undefined)) {
+      if (values.every((val) => val === undefined)) {
         return acc
       }
 

--- a/src/lib/repository-helpers.js
+++ b/src/lib/repository-helpers.js
@@ -1,4 +1,5 @@
-const { isObject } = require('lodash')
+'use strict'
+
 const Boom = require('@hapi/boom')
 
 /**
@@ -11,8 +12,7 @@ const Boom = require('@hapi/boom')
  */
 const findOne = async (repository, id) => {
   const { primaryKey } = repository.config
-
-  const filter = isObject(id) ? id : { [primaryKey]: id }
+  const filter = id instanceof Object ? id : { [primaryKey]: id }
 
   let response
 

--- a/src/lib/services/invoice-service.js
+++ b/src/lib/services/invoice-service.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { find, partialRight, pickBy } = require('lodash')
+const { partialRight, pickBy } = require('lodash')
 const pWaterfall = require('p-waterfall')
 
 const { logger } = require('../../logger')
@@ -113,7 +113,7 @@ const getInvoice = async context => {
  * @param {Object} context
  */
 const decorateInvoiceWithCRMData = (invoice, context) => {
-  const crmInvoiceAccount = find(context.crmInvoiceAccounts, { invoiceAccountId: invoice.invoiceAccount.id })
+  const crmInvoiceAccount = context.crmInvoiceAccounts.find(o => o.invoiceAccountId === invoice.invoiceAccount.id)
 
   const properties = mappers.invoice.crmToModel(crmInvoiceAccount).pick(
     'address',
@@ -151,7 +151,7 @@ const mapToInvoices = async context => {
 const mapBillingAccountNameToInvoices = async context => {
   const invoices = []
   for (const billingInvoice of context.billingInvoices) {
-    const crmInvoiceAccount = find(context.crmInvoiceAccounts, { invoiceAccountId: billingInvoice.invoiceAccountId })
+    const crmInvoiceAccount = context.crmInvoiceAccounts.find(o => o.invoiceAccountId === billingInvoice.invoiceAccountId)
     invoices.push({ ...billingInvoice, invoiceAccount: crmInvoiceAccount })
   }
   return invoices

--- a/src/lib/services/invoice-service.js
+++ b/src/lib/services/invoice-service.js
@@ -113,7 +113,7 @@ const getInvoice = async context => {
  * @param {Object} context
  */
 const decorateInvoiceWithCRMData = (invoice, context) => {
-  const crmInvoiceAccount = context.crmInvoiceAccounts.find(o => o.invoiceAccountId === invoice.invoiceAccount.id)
+  const crmInvoiceAccount = context.crmInvoiceAccounts.find((o) => o.invoiceAccountId === invoice.invoiceAccount.id)
 
   const properties = mappers.invoice.crmToModel(crmInvoiceAccount).pick(
     'address',
@@ -151,7 +151,7 @@ const mapToInvoices = async context => {
 const mapBillingAccountNameToInvoices = async context => {
   const invoices = []
   for (const billingInvoice of context.billingInvoices) {
-    const crmInvoiceAccount = context.crmInvoiceAccounts.find(o => o.invoiceAccountId === billingInvoice.invoiceAccountId)
+    const crmInvoiceAccount = context.crmInvoiceAccounts.find((o) => o.invoiceAccountId === billingInvoice.invoiceAccountId)
     invoices.push({ ...billingInvoice, invoiceAccount: crmInvoiceAccount })
   }
   return invoices

--- a/src/lib/services/returns/api-connector.js
+++ b/src/lib/services/returns/api-connector.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { first } = require('lodash')
 const apiConnector = require('../../connectors/returns')
 
 /**
@@ -37,7 +36,7 @@ const getCurrentVersion = async returnId => {
   }
   const sort = { version_number: -1 }
   const versions = await apiConnector.versions.findAll(filter, sort)
-  return first(versions)
+  return versions[0]
 }
 
 /**

--- a/src/lib/services/returns/index.js
+++ b/src/lib/services/returns/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { flatMap, first, identity } = require('lodash')
+const { flatMap, identity } = require('lodash')
 const bluebird = require('bluebird')
 const moment = require('moment')
 
@@ -147,11 +147,13 @@ const getFilterStartDate = (document) => {
  * @param {Document} document
  * @return {String} date YYYY-MM-DD
  */
-const getFilterEndDate = document => first(
-  [document.dateRange.endDate, moment().format(DATE_FORMAT)]
+const getFilterEndDate = (document) => {
+  const result = [document.dateRange.endDate, moment().format(DATE_FORMAT)]
     .filter(identity)
     .sort()
-)
+
+  return result[0]
+}
 
 /**
  * Gets both the CRM document and a list of returns for the specified

--- a/src/lib/services/returns/returns-mapping-service.js
+++ b/src/lib/services/returns/returns-mapping-service.js
@@ -36,7 +36,7 @@ const getReturnRequirements = returnsData => {
  */
 const mapReturnDataToModel = (returnData, returnRequirements) => {
   const externalId = getReturnRequirementExternalId(returnData)
-  const returnRequirement = returnRequirements.find(o => o.externalId === externalId)
+  const returnRequirement = returnRequirements.find((o) => o.externalId === externalId)
   return returnMapper.returnsServiceToModel(returnData, returnRequirement)
 }
 

--- a/src/lib/services/returns/returns-mapping-service.js
+++ b/src/lib/services/returns/returns-mapping-service.js
@@ -9,7 +9,7 @@
 const returnRequirementsService = require('../return-requirements')
 const returnMapper = require('../../mappers/return')
 
-const { uniq, find } = require('lodash')
+const { uniq } = require('lodash')
 
 const getReturnRequirementExternalId = returnData => `${returnData.metadata.nald.regionCode}:${returnData.metadata.nald.formatId}`
 
@@ -36,7 +36,7 @@ const getReturnRequirements = returnsData => {
  */
 const mapReturnDataToModel = (returnData, returnRequirements) => {
   const externalId = getReturnRequirementExternalId(returnData)
-  const returnRequirement = find(returnRequirements, { externalId })
+  const returnRequirement = returnRequirements.find(o => o.externalId === externalId)
   return returnMapper.returnsServiceToModel(returnData, returnRequirement)
 }
 

--- a/src/lib/stringify-values.js
+++ b/src/lib/stringify-values.js
@@ -1,4 +1,6 @@
-const { isArray, isObject, mapValues } = require('lodash')
+'use strict'
+
+const { mapValues } = require('lodash')
 
 /**
  * Stringifies array/object data for writing to DB
@@ -6,12 +8,14 @@ const { isArray, isObject, mapValues } = require('lodash')
  * @return {Object}      - row data with arrays/objects stringified
  */
 const stringifyValues = data => {
-  return mapValues(data, (value, key) => {
-    if (isArray(value) || isObject(value)) {
+  const result = mapValues(data, (value, key) => {
+    if (value instanceof Object) {
       return JSON.stringify(value)
     }
     return value
   })
+
+  return result
 }
 
 exports.stringifyValues = stringifyValues

--- a/src/modules/ar-analysis/lib/licence-row-mapper.js
+++ b/src/modules/ar-analysis/lib/licence-row-mapper.js
@@ -1,5 +1,7 @@
+'use strict'
+
 const moment = require('moment')
-const { find, intersection } = require('lodash')
+const { intersection } = require('lodash')
 
 const inReviewFilter = action => action.payload.status === 'In review'
 const approvedFilter = action => action.payload.status === 'Approved'
@@ -29,7 +31,7 @@ const getFirstEditTimestamp = (actions) => {
  * @return {String} ISO 8601 timestamp
  */
 const getTimestamp = (actions, predicate) => {
-  const action = find(actions, predicate)
+  const action = actions.find(predicate)
   return action ? getActionTimestamp(action) : null
 }
 

--- a/src/modules/batch-notifications/config/returns/lib/create-notification-data.js
+++ b/src/modules/batch-notifications/config/returns/lib/create-notification-data.js
@@ -98,7 +98,9 @@ const templateRandomiser = templateType => {
 
 const getRelevantRowData = (rows, reminderRef) => {
   const contactAndMessageType = reminderRef.substring(17) // remove 'returns_invitation' from beginning
-  return (rows.filter(row => row.message_ref.includes(contactAndMessageType)))[0]
+  const filteredRows = rows.filter((row) =>
+    row.message_ref.includes(contactAndMessageType))
+  return filteredRows[0]
 }
 
 const reminderSuffixMap = {

--- a/src/modules/batch-notifications/config/returns/lib/create-notification-data.js
+++ b/src/modules/batch-notifications/config/returns/lib/create-notification-data.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { v4: uuid } = require('uuid')
-const { first } = require('lodash')
 
 const { MESSAGE_STATUS_DRAFT } = require('../../../lib/message-statuses')
 const notifyHelpers = require('../../../lib/notify-helpers')
@@ -99,7 +98,7 @@ const templateRandomiser = templateType => {
 
 const getRelevantRowData = (rows, reminderRef) => {
   const contactAndMessageType = reminderRef.substring(17) // remove 'returns_invitation' from beginning
-  return first(rows.filter(row => row.message_ref.includes(contactAndMessageType)))
+  return (rows.filter(row => row.message_ref.includes(contactAndMessageType)))[0]
 }
 
 const reminderSuffixMap = {

--- a/src/modules/batch-notifications/controller.js
+++ b/src/modules/batch-notifications/controller.js
@@ -24,7 +24,7 @@ const postPrepare = async (request, h) => {
 
   try {
     // Get message config based on message type
-    const config = configs.find(o => o.messageType === messageType)
+    const config = configs.find((o) => o.messageType === messageType)
 
     // Validate payload against schema defined in message config
     const { error } = config.schema.validate(data)

--- a/src/modules/batch-notifications/controller.js
+++ b/src/modules/batch-notifications/controller.js
@@ -2,7 +2,6 @@
 
 const Boom = require('@hapi/boom')
 const { logger } = require('../../logger')
-const { find } = require('lodash')
 
 const configs = require('./config')
 
@@ -25,7 +24,7 @@ const postPrepare = async (request, h) => {
 
   try {
     // Get message config based on message type
-    const config = find(configs, { messageType })
+    const config = configs.find(o => o.messageType === messageType)
 
     // Validate payload against schema defined in message config
     const { error } = config.schema.validate(data)

--- a/src/modules/batch-notifications/lib/batch-notifications.js
+++ b/src/modules/batch-notifications/lib/batch-notifications.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { find } = require('lodash')
 const configs = require('../config')
 const eventsService = require('../../../lib/services/events')
 
@@ -17,7 +16,7 @@ const loadJobData = async (eventId) => {
   }
 
   // Load config
-  const config = find(configs, { messageType: event.subtype })
+  const config = configs.find(o => o.messageType === event.subtype)
   if (!config) {
     throw new Error(`Batch notification ${event.subtype} not found`)
   }

--- a/src/modules/batch-notifications/lib/batch-notifications.js
+++ b/src/modules/batch-notifications/lib/batch-notifications.js
@@ -16,7 +16,7 @@ const loadJobData = async (eventId) => {
   }
 
   // Load config
-  const config = configs.find(o => o.messageType === event.subtype)
+  const config = configs.find((o) => o.messageType === event.subtype)
   if (!config) {
     throw new Error(`Batch notification ${event.subtype} not found`)
   }

--- a/src/modules/batch-notifications/lib/event-helpers.js
+++ b/src/modules/batch-notifications/lib/event-helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { find, set, uniq } = require('lodash')
+const { set, uniq } = require('lodash')
 const generateReference = require('../../../lib/reference-generator')
 const {
   EVENT_STATUS_PROCESSING, EVENT_STATUS_PROCESSED, EVENT_STATUS_SENDING,
@@ -70,7 +70,7 @@ const markAsProcessed = async (eventId, licenceNumbers, recipientCount) => {
  * @return {Number} of messages in the requested status
  */
 const getStatusCount = (statuses, status) => {
-  const foundStatus = find(statuses, { status })
+  const foundStatus = statuses.find(o => o.status === status)
   const count = foundStatus.count ?? 0
 
   return parseInt(count)

--- a/src/modules/batch-notifications/lib/event-helpers.js
+++ b/src/modules/batch-notifications/lib/event-helpers.js
@@ -70,7 +70,7 @@ const markAsProcessed = async (eventId, licenceNumbers, recipientCount) => {
  * @return {Number} of messages in the requested status
  */
 const getStatusCount = (statuses, status) => {
-  const foundStatus = statuses.find(o => o.status === status)
+  const foundStatus = statuses.find((o) => o.status === status)
   const count = foundStatus.count ?? 0
 
   return parseInt(count)

--- a/src/modules/billing/lib/charge-period.js
+++ b/src/modules/billing/lib/charge-period.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const moment = require('moment')
-const { sortBy, first, identity } = require('lodash')
+const { sortBy, identity } = require('lodash')
 
 const config = require('../../../../config')
 
@@ -22,7 +22,7 @@ const getSortedDates = arr => sortBy(
   m => m.unix()
 )
 
-const getMinDate = arr => first(getSortedDates(arr))
+const getMinDate = arr => getSortedDates(arr)[0]
 const getMaxDate = (arr) => {
   const sorted = getSortedDates(arr)
   return sorted[sorted.length - 1]

--- a/src/modules/internal-search/lib/search-returns.js
+++ b/src/modules/internal-search/lib/search-returns.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { groupBy, mapValues, first } = require('lodash')
+const { groupBy, mapValues } = require('lodash')
 const helpers = require('@envage/water-abstraction-helpers')
 const { throwIfError } = require('@envage/hapi-pg-rest-api')
 const returnsService = require('../../../lib/connectors/returns')
@@ -82,7 +82,7 @@ const mapRecentReturns = (returns) => {
   const grouped = groupBy(returns, ret => ret.metadata.nald.regionCode)
 
   // Discard all but last item in each group
-  const filtered = mapValues(grouped, group => first(group))
+  const filtered = mapValues(grouped, group => group[0])
 
   // Return the values from each group as array
   return Object.values(filtered)

--- a/src/modules/licences/controllers/documents.js
+++ b/src/modules/licences/controllers/documents.js
@@ -2,7 +2,6 @@
 
 const moment = require('moment')
 const Boom = require('@hapi/boom')
-const { isObject } = require('lodash')
 const documentsClient = require('../../../lib/connectors/crm/documents')
 const crmEntities = require('../../../lib/connectors/crm/entities')
 const { usersClient } = require('../../../lib/connectors/idm')
@@ -58,7 +57,7 @@ const throwIfUnauthorised = (documentHeader, companyId) => {
  * @return {Promise}                resolves with permit repo data
  */
 const getLicence = async (document, includeExpired, companyId) => {
-  const documentHeader = isObject(document)
+  const documentHeader = document instanceof Object
     ? document
     : await getDocumentHeader(document, includeExpired)
 

--- a/src/modules/returns/controllers/csv-upload.js
+++ b/src/modules/returns/controllers/csv-upload.js
@@ -76,7 +76,7 @@ const getUploadPreviewReturn = async (request, h) => {
   const { returnId } = request.params
 
   try {
-    const match = request.jsonData.find(o => o.returnId === returnId)
+    const match = request.jsonData.find((o) => o.returnId === returnId)
 
     if (!match) {
       throw Boom.notFound(`Return ${returnId} not found in upload`, request.params)

--- a/src/modules/returns/controllers/csv-upload.js
+++ b/src/modules/returns/controllers/csv-upload.js
@@ -5,7 +5,7 @@
  */
 
 const Boom = require('@hapi/boom')
-const { find, set } = require('lodash')
+const { set } = require('lodash')
 const { throwIfError } = require('@envage/hapi-pg-rest-api')
 
 const eventFactory = require('../lib/event-factory')
@@ -76,7 +76,7 @@ const getUploadPreviewReturn = async (request, h) => {
   const { returnId } = request.params
 
   try {
-    const match = find(request.jsonData, { returnId })
+    const match = request.jsonData.find(o => o.returnId === returnId)
 
     if (!match) {
       throw Boom.notFound(`Return ${returnId} not found in upload`, request.params)

--- a/src/modules/returns/lib/jobs/persist-returns.js
+++ b/src/modules/returns/lib/jobs/persist-returns.js
@@ -70,7 +70,7 @@ const persistReturn = async (validatedReturn, returnToSave) => {
  */
 const createMapper = allReturns => validatedReturn => {
   const { returnId } = validatedReturn
-  const returnToSave = allReturns.find(o => o.returnId === returnId)
+  const returnToSave = allReturns.find((o) => o.returnId === returnId)
   return persistReturn(validatedReturn, returnToSave)
 }
 

--- a/src/modules/returns/lib/jobs/persist-returns.js
+++ b/src/modules/returns/lib/jobs/persist-returns.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { find, set } = require('lodash')
+const { set } = require('lodash')
 const eventsService = require('../../../../lib/services/events')
 const { logger } = require('../../../../logger')
 const returnsUpload = require('../../lib/returns-upload')
@@ -70,7 +70,7 @@ const persistReturn = async (validatedReturn, returnToSave) => {
  */
 const createMapper = allReturns => validatedReturn => {
   const { returnId } = validatedReturn
-  const returnToSave = find(allReturns, { returnId })
+  const returnToSave = allReturns.find(o => o.returnId === returnId)
   return persistReturn(validatedReturn, returnToSave)
 }
 

--- a/src/modules/returns/lib/returns-upload-validator.js
+++ b/src/modules/returns/lib/returns-upload-validator.js
@@ -154,7 +154,7 @@ const validateLineFrequency = ret => {
  */
 const validateLicence = (ret, context) => {
   const externalId = getDocumentFilter(ret.licenceNumber)
-  return context.documents.find(o => o.system_external_id === externalId.system_external_id)
+  return context.documents.find((o) => o.system_external_id === externalId.system_external_id)
 }
 
 /**
@@ -165,7 +165,7 @@ const validateLicence = (ret, context) => {
  */
 const validatePermission = (ret, context) => {
   const result = getCompanyDocumentFilter(ret.licenceNumber, context.companyId)
-  return context.documents.find(o => o.system_external_id === result.system_external_id && o.company_entity_id === result.company_entity_id)
+  return context.documents.find((o) => o.system_external_id === result.system_external_id && o.company_entity_id === result.company_entity_id)
 }
 
 /**
@@ -175,7 +175,7 @@ const validatePermission = (ret, context) => {
  * @return {Boolean}         true if return found
  */
 const validateReturnExists = (ret, context) => {
-  return context.returns.find(o => o.return_id === ret.returnId)
+  return context.returns.find((o) => o.return_id === ret.returnId)
 }
 
 /**

--- a/src/modules/returns/lib/returns-upload-validator.js
+++ b/src/modules/returns/lib/returns-upload-validator.js
@@ -111,7 +111,7 @@ const validateReturnlines = (ret, context) => {
   }
 
   // Generate required lines specified by return header
-  const header = context.returns.find(o => o.return_id === ret.returnId)
+  const header = context.returns.find((o) => o.return_id === ret.returnId)
   const requiredLines = returnLines.getRequiredLines(
     header.start_date,
     header.end_date,
@@ -185,7 +185,7 @@ const validateReturnExists = (ret, context) => {
  * @return {Boolean}         true if return is due
  */
 const validateReturnDue = (ret, context) => {
-  const match = context.returns.find(o => o.return_id === ret.returnId)
+  const match = context.returns.find((o) => o.return_id === ret.returnId)
   return match.status === 'due'
 }
 

--- a/src/modules/returns/lib/xml-adapter/mapper.js
+++ b/src/modules/returns/lib/xml-adapter/mapper.js
@@ -248,7 +248,7 @@ const getReturnIds = returns => returns.map(ret => ret.returnId)
  */
 const mapReturnsData = (ret, returnsData) => {
   const { returnId } = ret
-  const match = returnsData.find(o => o.return_id === returnId)
+  const match = returnsData.find((o) => o.return_id === returnId)
   return {
     ...ret,
     dueDate: match.due_date

--- a/src/modules/returns/lib/xml-adapter/mapper.js
+++ b/src/modules/returns/lib/xml-adapter/mapper.js
@@ -4,7 +4,7 @@ const moment = require('moment')
 const waterHelpers = require('@envage/water-abstraction-helpers')
 const { getReturnId } = waterHelpers.returns
 
-const { flatMap, uniq, find, intersection } = require('lodash')
+const { flatMap, uniq, intersection } = require('lodash')
 const libxmljs = require('libxmljs')
 
 const returnsConnector = require('../../../../lib/connectors/returns')
@@ -248,7 +248,7 @@ const getReturnIds = returns => returns.map(ret => ret.returnId)
  */
 const mapReturnsData = (ret, returnsData) => {
   const { returnId } = ret
-  const match = find(returnsData, { return_id: returnId })
+  const match = returnsData.find(o => o.return_id === returnId)
   return {
     ...ret,
     dueDate: match.due_date

--- a/test/lib/services/invoice-service.test.js
+++ b/test/lib/services/invoice-service.test.js
@@ -414,12 +414,12 @@ experiment('modules/billing/services/invoiceService', () => {
       })
 
       test('has the correct transaction amount for transaction 1', async () => {
-        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[0])
+        const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[0])
         expect(transaction.value).to.equal(2345)
       })
 
       test('has the correct transaction amount for transaction 2', async () => {
-        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[1])
+        const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[1])
         expect(transaction.value).to.equal(10000)
       })
 
@@ -452,12 +452,12 @@ experiment('modules/billing/services/invoiceService', () => {
       })
 
       test('has the correct transaction amount for transaction 1', async () => {
-        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[4])
+        const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[4])
         expect(transaction.value).to.equal(100)
       })
 
       test('has the correct transaction amount for transaction 2', async () => {
-        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[5])
+        const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[5])
         expect(transaction.value).to.equal(-200)
       })
 
@@ -490,12 +490,12 @@ experiment('modules/billing/services/invoiceService', () => {
       })
 
       test('has the correct transaction amount for transaction 1', async () => {
-        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[2])
+        const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[2])
         expect(transaction.value).to.equal(400)
       })
 
       test('has the correct transaction amount for transaction 2', async () => {
-        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[3])
+        const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[3])
         expect(transaction.value).to.equal(123)
       })
 
@@ -567,12 +567,12 @@ experiment('modules/billing/services/invoiceService', () => {
         })
 
         test('has the correct transaction amount for transaction 1', async () => {
-          const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[0])
+          const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[0])
           expect(transaction.value).to.equal(2345)
         })
 
         test('has the correct transaction amount for transaction 2', async () => {
-          const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[1])
+          const transaction = invoice.invoiceLicences[0].transactions.find((o) => o.externalId === IDS.transactions[1])
           expect(transaction.value).to.equal(10000)
         })
 

--- a/test/lib/services/invoice-service.test.js
+++ b/test/lib/services/invoice-service.test.js
@@ -10,7 +10,6 @@ const { expect } = require('@hapi/code')
 const sinon = require('sinon')
 const sandbox = sinon.createSandbox()
 const { v4: uuid } = require('uuid')
-const { find } = require('lodash')
 
 const Batch = require('../../../src/lib/models/batch')
 const Invoice = require('../../../src/lib/models/invoice')
@@ -161,7 +160,7 @@ const createBatchDataWithoutTransactions = () => {
 const getInvoiceAccountNumber = invoice => invoice.invoiceAccount.accountNumber
 const getInvoiceFinancialYear = invoice => invoice.financialYear.yearEnding
 
-const findInvoice = (invoices, accountNumber, financialYear) => find(invoices, invoice =>
+const findInvoice = (invoices, accountNumber, financialYear) => invoices.find(invoice =>
   getInvoiceAccountNumber(invoice) === accountNumber && getInvoiceFinancialYear(invoice) === financialYear
 )
 
@@ -415,12 +414,12 @@ experiment('modules/billing/services/invoiceService', () => {
       })
 
       test('has the correct transaction amount for transaction 1', async () => {
-        const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[0] })
+        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[0])
         expect(transaction.value).to.equal(2345)
       })
 
       test('has the correct transaction amount for transaction 2', async () => {
-        const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[1] })
+        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[1])
         expect(transaction.value).to.equal(10000)
       })
 
@@ -453,12 +452,12 @@ experiment('modules/billing/services/invoiceService', () => {
       })
 
       test('has the correct transaction amount for transaction 1', async () => {
-        const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[4] })
+        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[4])
         expect(transaction.value).to.equal(100)
       })
 
       test('has the correct transaction amount for transaction 2', async () => {
-        const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[5] })
+        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[5])
         expect(transaction.value).to.equal(-200)
       })
 
@@ -491,12 +490,12 @@ experiment('modules/billing/services/invoiceService', () => {
       })
 
       test('has the correct transaction amount for transaction 1', async () => {
-        const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[2] })
+        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[2])
         expect(transaction.value).to.equal(400)
       })
 
       test('has the correct transaction amount for transaction 2', async () => {
-        const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[3] })
+        const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[3])
         expect(transaction.value).to.equal(123)
       })
 
@@ -568,12 +567,12 @@ experiment('modules/billing/services/invoiceService', () => {
         })
 
         test('has the correct transaction amount for transaction 1', async () => {
-          const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[0] })
+          const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[0])
           expect(transaction.value).to.equal(2345)
         })
 
         test('has the correct transaction amount for transaction 2', async () => {
-          const transaction = find(invoice.invoiceLicences[0].transactions, { externalId: IDS.transactions[1] })
+          const transaction = invoice.invoiceLicences[0].transactions.find(o => o.externalId === IDS.transactions[1])
           expect(transaction.value).to.equal(10000)
         })
 

--- a/test/modules/returns/lib/csv-adapter/mapper.test.js
+++ b/test/modules/returns/lib/csv-adapter/mapper.test.js
@@ -159,7 +159,7 @@ experiment('returns CSV to JSON mapper', () => {
     })
 
     test('maps numbers into a return line with numeric quantity', async () => {
-      const line = result.find(o => o.endDate === '2019-04-06')
+      const line = result.find((o) => o.endDate === '2019-04-06')
       expect(line).to.equal({
         unit: 'm³',
         userUnit: 'm³',
@@ -172,7 +172,7 @@ experiment('returns CSV to JSON mapper', () => {
     })
 
     test('maps empty cell to a return line with a null quantity', async () => {
-      const line = result.find(o => o.endDate === '2019-04-13')
+      const line = result.find((o) => o.endDate === '2019-04-13')
       expect(line).to.equal({
         unit: 'm³',
         userUnit: 'm³',
@@ -185,7 +185,7 @@ experiment('returns CSV to JSON mapper', () => {
     })
 
     test('excludes cells containing "Do not edit" from the mapped lines', async () => {
-      const line = result.find(o => o.endDate === '2019-04-20')
+      const line = result.find((o) => o.endDate === '2019-04-20')
       expect(line).to.be.undefined()
     })
   })

--- a/test/modules/returns/lib/csv-adapter/mapper.test.js
+++ b/test/modules/returns/lib/csv-adapter/mapper.test.js
@@ -1,5 +1,6 @@
+'use strict'
+
 const { expect } = require('@hapi/code')
-const { find } = require('lodash')
 const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
 const sandbox = require('sinon').createSandbox()
 const moment = require('moment')
@@ -158,7 +159,7 @@ experiment('returns CSV to JSON mapper', () => {
     })
 
     test('maps numbers into a return line with numeric quantity', async () => {
-      const line = find(result, { endDate: '2019-04-06' })
+      const line = result.find(o => o.endDate === '2019-04-06')
       expect(line).to.equal({
         unit: 'm³',
         userUnit: 'm³',
@@ -171,7 +172,7 @@ experiment('returns CSV to JSON mapper', () => {
     })
 
     test('maps empty cell to a return line with a null quantity', async () => {
-      const line = find(result, { endDate: '2019-04-13' })
+      const line = result.find(o => o.endDate === '2019-04-13')
       expect(line).to.equal({
         unit: 'm³',
         userUnit: 'm³',
@@ -184,7 +185,7 @@ experiment('returns CSV to JSON mapper', () => {
     })
 
     test('excludes cells containing "Do not edit" from the mapped lines', async () => {
-      const line = find(result, { endDate: '2019-04-20' })
+      const line = result.find(o => o.endDate === '2019-04-20')
       expect(line).to.be.undefined()
     })
   })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

Lodash is used a lot in our codebase. Although we are not totally removing this module, some of the functions in the code using lodash are unnecessary. Here we are removing the unnecessary ones are replacing it with vanilla js. 
This PR is focusing on the 'isObject', 'first', 'isUndefined', and 'find' functions