### PR TITLE
Clear Include In SROC supp. billing flag on send

### DIFF
--- a/src/lib/connectors/repos/licences.js
+++ b/src/lib/connectors/repos/licences.js
@@ -117,6 +117,24 @@ const updateIncludeInSupplementaryBillingStatusForBatchCreatedDate = (regionId, 
 }
 
 /**
+ * For all licences where the created date is less than the batch created date update the
+ * include_in_sroc_supplementary_billing value to a new value where the current
+ * value is equal to the 'from' parameter value.
+ *
+ * @param {String} regionId
+ * @param {Date} batchCreatedDate
+ * @param {String} from The status value to move from (enum water.include_in_supplementary_billing)
+ * @param {String} to The status value to move to (enum water.include_in_supplementary_billing)
+ */
+const updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate = (regionId, batchCreatedDate, from, to) => {
+  const params = { batchCreatedDate: batchCreatedDate.toISOString(), from, to, regionId }
+
+  return bookshelf
+    .knex
+    .raw(queries.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate, params)
+}
+
+/**
  * Finds licences which have a 'current' charge version linked to the specified
  * invoice account ID
  *
@@ -137,3 +155,4 @@ exports.update = update
 exports.updateIncludeLicenceInSupplementaryBilling = updateIncludeLicenceInSupplementaryBilling
 exports.updateIncludeInSupplementaryBillingStatusForBatch = updateIncludeInSupplementaryBillingStatusForBatch
 exports.updateIncludeInSupplementaryBillingStatusForBatchCreatedDate = updateIncludeInSupplementaryBillingStatusForBatchCreatedDate
+exports.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate = updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -107,6 +107,13 @@ const updateIncludeInSupplementaryBillingStatusForBatchCreatedDate = async (regi
   INCLUDE_IN_SUPPLEMENTARY_BILLING.no
 )
 
+const updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate = async (regionId, dateCreated) => repos.licences.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate(
+  regionId,
+  dateCreated,
+  INCLUDE_IN_SUPPLEMENTARY_BILLING.yes,
+  INCLUDE_IN_SUPPLEMENTARY_BILLING.no
+)
+
 /**
  * Fetches the invoice accounts associated with a licence using the licence ref and date as input.
  * @todo move to invoice accounts service
@@ -233,6 +240,7 @@ exports.getLicenceAccountsByRefAndDate = getLicenceAccountsByRefAndDate
 exports.updateIncludeInSupplementaryBillingStatus = updateIncludeInSupplementaryBillingStatus
 exports.updateIncludeInSupplementaryBillingStatusForSentBatch = updateIncludeInSupplementaryBillingStatusForSentBatch
 exports.updateIncludeInSupplementaryBillingStatusForBatchCreatedDate = updateIncludeInSupplementaryBillingStatusForBatchCreatedDate
+exports.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate = updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate
 exports.flagForSupplementaryBilling = flagForSupplementaryBilling
 exports.getLicenceInvoices = getLicenceInvoices
 exports.getLicencesByInvoiceAccountId = getLicencesByInvoiceAccountId

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -90,6 +90,13 @@ const updateIncludeInSupplementaryBillingStatusForSentBatch = async batchId => {
  * Sets the water.licences.include_in_supplementary_billing value
  * from yes to no based on the region and batch created date
  *
+ * NOTE: Logically, if you know the batch you would update the flag for those licences linked to it. The problem is a
+ * licence might be flagged for inclusion but end up not being included. The billing process might calculate the
+ * billable days as 0, or the debit line gets cancelled out by a credit in a supplementary bill run.
+ *
+ * Least, that is the issue we think the previous team were trying to tackle with this way of resetting the flags
+ * when a bill run gets approved (only place this is called).
+ *
  * @param {String} regionId
  * @param {Date} dateCreated
  */

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -110,8 +110,8 @@ const updateIncludeInSupplementaryBillingStatusForBatchCreatedDate = async (regi
 const updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate = async (regionId, dateCreated) => repos.licences.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate(
   regionId,
   dateCreated,
-  INCLUDE_IN_SUPPLEMENTARY_BILLING.yes,
-  INCLUDE_IN_SUPPLEMENTARY_BILLING.no
+  true,
+  false
 )
 
 /**

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -197,7 +197,6 @@ const approveBatch = async (batch, internalCallingUser) => {
       // invoices sent in this batch for the relevant region.
       await transactionsService.updateIsCredited(batch.region.id)
 
-
       if (batch.scheme === 'alcs') {
         await licencesService.updateIncludeInSupplementaryBillingStatusForBatchCreatedDate(
           batch.region.id,

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -192,12 +192,23 @@ const approveBatch = async (batch, internalCallingUser) => {
     await saveEvent('billing-batch:approve', 'sent', internalCallingUser, batch)
     await invoiceService.resetIsFlaggedForRebilling(batch.id)
 
-    // if it is a supplementary batch mark all the
-    // old transactions in previous batches that was credited back in new invoices sent in this batch
-    // for the relevant region.
     if (batch.type === BATCH_TYPE.supplementary) {
+      // if it is a supplementary batch mark all the old transactions in previous batches that was credited back in new
+      // invoices sent in this batch for the relevant region.
       await transactionsService.updateIsCredited(batch.region.id)
-      await licencesService.updateIncludeInSupplementaryBillingStatusForBatchCreatedDate(batch.region.id, batch.dateCreated)
+
+
+      if (batch.scheme === 'alcs') {
+        await licencesService.updateIncludeInSupplementaryBillingStatusForBatchCreatedDate(
+          batch.region.id,
+          batch.dateCreated
+        )
+      } else {
+        await licencesService.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate(
+          batch.region.id,
+          batch.dateCreated
+        )
+      }
     }
 
     return batch

--- a/test/lib/connectors/repos/licences.test.js
+++ b/test/lib/connectors/repos/licences.test.js
@@ -232,6 +232,37 @@ experiment('lib/connectors/repos/licences.js', () => {
     })
   })
 
+  experiment('.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate', () => {
+    let batchCreatedDate
+    let regionId
+
+    beforeEach(async () => {
+      batchCreatedDate = moment()
+      regionId = uuid()
+      await licencesRepo.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate(
+        regionId,
+        batchCreatedDate,
+        'from-value',
+        'to-value'
+      )
+    })
+
+    test('uses the expected SQL query', async () => {
+      const [query] = bookshelf.knex.raw.lastCall.args
+      expect(query).to.equal(licenceQueries.updateIncludeInSrocSupplementaryBillingStatusForBatchCreatedDate)
+    })
+
+    test('passes the expected params to the query', async () => {
+      const [, params] = bookshelf.knex.raw.lastCall.args
+      expect(params).to.equal({
+        regionId,
+        batchCreatedDate: batchCreatedDate.toISOString(),
+        from: 'from-value',
+        to: 'to-value'
+      })
+    })
+  })
+
   experiment('.findByBatchIdForTwoPartTariffReview', () => {
     beforeEach(async () => {
       await licencesRepo.findByBatchIdForTwoPartTariffReview('batch-id')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3948

We have an issue that the current `include_in_supplementary_billing` was added at a time there was only 1 charge scheme. A licence gets flagged irrespective of whether the change relates to PRESROC or SROC.

Where that has impacted us is when sending a billing batch. When it gets sent it clears the flag for _all_ licences included. But if we cancel one, for example, the PRESROC bill run, and send the SROC one we lose which licences still need to be processed on the PRESROC one.

Our solution was to add a new `include_in_sroc_supplementary_billing` flag to the `licences` table in [Add SROC include in supplementary billing flag](https://github.com/DEFRA/water-abstraction-service/pull/2077). That also covered setting the new flag when a new charge version is approved. We now need to handle clearing the flag when the SROC bill run is 'sent'.