### PR TITLE
Stop hammering DB for batch state during bill run

### DIFF
--- a/src/modules/billing/jobs/create-charge.js
+++ b/src/modules/billing/jobs/create-charge.js
@@ -16,11 +16,12 @@ const workerOptions = {
   concurrency: config.billing.createChargeJobConcurrency
 }
 
-const createMessage = (batchId, billingBatchTransactionId) => ([
+const createMessage = (batchId, billingBatchTransactionId, lastOfUs) => ([
   JOB_NAME,
   {
     batchId,
-    billingBatchTransactionId
+    billingBatchTransactionId,
+    lastOfUs
   },
   {
     jobId: `${JOB_NAME}.${batchId}.${billingBatchTransactionId}`

--- a/src/modules/billing/jobs/lib/batch-job.js
+++ b/src/modules/billing/jobs/lib/batch-job.js
@@ -7,6 +7,10 @@ const logHandling = job => {
   logger.info(`Handling: ${job.id}`)
 }
 
+const logInfo = (job, msg) => {
+  logger.info(`Info: ${job.id} - ${msg}`)
+}
+
 const logOnComplete = job => {
   logger.info(`onComplete: ${job.id}`)
 }
@@ -40,6 +44,7 @@ const logHandlingErrorAndSetBatchStatus = async (job, err, errorCode) => {
   return err
 }
 
+exports.logInfo = logInfo
 exports.logHandling = logHandling
 exports.logHandlingError = logHandlingError
 exports.logOnComplete = logOnComplete

--- a/src/modules/billing/jobs/prepare-transactions.js
+++ b/src/modules/billing/jobs/prepare-transactions.js
@@ -12,7 +12,6 @@ const { jobName: createChargeJobName } = require('./create-charge')
 const { jobName: refreshTotalsJobName } = require('./refresh-totals')
 
 const config = require('../../../../config')
-const { logger } = require('../../../logger')
 const supplementaryBillingService = require('../services/supplementary-billing-service')
 const licenceService = require('../services/licences-service')
 
@@ -38,7 +37,7 @@ const handler = async job => {
 
     // Supplementary processing handles credits/charges
     if (batch.isSupplementary()) {
-      logger.info(`Processing supplementary transactions ${job.name}`)
+      batchJob.logInfo(job, 'Processing supplementary transactions')
       await supplementaryBillingService.processBatch(batch.id)
     }
 
@@ -52,7 +51,7 @@ const handler = async job => {
       billingTransactionIds
     }
   } catch (err) {
-    await batchJob.logHandlingErrorAndSetBatchStatus(job, err, BATCH_ERROR_CODE.failedToPrepareTransactions)
+    batchJob.logHandlingErrorAndSetBatchStatus(job, err, BATCH_ERROR_CODE.failedToPrepareTransactions)
     throw err
   }
 }
@@ -64,21 +63,25 @@ const onComplete = async (job, queueManager) => {
 
     // If there's nothing to process, skip to cm refresh
     if (billingTransactionIds.length === 0) {
-      logger.info(`No transactions left to process for batch ${batchId}. Requesting CM batch generation...`)
+      batchJob.logInfo(job, `No transactions left to process for batch ${batchId}. Requesting CM batch generation...`)
 
       const numberOfTransactionsInBatch = await billingTransactionsRepo.findByBatchId(batchId)
 
       if (numberOfTransactionsInBatch.length === 0) {
-        logger.info(`Batch ${batchId} is empty - WRLS will mark is as Empty, and will not ask the Charging module to generate it.`)
+        batchJob.logInfo(job, `Batch ${batchId} is empty - do not request Charging module generate.`)
         await billingBatchesRepo.update(batchId, { status: BATCH_STATUS.empty })
         // Set "IncludeInSupplementaryBillingStatus" to 'no' for all licences in this batch
         await licenceService.updateIncludeInSupplementaryBillingStatusForEmptyBatch(batchId)
       } else {
+        batchJob.logInfo(job, `Batch ${batchId} not empty - requesting Charging module generate.`)
         await batchService.requestCMBatchGeneration(batchId)
         await queueManager.add(refreshTotalsJobName, batchId)
       }
     } else {
-      logger.info(`${billingTransactionIds.length} transactions produced for batch ${batchId} - creating charges`)
+      batchJob.logInfo(
+        job,
+        `${billingTransactionIds.length} transactions produced for batch ${batchId} - creating charges`
+      )
       for (let i = 0; i < billingTransactionIds.length; i++) {
         const lastOfUs = i + 1 === billingTransactionIds.length
         await queueManager.add(createChargeJobName, batchId, billingTransactionIds[i], lastOfUs)

--- a/src/modules/billing/jobs/prepare-transactions.js
+++ b/src/modules/billing/jobs/prepare-transactions.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { partial } = require('lodash')
-const bluebird = require('bluebird')
 
 const JOB_NAME = 'billing.prepare-transactions'
 
@@ -80,10 +79,10 @@ const onComplete = async (job, queueManager) => {
       }
     } else {
       logger.info(`${billingTransactionIds.length} transactions produced for batch ${batchId} - creating charges`)
-      await bluebird.mapSeries(
-        billingTransactionIds,
-        billingTransactionId => queueManager.add(createChargeJobName, batchId, billingTransactionId)
-      )
+      for (let i = 0; i < billingTransactionIds.length; i++) {
+        const lastOfUs = i + 1 === billingTransactionIds.length
+        await queueManager.add(createChargeJobName, batchId, billingTransactionIds[i], lastOfUs)
+      }
     }
   } catch (err) {
     batchJob.logOnCompleteError(job, err)

--- a/test/modules/billing/jobs/create-charge.test.js
+++ b/test/modules/billing/jobs/create-charge.test.js
@@ -147,14 +147,14 @@ experiment('modules/billing/jobs/create-charge', () => {
     test('creates the expected message array', async () => {
       const message = createChargeJob.createMessage(
         batchId,
-        transactionId
+        transactionId,
       )
 
       expect(message).to.equal([
         'billing.create-charge',
         {
           batchId,
-          billingBatchTransactionId: transactionId
+          billingBatchTransactionId: transactionId,
         },
         {
           jobId: `billing.create-charge.${batchId}.${transactionId}`

--- a/test/modules/billing/jobs/create-charge.test.js
+++ b/test/modules/billing/jobs/create-charge.test.js
@@ -9,7 +9,6 @@ const {
 
 const { expect } = require('@hapi/code')
 const sandbox = require('sinon').createSandbox()
-const { v4: uuid } = require('uuid')
 
 const batchJob = require('../../../../src/modules/billing/jobs/lib/batch-job')
 const createChargeJob = require('../../../../src/modules/billing/jobs/create-charge')
@@ -29,9 +28,9 @@ const InvoiceLicence = require('../../../../src/lib/models/invoice-licence')
 const Invoice = require('../../../../src/lib/models/invoice')
 const Transaction = require('../../../../src/lib/models/transaction')
 
-const transactionId = uuid()
-const batchId = uuid()
-const chargeModuleBillRunId = uuid()
+const transactionId = 'fef6bc45-ffba-48a9-8fa0-456ac51d6f3a'
+const batchId = '7eb70e4a-a5b0-4509-ae86-14a4cf55fe82'
+const chargeModuleBillRunId = 'dac89570-7f44-4f94-b2fb-4722f2fecce0'
 
 const { BATCH_ERROR_CODE } = require('../../../../src/lib/models/batch')
 

--- a/test/modules/billing/jobs/lib/batch-job.test.js
+++ b/test/modules/billing/jobs/lib/batch-job.test.js
@@ -43,6 +43,23 @@ experiment('modules/billing/jobs/lib/batch-job', () => {
     })
   })
 
+  experiment('.logInfo', () => {
+    let job
+
+    beforeEach(async () => {
+      job = {
+        id: 'test-job-id'
+      }
+    })
+
+    test('create the expected message', async () => {
+      batchJob.logInfo(job, 'Is it safe?')
+
+      const [message] = logger.info.lastCall.args
+      expect(message).to.equal('Info: test-job-id - Is it safe?')
+    })
+  })
+
   experiment('.logHandlingError', () => {
     let job
     let error

--- a/test/modules/billing/jobs/prepare-transactions.test.js
+++ b/test/modules/billing/jobs/prepare-transactions.test.js
@@ -193,11 +193,17 @@ experiment('modules/billing/jobs/prepare-transactions', () => {
 
       test('adds a message to the queue for every transaction', async () => {
         expect(queueManager.add.callCount).to.equal(2)
+      })
+
+      test('the message for the first job is not flagged as the last one', async () => {
         expect(queueManager.add.firstCall.calledWith(
-          'billing.create-charge', BATCH_ID, data.transactions[0].billingTransactionId
+          'billing.create-charge', BATCH_ID, data.transactions[0].billingTransactionId, false
         )).to.be.true()
+      })
+
+      test('the message for the (second) last job is flagged as the last one', async () => {
         expect(queueManager.add.secondCall.calledWith(
-          'billing.create-charge', BATCH_ID, data.transactions[1].billingTransactionId
+          'billing.create-charge', BATCH_ID, data.transactions[1].billingTransactionId, true
         )).to.be.true()
       })
 
@@ -207,10 +213,9 @@ experiment('modules/billing/jobs/prepare-transactions', () => {
     })
 
     experiment('when there is an error', () => {
-      let err
+      const err = new Error('oops')
 
       beforeEach(async () => {
-        err = new Error('oops')
         queueManager.add.rejects(err)
         await prepareTransactions.onComplete(job, queueManager)
       })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/74

The legacy code, because of its use of [BullMQ](https://docs.bullmq.io/) is left with a bit of a problem to crack. Each step of the bill run process is represented as a 'queue' in **BullMQ**. To kick things off a job is added to the first queue (step) in the process. Typically, when one job completes it handles adding the next job to the next appropriate queue in the process.

But the point of BullMQ was for steps like creating transactions in the Charging Module; there could be thousands. So, you add all of them as individual jobs to a queue, and you have multiple workers process them asynchronously.

What happens if the next step should only happen once? For example, after adding your thousand transactions you need to tell the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) to 'generate' the bill run. But you only need to send that request once.

1000 create-charge jobs need to somehow queue up a single refresh-totals job in their [onComplete() event handler](https://docs.bullmq.io/guide/returning-job-data).

The legacy solution is to query the DB each time and get a count of the different states of the transactions linked to the bill run. The more transactions you have, the more times you fire that query and the more work it has to do.

What if the last create-charge job knew it was the last one added to the queue? By default, jobs are processed on a [First-In, First-Out](https://docs.bullmq.io/guide/jobs/fifo) basis. So, the last job would know it was the last to be processed. It could then queue up the refresh-totals job and we'd avoid all those hits on the DB.

This change implements this new approach to dealing with when to queue the refresh-totals job.