### PR TITLE
Add SROC include in supplementary billing flag

### DIFF
--- a/migrations/20230327150452-add-include-in-sroc-supplementary-billing-flag.js
+++ b/migrations/20230327150452-add-include-in-sroc-supplementary-billing-flag.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230327150452-add-include-in-sroc-supplementary-billing-flag-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230327150452-add-include-in-sroc-supplementary-billing-flag-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20230327150452-add-include-in-sroc-supplementary-billing-flag-down.sql
+++ b/migrations/sqls/20230327150452-add-include-in-sroc-supplementary-billing-flag-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.licences DROP COLUMN include_in_sroc_supplementary_billing;

--- a/migrations/sqls/20230327150452-add-include-in-sroc-supplementary-billing-flag-up.sql
+++ b/migrations/sqls/20230327150452-add-include-in-sroc-supplementary-billing-flag-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.licences ADD include_in_sroc_supplementary_billing bool NOT NULL DEFAULT false;

--- a/src/lib/mappers/licence.js
+++ b/src/lib/mappers/licence.js
@@ -36,7 +36,8 @@ const dbToModelMapper = createMapper()
     'expiredDate',
     'lapsedDate',
     'revokedDate',
-    'includeInSupplementaryBilling'
+    'includeInSupplementaryBilling',
+    'includeInSrocSupplementaryBilling'
   )
   .map('regions').to('historicalArea', dbToHistoricalArea)
   .map('regions').to('regionalChargeArea', dbToRegionalChargeArea)

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -121,8 +121,13 @@ const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
  * Ensures the specified licence is included in the next supplementary bill run
  * @param {String} licenceId
  */
