### PR TITLE
Make Got http request retries more robust

### DIFF
--- a/src/lib/connectors/charge-module/lib/got-cm.js
+++ b/src/lib/connectors/charge-module/lib/got-cm.js
@@ -66,13 +66,26 @@ const afterResponseHook = async (response, retryWithMergedOptions) => {
 }
 
 /**
- * Creates a got instance which is further extended to include:
+ * Creates an extended Got instance
  *
- * - fetching of access token
+ * The Got default options are updated to include:
+ *
  * - prefixUrl set to the CM API base URL
+ * - JSON response types (all the CM APIs have JSON responses)
+ * - how long to try before timing out the request
+ * - Resolve with the response body only - this helps make the API more compatible with request which was
+ *   used previously
+ *
+ * We also add 2 hooks; beforeRequest() to handle applying the auth header and token and afterResponse() to handle
+ * logging errors and force a token refresh on a 401 Unauthorized response.
  */
 const instance = gotWithProxy.extend({
   prefixUrl: config.chargeModule.host,
+  responseType: 'json',
+  resolveBodyOnly: true,
+  timeout: {
+    request: 10000
+  },
   // Got has a built in retry mechanism. We have found though you have to be careful with what gets retried. Our
   // preference is to only retry in the event of a timeout on assumption the destination server might be busy but has
   // a chance to succeed when attempted again

--- a/src/lib/connectors/charge-module/lib/got-with-proxy.js
+++ b/src/lib/connectors/charge-module/lib/got-with-proxy.js
@@ -22,20 +22,13 @@ const beforeRequestHook = options => {
 }
 
 /**
- * Creates a got instance which is extended to include:
+ * Creates an extended Got instance
+ *
+ * The Got default options are updated to include:
  *
  * - proxy settings to work on AWS environments
- * - JSON response types (all the CM APIs have JSON responses)
- * - how long to try before timing out the request
- * - to resolve with the response body only - this helps make the API
- *   more compatible with request which was used previously
  */
 const gotWithProxy = got.extend({
-  responseType: 'json',
-  resolveBodyOnly: true,
-  timeout: {
-    request: 5000
-  },
   hooks: {
     beforeRequest: [beforeRequestHook]
   }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/74

One of the other things we've spotted with the legacy billing process is it's using both [Got](https://github.com/sindresorhus/got) and [BullMQ](https://docs.bullmq.io/) to retry failed requests.

In [Fix broken AccessTokenManager](https://github.com/DEFRA/water-abstraction-service/pull/1993) we've hopefully nullified the repeated `401` errors we see in the logs.

But sometimes a request will timeout, for example when requesting a token from the AWS Cognito service for the first time (it is like you kick it awake on the first attempt each day 🤷🫤). With the current setup, it's not **Got** that retries these, but **BullMQ** (if configured in the job).

Using our experience on [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api) we believe there are changes we can make to **Got** so where we genuinely need to re-try, it can be done there. We can then remove the retry mechanism from the **BullMQ** jobs that don't need it. But we'll make those changes in a separate PR.