### PR TITLE
Remove constraint from `billing_transactions` table

### DIFF
--- a/migrations/20230315122011-remove-constraint-from-billing-transactions.js
+++ b/migrations/20230315122011-remove-constraint-from-billing-transactions.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230120140933-queued-batch-status-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230120140933-queued-batch-status-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/20230315122011-remove-constraint-from-billing-transactions.js
+++ b/migrations/20230315122011-remove-constraint-from-billing-transactions.js
@@ -13,7 +13,7 @@ exports.setup = function (options, _seedLink) {
 }
 
 exports.up = function (db) {
-  const filePath = path.join(__dirname, 'sqls', '20230120140933-queued-batch-status-up.sql')
+  const filePath = path.join(__dirname, 'sqls', '20230315122011-remove-constraint-from-billing-transactions-up.sql')
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
@@ -28,7 +28,7 @@ exports.up = function (db) {
 }
 
 exports.down = function (db) {
-  const filePath = path.join(__dirname, 'sqls', '20230120140933-queued-batch-status-down.sql')
+  const filePath = path.join(__dirname, 'sqls', '20230315122011-remove-constraint-from-billing-transactions-down.sql')
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)

--- a/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-down.sql
+++ b/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+ALTER TABLE water.billing_transactions ADD CONSTRAINT billing_transactions_billing_invoice_licence_id_fkey FOREIGN KEY (billing_invoice_licence_id) REFERENCES water.billing_invoice_licences(billing_invoice_licence_id);

--- a/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-down.sql
+++ b/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-down.sql
@@ -1,2 +1,1 @@
-/* Replace with your SQL commands */
 ALTER TABLE water.billing_transactions ADD CONSTRAINT billing_transactions_billing_invoice_licence_id_fkey FOREIGN KEY (billing_invoice_licence_id) REFERENCES water.billing_invoice_licences(billing_invoice_licence_id);

--- a/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-up.sql
+++ b/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-up.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+ALTER TABLE water.billing_transactions DROP CONSTRAINT IF EXISTS billing_invoice_licence_id;

--- a/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-up.sql
+++ b/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-up.sql
@@ -1,2 +1,2 @@
 /* Replace with your SQL commands */
-ALTER TABLE water.billing_transactions DROP CONSTRAINT IF EXISTS billing_invoice_licence_id;
+ALTER TABLE water.billing_transactions DROP CONSTRAINT IF EXISTS billing_transactions_billing_invoice_licence_id_fkey;

--- a/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-up.sql
+++ b/migrations/sqls/20230315122011-remove-constraint-from-billing-transactions-up.sql
@@ -1,2 +1,1 @@
-/* Replace with your SQL commands */
 ALTER TABLE water.billing_transactions DROP CONSTRAINT IF EXISTS billing_transactions_billing_invoice_licence_id_fkey;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3906

Somehow (seriously, how!? :angry: :sob: ) our local DB schema does not match the `dev` schema (and most likely all AWS DB schemas).

Our solution is premised on the constraint `CONSTRAINT billing_transactions_billing_invoice_licence_id_fkey FOREIGN KEY (billing_invoice_licence_id) REFERENCES water.billing_invoice_licences(billing_invoice_licence_id)` not being there. So, we just need to throw together a fix migration and re-deploy to `dev` and all will be well. :weary: