### PR TITLE
Add new batch refresh totals endpoint

### DIFF
--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -70,18 +70,6 @@ const postCreateBatch = async (request, h) => {
   }
 }
 
-const postRefreshBatch = async (request, h) => {
-  const { batchId } = request.params
-
-  try {
-    await request.queueManager.add(refreshTotalsJobName, batchId)
-
-    return h.response().code(204)
-  } catch (err) {
-    return mapErrorResponse(err)
-  }
-}
-
 /**
  * Get batch with region, and optionally include batch totals
  * @param {Boolean} request.query.totals - indicates that batch totals should be included in response
@@ -150,6 +138,18 @@ const deleteBatch = (request, h) => controller.deleteEntity(
   request.pre.batch,
   request.defra.internalCallingUser
 )
+
+const postRefreshBatch = async (request, h) => {
+  const { batchId } = request.params
+
+  try {
+    await request.queueManager.add(refreshTotalsJobName, batchId)
+
+    return h.response().code(204)
+  } catch (err) {
+    return mapErrorResponse(err)
+  }
+}
 
 const postApproveBatch = async request => {
   const { batch } = request.pre

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -147,7 +147,7 @@ const postRefreshBatch = async (request, h) => {
 
     return h.response().code(204)
   } catch (err) {
-    return mapErrorResponse(err)
+    return err
   }
 }
 

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -70,6 +70,18 @@ const postCreateBatch = async (request, h) => {
   }
 }
 
+const postRefreshBatch = async (request, h) => {
+  const { batchId } = request.params
+
+  try {
+    await request.queueManager.add(refreshTotalsJobName, batchId)
+
+    return h.response().code(204)
+  } catch (err) {
+    return mapErrorResponse(err)
+  }
+}
+
 /**
  * Get batch with region, and optionally include batch totals
  * @param {Boolean} request.query.totals - indicates that batch totals should be included in response
@@ -253,6 +265,7 @@ module.exports = {
   deleteBatch,
   postApproveBatch,
   postCreateBatch,
+  postRefreshBatch,
   deleteAllBillingData,
   postSetBatchStatusToCancel,
   postBatchBillableYears

--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -46,6 +46,19 @@ const postCreateBatch = {
   }
 }
 
+const postRefreshBatch = {
+  method: 'POST',
+  path: `${BASE_PATH}/{batchId}/refresh`,
+  handler: controller.postRefreshBatch,
+  config: {
+    validate: {
+      params: Joi.object().keys({
+        batchId: Joi.string().uuid().required()
+      })
+    }
+  }
+}
+
 const getBatch = {
   method: 'GET',
   path: `${BASE_PATH}/{batchId}`,
@@ -301,6 +314,7 @@ module.exports = {
   postApproveBatch,
   postBatchBillableYears,
   postCreateBatch,
+  postRefreshBatch,
   postApproveReviewBatch,
   getBatchDownloadData,
   postSetBatchStatusToCancel,

--- a/src/modules/billing/routes/batches.js
+++ b/src/modules/billing/routes/batches.js
@@ -46,19 +46,6 @@ const postCreateBatch = {
   }
 }
 
-const postRefreshBatch = {
-  method: 'POST',
-  path: `${BASE_PATH}/{batchId}/refresh`,
-  handler: controller.postRefreshBatch,
-  config: {
-    validate: {
-      params: Joi.object().keys({
-        batchId: Joi.string().uuid().required()
-      })
-    }
-  }
-}
-
 const getBatch = {
   method: 'GET',
   path: `${BASE_PATH}/{batchId}`,
@@ -176,6 +163,19 @@ const deleteBatch = {
     pre: [
       { method: preHandlers.loadBatch, assign: 'batch' }
     ]
+  }
+}
+
+const postRefreshBatch = {
+  method: 'POST',
+  path: `${BASE_PATH}/{batchId}/refresh`,
+  handler: controller.postRefreshBatch,
+  config: {
+    validate: {
+      params: Joi.object().keys({
+        batchId: Joi.string().uuid().required()
+      })
+    }
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906
https://eaflood.atlassian.net/browse/WATER-3912

> This is part of the [SROC supplementary bill run work](https://eaflood.atlassian.net/browse/WATER-3803)

In the supplementary bill run process the [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) is taking things as far as having the batch, invoice, invoice licence and transaction records created in the DB and the Charging Module API.

It will then hand over control to the legacy service to extract ‘post-generate’ info from the charging module and update our data with it, and all other actions from that point on.

So, we need a way of passing control to the legacy service. Currently, in the `src/modules/billing/jobs/create-charge.js` job, once the transactions have been sent to the charging module and the bill run generated, it adds the `src/modules/billing/jobs/refresh-totals.js` job to a queue.

We need to add a new endpoint that allows us when called, to add that **refresh-totals** job for our newly created SROC supplementary batch.
