### PR TITLE
Revert and move Got config

### DIFF
--- a/src/lib/connectors/charge-module/lib/got-cm.js
+++ b/src/lib/connectors/charge-module/lib/got-cm.js
@@ -65,41 +65,19 @@ const afterResponseHook = async (response, retryWithMergedOptions) => {
 /**
  * Creates an extended Got instance
  *
- * The Got default options are updated to include:
+ * It updates the Got default options 'got-with-proxy' applies to include:
  *
  * - prefixUrl set to the CM API base URL
- * - JSON response types (all the CM APIs have JSON responses)
- * - how long to try before timing out the request
- * - Resolve with the response body only - this helps make the API more compatible with request which was
- *   used previously
  *
  * We also add 2 hooks; beforeRequest() to handle applying the auth header and token and afterResponse() to handle
  * logging errors and force a token refresh on a 401 Unauthorized response.
  */
 const instance = gotWithProxy.extend({
   prefixUrl: config.chargeModule.host,
-  responseType: 'json',
-  resolveBodyOnly: true,
-  timeout: {
-    request: 10000
-  },
-  // Got has a built in retry mechanism. We have found though you have to be careful with what gets retried. Our
-  // preference is to only retry in the event of a timeout on assumption the destination server might be busy but has
-  // a chance to succeed when attempted again
-  retry: {
-    // We ensure that the only network errors Got retries are timeout errors
-    errorCodes: ['ETIMEDOUT'],
-    // By default, Got does not retry POST requests. As we only retry timeouts there is no risk in retrying POST
-    // requests. So, we set methods to be Got's defaults plus 'POST'
-    methods: ['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
-    // The only status code we want to retry is 401 Unauthorized. We do not believe there is value in retrying others
-    statusCodes: [401]
-  },
   hooks: {
     beforeRequest: [beforeRequestHook],
     afterResponse: [afterResponseHook]
-  },
-  mutableDefaults: true
+  }
 })
 
 module.exports = instance

--- a/src/lib/connectors/charge-module/lib/got-with-proxy.js
+++ b/src/lib/connectors/charge-module/lib/got-with-proxy.js
@@ -26,9 +26,33 @@ const beforeRequestHook = options => {
  *
  * The Got default options are updated to include:
  *
- * - proxy settings to work on AWS environments
+ * - JSON response types (all the CM APIs have JSON responses)
+ * - Resolve with the response body only - this helps make the API more compatible with request which was used
+ *   previously
+ * - how long to try before timing out the request
+ * - what requests should be retried (more details inline)
+ * - proxy settings to support running in AWS environments
+ *
  */
 const gotWithProxy = got.extend({
+  responseType: 'json',
+  resolveBodyOnly: true,
+  timeout: {
+    request: 10000
+  },
+  // Got has a built in retry mechanism. We have found though you have to be careful with what gets retried. Our
+  // preference is to only retry in the event of a timeout on assumption the destination server might be busy but has
+  // a chance to succeed when attempted again
+  retry: {
+    // We ensure that the only network errors Got retries are timeout errors
+    errorCodes: ['ETIMEDOUT'],
+    // By default, Got does not retry POST requests. As we only retry timeouts there is no risk in retrying POST
+    // requests. So, we set methods to be Got's defaults plus 'POST'
+    methods: ['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
+    // The only status code we want to retry is 401 Unauthorized. We do not believe there is value in retrying others
+    statusCodes: [401]
+  },
+  mutableDefaults: true,
   hooks: {
     beforeRequest: [beforeRequestHook]
   }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/74

In the recent change [Make Got http request retries more robust](https://github.com/DEFRA/water-abstraction-service/pull/2000) we remarked that config we would expect to see in `src/lib/connectors/charge-module/lib/got-cm.js` was in `got-with-proxy.js`. So, we moved it!

We very quickly realised why it was there when everything broke! 🤦

What we _should_ have spotted is that `src/lib/connectors/charge-module/lib/AccessTokenManager.js` uses `got-with-proxy.js` because of the hooks built into `got-cm.js`. These automatically call AccessTokenManager, which would lead to a right mess if we used it.

So, when we moved the config we broke AccessTokenManager. This means what we _should_ have done is move our general config down into `got-with-proxy.js`. Then both calls to the Charging Module API and the AWS Cognito instance will benefit from our more robust settings.