### PR TITLE
Fix missing adjustments in SROC test fixture data

### DIFF
--- a/integration-tests/billing/fixtures/sroc-charge-info.yaml
+++ b/integration-tests/billing/fixtures/sroc-charge-info.yaml
@@ -27,6 +27,7 @@
     volume: 100
     billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
+    adjustments: {}
 
 - ref: $chargePurpose01
   model: ChargePurpose
@@ -110,6 +111,7 @@
     volume: 100
     billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
+    adjustments: {}
 
 - ref: $chargePurpose02
   model: ChargePurpose
@@ -193,6 +195,7 @@
     volume: 100
     billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
+    adjustments: {}
 
 - ref: $chargePurpose03
   model: ChargePurpose
@@ -240,6 +243,7 @@
     volume: 100
     billingChargeCategoryId: $chargeCategory421.billing_charge_category_id
     eiucRegion: Southern
+    adjustments: {}
 
 - ref: $chargePurpose04
   model: ChargePurpose
@@ -289,6 +293,7 @@
     volume: 750
     billingChargeCategoryId: $chargeCategory4210.billing_charge_category_id
     eiucRegion: Southern
+    adjustments: {}
 
 - ref: $chargePurpose06
   model: ChargePurpose


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906
https://eaflood.atlassian.net/browse/WATER-3920

When trying to test the SROC supplementary bill run changes we hit an unexpected error. We were using the test data `sroc-billing-data` creates for us (see `integration-tests/billing/fixtures/sets.json`) but the bill run kept erroring unexpectedly.

We were able to diagnose the issue as a fault with the test data. The `adjustments` JSONB field in `charge_elements` is always populated for any SROC charge versions in the production data. If there are no adjustments it defaults to `{}`. This is unlike its neighbouring `additional_charges` JSONB field which is left `NULL` when empty 😩🤦.

So, we need to fix the SROC test data to ensure `adjustments` is always populated.