### PR TITLE
Fix no contacts in external login

### DIFF
--- a/src/modules/users/controller.js
+++ b/src/modules/users/controller.js
@@ -45,7 +45,7 @@ const getCompanyLicences = (company, documentHeaders, licencesMap) => {
     .map(doc => ({
       documentId: doc.document_id,
       licenceRef: doc.system_external_id,
-      licenceHolder: doc.metadata.contacts[0].name ?? '',
+      licenceHolder: doc.metadata?.contacts?.[0].name ?? '',
       licence: licencesMap.get(doc.system_external_id)
     }))
 }

--- a/test/modules/users/controller.test.js
+++ b/test/modules/users/controller.test.js
@@ -348,7 +348,7 @@ experiment('modules/users/controller', () => {
           {
             documentId: 'lic_3_document_id',
             licenceRef: '03/456',
-            licenceHolder: 'Max Irrigation LH',
+            licenceHolder: '',
             licence: licences[2]
           }
         ])

--- a/test/modules/users/controller.test.js
+++ b/test/modules/users/controller.test.js
@@ -112,11 +112,7 @@ const getDocumentHeaderResponse = () => ({
       document_id: 'lic_3_document_id',
       system_external_id: '03/456',
       metadata: {
-        Name: 'Max Irrigation',
-        contacts: [
-          { name: 'Max Irrigation LH', role: 'Licence holder' },
-          { name: 'Max Irrigation Other', role: 'other role' }
-        ]
+        Name: 'Max Irrigation'
       },
       company_entity_id: 'max_irrigation_id'
     }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

A recent change as part of our efforts to remove the code base's dependency on Lodash has introduced an error. The Lodash `get()` method doesn't care if the object you are getting a property from is undefined. It will just return whatever default value you provide.

Our issue is that the existing code nor the tests gave any clue this might be the case. So, though we test for the property `name` we were assuming `doc.metadata.contacts[0]` would always be defined.

Turns out this is not the case. So, this change fixes the issue and prevents an error from being thrown.

For reference the error we saw was `Uncaught TypeError: Cannot read property '0' of undefined`.