### PR TITLE
Fix SROC invoices flagged for re-issue

### DIFF
--- a/src/lib/connectors/repos/queries/billing-invoices.js
+++ b/src/lib/connectors/repos/queries/billing-invoices.js
@@ -1,17 +1,17 @@
-exports.upsert = `insert into water.billing_invoices 
+exports.upsert = `insert into water.billing_invoices
   (
-    invoice_account_id, address, invoice_account_number, 
+    invoice_account_id, address, invoice_account_number,
     date_created, date_updated, billing_batch_id, financial_year_ending,
     net_amount, invoice_number, credit_note_value, invoice_value, is_de_minimis, is_credit, external_id
   )
 values (
-    :invoiceAccountId, :address, :invoiceAccountNumber, 
+    :invoiceAccountId, :address, :invoiceAccountNumber,
     NOW(), NOW(), :billingBatchId, :financialYearEnding,
     :netAmount, :invoiceNumber, :creditNoteValue, :invoiceValue, :isDeMinimis, :isCredit, :externalId
 )
-on conflict (invoice_account_id, billing_batch_id, financial_year_ending) where legacy_id is null and rebilling_state is null do update 
-  set date_updated = NOW(), 
-    net_amount=EXCLUDED.net_amount, 
+on conflict (invoice_account_id, billing_batch_id, financial_year_ending) where legacy_id is null and rebilling_state is null do update
+  set date_updated = NOW(),
+    net_amount=EXCLUDED.net_amount,
     credit_note_value=EXCLUDED.credit_note_value,
     invoice_value=EXCLUDED.invoice_value,
     invoice_number=EXCLUDED.invoice_number,
@@ -22,7 +22,7 @@ on conflict (invoice_account_id, billing_batch_id, financial_year_ending) where 
 
 exports.deleteEmptyByBatchId = `delete from water.billing_invoices i
   where i.billing_invoice_id in (
-  select i.billing_invoice_id from water.billing_batches b 
+  select i.billing_invoice_id from water.billing_batches b
   join water.billing_invoices i on b.billing_batch_id=i.billing_batch_id
   left join water.billing_invoice_licences l on i.billing_invoice_id=l.billing_invoice_id
   where b.billing_batch_id=:batchId
@@ -33,16 +33,17 @@ exports.findByIsFlaggedForRebillingAndRegion = `
 select i.* from water.billing_invoices i
 join water.billing_batches b on i.billing_batch_id=b.billing_batch_id
 where i.is_flagged_for_rebilling=true
-and b.region_id=:regionId;
+and b.region_id=:regionId
+and b.scheme='alcs';
 `
 
 exports.resetIsFlaggedForRebilling = `
 update water.billing_invoices t1
 set is_flagged_for_rebilling=false
 from water.billing_invoices t2
-where 
-  t2.billing_batch_id=:batchId 
-  and t1.billing_batch_id<>t2.billing_batch_id 
+where
+  t2.billing_batch_id=:batchId
+  and t1.billing_batch_id<>t2.billing_batch_id
   and t1.billing_invoice_id=t2.original_billing_invoice_id
   and t2.original_billing_invoice_id is not null
 returning *;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3937

We had an issue logged with our live environment. Users were attempting to run a supplementary bill run for Midlands. However, all attempts resulted in an errored bill run.

When we checked the logs, all we could find was

```
2023-03-13T09:17:34.860Z - [31merror[39m: Failed to mark invoice 26d58547-b6d4-4d72-98ca-621b327bd5ba for rebilling in charge module
2023-03-13T09:17:34.863Z - [31merror[39m: Rebilling failed 1e5649c9-448b-49d3-bbd2-1a080f045281
2023-03-13T09:17:34.881Z - [31merror[39m: Batch 1e5649c9-448b-49d3-bbd2-1a080f045281 failed with error code 90
```

After some investigation, we managed to track down the cause. An invoice created as part of the Midland 2022 Annual bill run had been flagged for re-issue. This means it's an SROC invoice and that is what the [charging-module-api](https://github.com/DEFRA/sroc-charging-module-api) has the original bill run type as.

But the legacy supplementary process that is being run is generating a PRESROC bill run on both sides; WRLS and Charging Module. The request we are sending (`/v3/wrls/bill-runs/0ca2280a-2cb6-460e-9cba-2dac17ef4571/invoices/32c9cba5-33b4-47fd-b655-3d270b6dd977/rebill`) is asking the Charging Module API to re-bill the SROC invoice to a PRESROC bill run. Quite rightly, the Charging Module is responding with

```
409 - Invoice 32c9cba5-33b4-47fd-b655-3d270b6dd977 is linked to ruleset sroc but bill run 387a792e-d9a0-425f-af8b-a2ee000b360d is linked to ruleset presroc
```

So, this change amends the query the legacy supplementary process is using to find invoices flagged for re-issue to only return those linked to a PRESROC bill run. Support for re-issuing SROC invoices will be added once our SROC supplementary work in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) is complete.