### PR TITLE
Fix error with internal search for users

### DIFF
--- a/src/modules/internal-search/lib/search-users.js
+++ b/src/modules/internal-search/lib/search-users.js
@@ -27,7 +27,7 @@ const getFilter = (query) => {
  * @return {Array}          - users
  */
 const mapRow = (row) => {
-  const scopes = row.role.scopes ?? []
+  const scopes = row.role?.scopes ?? []
   return {
     userId: row.user_id,
     email: row.user_name,


### PR DESCRIPTION
Just spotted in regression testing that we have a bug with the internal search. If you enter a user email that exists the search errors causing a `500` to be returned to the client. In our AWS environments that results in a WAF violation and the user seeing the WAF error page.

The problem is caused by not all users having scopes attached to their roles. A quick tweak and all is well.