-const flagForSupplementaryBilling = licenceId =>
-  repos.licences.update(licenceId, { includeInSupplementaryBilling: INCLUDE_IN_SUPPLEMENTARY_BILLING.yes })
+const flagForSupplementaryBilling = (licenceId, scheme = 'alcs') => {
+  if (scheme === 'alcs') {
+    repos.licences.update(licenceId, { includeInSupplementaryBilling: INCLUDE_IN_SUPPLEMENTARY_BILLING.yes })
+  } else {
+    repos.licences.update(licenceId, { includeInSupplementaryBilling: INCLUDE_IN_SUPPLEMENTARY_BILLING.yes })
+  }
+}
 
 /**
  * Retrieves the invoices associated with a licence

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -122,11 +122,15 @@ const getLicenceAccountsByRefAndDate = async (documentRef, date) => {
  * @param {String} licenceId
  */
 const flagForSupplementaryBilling = (licenceId, scheme = 'alcs') => {
+  const argument = {}
+
   if (scheme === 'alcs') {
-    repos.licences.update(licenceId, { includeInSupplementaryBilling: INCLUDE_IN_SUPPLEMENTARY_BILLING.yes })
+    argument.includeInSupplementaryBilling = INCLUDE_IN_SUPPLEMENTARY_BILLING.yes
   } else {
-    repos.licences.update(licenceId, { includeInSupplementaryBilling: INCLUDE_IN_SUPPLEMENTARY_BILLING.yes })
+    argument.includeInSrocSupplementaryBilling = true
   }
+
+  repos.licences.update(licenceId, argument)
 }
 
 /**

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -229,7 +229,7 @@ const approve = async (chargeVersionWorkflow, approvedBy) => {
   const persistedChargeVersion = await chargeVersionService.create(chargeVersion)
 
   // flag for supplementary billing
-  await licencesService.flagForSupplementaryBilling(chargeVersionWorkflow.licence.id, persistedChargeVersion.scheme)
+  licencesService.flagForSupplementaryBilling(chargeVersionWorkflow.licence.id, persistedChargeVersion.scheme)
 
   // Delete the charge version workflow record as it is no longer needed
   await deleteOne(chargeVersionWorkflow, false)

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -229,7 +229,7 @@ const approve = async (chargeVersionWorkflow, approvedBy) => {
   const persistedChargeVersion = await chargeVersionService.create(chargeVersion)
 
   // flag for supplementary billing
-  await licencesService.flagForSupplementaryBilling(chargeVersionWorkflow.licence.id)
+  await licencesService.flagForSupplementaryBilling(chargeVersionWorkflow.licence.id, persistedChargeVersion.scheme)
 
   // Delete the charge version workflow record as it is no longer needed
   await deleteOne(chargeVersionWorkflow, false)

--- a/test/lib/mappers/licence.test.js
+++ b/test/lib/mappers/licence.test.js
@@ -24,6 +24,7 @@ const data = {
     expiredDate: null,
     lapsedDate: '2020-02-03',
     revokedDate: null,
+    includeInSupplementaryBilling: 'no',
     regions: {
       historicalAreaCode: 'ABC',
       regionalChargeArea: 'Anglian'
@@ -54,6 +55,7 @@ experiment('modules/billing/mappers/licence', () => {
       expect(result.id).to.equal(data.dbRow.licenceId)
       expect(result.licenceNumber).to.equal(data.dbRow.licenceRef)
       expect(result.isWaterUndertaker).to.equal(data.dbRow.isWaterUndertaker)
+      expect(result.includeInSupplementaryBilling).to.equal(data.dbRow.includeInSupplementaryBilling)
     })
 
     test('licence dates are mapped correctly', async () => {

--- a/test/lib/mappers/licence.test.js
+++ b/test/lib/mappers/licence.test.js
@@ -25,6 +25,7 @@ const data = {
     lapsedDate: '2020-02-03',
     revokedDate: null,
     includeInSupplementaryBilling: 'no',
+    includeInSrocSupplementaryBilling: false,
     regions: {
       historicalAreaCode: 'ABC',
       regionalChargeArea: 'Anglian'
@@ -56,6 +57,7 @@ experiment('modules/billing/mappers/licence', () => {
       expect(result.licenceNumber).to.equal(data.dbRow.licenceRef)
       expect(result.isWaterUndertaker).to.equal(data.dbRow.isWaterUndertaker)
       expect(result.includeInSupplementaryBilling).to.equal(data.dbRow.includeInSupplementaryBilling)
+      expect(result.includeInSrocSupplementaryBilling).to.equal(data.dbRow.includeInSrocSupplementaryBilling)
     })
 
     test('licence dates are mapped correctly', async () => {

--- a/test/lib/services/licences.test.js
+++ b/test/lib/services/licences.test.js
@@ -303,15 +303,26 @@ experiment('src/lib/services/licences', () => {
   experiment('.flagForSupplementaryBilling', () => {
     const licenceId = 'test-id'
 
-    beforeEach(async () => {
-      await licencesService.flagForSupplementaryBilling(licenceId)
+    experiment('when the scheme is alcs (or left as the default)', () => {
+      test('calls the .update method on the repo', async () => {
+        await licencesService.flagForSupplementaryBilling(licenceId)
+
+        expect(repos.licences.update.calledWith(
+          licenceId,
+          { includeInSupplementaryBilling: 'yes' }
+        )).to.be.true()
+      })
     })
 
-    test('calls the .update method on the repo', async () => {
-      expect(repos.licences.update.calledWith(
-        licenceId,
-        { includeInSupplementaryBilling: 'yes' }
-      )).to.be.true()
+    experiment('when the scheme is sroc', () => {
+      test('calls the .update method on the repo', async () => {
+        await licencesService.flagForSupplementaryBilling(licenceId, 'sroc')
+
+        expect(repos.licences.update.calledWith(
+          licenceId,
+          { includeInSrocSupplementaryBilling: true }
+        )).to.be.true()
+      })
     })
   })
 

--- a/test/modules/charge-versions/services/charge-version-workflows.test.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.test.js
@@ -65,7 +65,7 @@ const createDocument = () => {
   return doc
 }
 
-experiment('modules/charge-versions/services/charge-version-workflows', () => {
+experiment.only('modules/charge-versions/services/charge-version-workflows', () => {
   let chargeVersionWorkflow, result
 
   beforeEach(async () => {
@@ -396,6 +396,8 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
       chargeVersionWorkflow.createdBy = new User(456, 'someone-else@example.com')
       chargeVersionWorkflow.licence = new Licence(uuid())
       chargeVersionWorkflow.chargeVersion = new ChargeVersion(uuid())
+
+      chargeVersionService.create.resolves(chargeVersionWorkflow.chargeVersion)
     })
 
     test('the new charge version is persisted', async () => {
@@ -432,7 +434,8 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
         await chargeVersionWorkflowService.approve(chargeVersionWorkflow, approvingUser)
 
         expect(licencesService.flagForSupplementaryBilling.calledWith(
-          chargeVersionWorkflow.licence.id
+          chargeVersionWorkflow.licence.id,
+          'alcs'
         )).to.be.true()
       })
     })
@@ -446,7 +449,8 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
         await chargeVersionWorkflowService.approve(chargeVersionWorkflow, approvingUser)
 
         expect(licencesService.flagForSupplementaryBilling.calledWith(
-          chargeVersionWorkflow.licence.id
+          chargeVersionWorkflow.licence.id,
+          'sroc'
         )).to.be.true()
       })
     })

--- a/test/modules/charge-versions/services/charge-version-workflows.test.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.test.js
@@ -65,7 +65,7 @@ const createDocument = () => {
   return doc
 }
 
-experiment.only('modules/charge-versions/services/charge-version-workflows', () => {
+experiment('modules/charge-versions/services/charge-version-workflows', () => {
   let chargeVersionWorkflow, result
 
   beforeEach(async () => {

--- a/test/modules/charge-versions/services/charge-version-workflows.test.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.test.js
@@ -391,13 +391,17 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
 
     beforeEach(async () => {
       approvingUser = new User(123, 'mail@example.com')
+
+      // New charge versions default to scheme 'alcs' in the constructor. So, we have to instantiate then update the
+      // scheme
+      const chargeVersion = new ChargeVersion(uuid())
+      chargeVersion.scheme = 'sroc'
+
       chargeVersionWorkflow = new ChargeVersionWorkflow(uuid())
-      chargeVersionWorkflow.fromHash({
-        chargeVersion: new ChargeVersion(uuid()),
-        createdBy: new User(456, 'someone-else@example.com')
-      })
+      chargeVersionWorkflow.createdBy = new User(456, 'someone-else@example.com')
       chargeVersionWorkflow.licence = new Licence(uuid())
-      chargeVersionWorkflow.chargeVersion = new ChargeVersion(uuid())
+      chargeVersionWorkflow.chargeVersion = chargeVersion
+
       await chargeVersionWorkflowService.approve(chargeVersionWorkflow, approvingUser)
     })
 
@@ -416,11 +420,6 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
     test('the approver of the new charge version is set', async () => {
       const [chargeVersion] = chargeVersionService.create.lastCall.args
       expect(chargeVersion.approvedBy).to.equal(approvingUser)
-    })
-
-    test('the charging scheme of the new charge version is set', async () => {
-      const [chargeVersion] = chargeVersionService.create.lastCall.args
-      expect(chargeVersion.scheme).to.equal('alcs')
     })
 
     test('the workflow record is deleted', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3948

We have an issue that the current `include_in_supplementary_billing` was added at a time there was only 1 charge scheme. A licence gets flagged irrespective of whether the change relates to PRESROC or SROC.

Where that has impacted us is when sending a billing batch. When it gets sent it clears the flag for _all_ licences included. But if we cancel one, for example, the PRESROC bill run, and send the SROC one we lose which licences still need to be processed on the PRESROC one.

Our solution is to add a new `include_in_sroc_supplementary_billing` flag to the `licences` table. This change covers

- a migration to add it to the table
- updating the logic which sets the include in supp. billing flags when a charge version is approved to update only the relevant flag