### PR TITLE
Stop create-charge job retrying on error

### DIFF
--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -101,7 +101,7 @@ const onComplete = async (job, queueManager) => {
 }
 
 const onFailedHandler = async (job, err) => {
-  await batchJob.logHandlingErrorAndSetBatchStatus(job, err, BATCH_ERROR_CODE.failedToCreateCharge)
+  batchJob.logHandlingErrorAndSetBatchStatus(job, err, BATCH_ERROR_CODE.failedToCreateCharge)
 }
 
 exports.handler = handler

--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -27,12 +27,7 @@ const createMessage = (batchId, billingBatchTransactionId) => ([
     billingBatchTransactionId
   },
   {
-    jobId: `${JOB_NAME}.${batchId}.${billingBatchTransactionId}`,
-    attempts: 6,
-    backoff: {
-      type: 'exponential',
-      delay: 5000
-    }
+    jobId: `${JOB_NAME}.${batchId}.${billingBatchTransactionId}`
   }
 ])
 

--- a/test/modules/billing/jobs/create-charge.test.js
+++ b/test/modules/billing/jobs/create-charge.test.js
@@ -158,11 +158,6 @@ experiment('modules/billing/jobs/create-charge', () => {
           billingBatchTransactionId: transactionId
         },
         {
-          attempts: 6,
-          backoff: {
-            type: 'exponential',
-            delay: 5000
-          },
           jobId: `billing.create-charge.${batchId}.${transactionId}`
         }
       ])


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/74

Currently, the `src/modules/billing/jobs/create-charge.js` job will retry creating the charge if an error occurs. Prior to our changes to [make Got http request retries more robust](https://github.com/DEFRA/water-abstraction-service/pull/2000) this is what the process depended on.

It was most obvious in the logs when a timeout error was thrown by **Got**.

```
2023-02-07T17:45:58.607Z - info: Handling: billing.create-bill-run.6d740335-5e6a-43b3-b0d4-b32f936b0217
2023-02-07T17:45:58.652Z - info: No cognito token found
2023-02-07T17:45:58.652Z - info: Fetching a new Cognito token
2023-02-07T17:46:17.401Z - error: Error handling: billing.create-charge.6d740335-5e6a-43b3-b0d4-b32f936b0217.622162f4-1d69-4e65-930b-e798b72d47d3 stack=RequestError: Timeout awaiting 'request' for 5000ms
    at ClientRequest.<anonymous> (/srv/app/node/water-abstraction-service/releases/20230207_174151/node_modules/got/dist/source/core/index.js:970:65)
    ....
2023-02-07T17:51:05.459Z - error: Batch 6d740335-5e6a-43b3-b0d4-b32f936b0217 failed with error code 40
2023-02-07T17:51:05.487Z - info: Attempting to queue a BullMQ job: billing.delete-errored-batch
```

A major issue with this dependence is how it affects the service in a catastrophic failure, for example, faulty data making every request to the Charging Module API invalid. The request will error, and the config in the job will therefore put the job back on the queue to be retried. It will do this 6 times for each transaction, with exponential backoff. The [BullMQ docs](https://docs.bullmq.io/guide/retrying-failing-jobs) contain the formula for how the exponential backoff is calculated. Using our config we can determine the following.

```javascript
const delay = 5000
let overallTime = 0

for (let attempts = 1; attempts <= 6; attempts++) {
  // Result is in milliseconds
  const exponentialBackoff = Math.pow(2,(attempts - 1)) * delay

  // convert to seconds for easier readability
  const exponentialBackoffInSecs = exponentialBackoff / 1000

  // Add to our overall time
  overallTime += exponentialBackoffInSecs
  console.log(`Next attempt in ${exponentialBackoffInSecs} secs. Overall time ${overallTime} secs`)
}
// Next attempt in 5 secs. Overall time 5 secs
// Next attempt in 10 secs. Overall time 15 secs
// Next attempt in 20 secs. Overall time 35 secs
// Next attempt in 40 secs. Overall time 75 secs
// Next attempt in 80 secs. Overall time 155 secs
// Next attempt in 160 secs. Overall time 315 secs
```

315 secs is 5 minutes and 25 seconds. So, should there be an issue with the transaction data, we have to wait more than 5 minutes before the job gives up. You can see this reflected in the times of the log extract. Where this really becomes a problem is when the bill run contains thousands of transactions. The service becomes blocked up retrying requests we know will never succeed and appears to hang for hours.

The only time we should ever need to retry is if auth has somehow failed, or we get a timeout error for the request. In both cases, we should only make 1 subsequent request before we abandon the job. With the changes we made in [make Got http request retries more robust](https://github.com/DEFRA/water-abstraction-service/pull/2000) and [Fix broken AccessTokenManager](https://github.com/DEFRA/water-abstraction-service/pull/1993) those scenarios are now handled by Got.

This means we can strip out all the retry config in the create charge **BullMQ** job.