### PR TITLE
Remove 'truncate', 'max' and 'maxBy' Lodash function

### DIFF
--- a/src/lib/mappers/charge-category.js
+++ b/src/lib/mappers/charge-category.js
@@ -1,10 +1,10 @@
 /* eslint-disable camelcase */
 'use strict'
-const { truncate } = require('lodash')
 
 const { createMapper } = require('../object-mapper')
 const camelCaseKeys = require('../camel-case-keys')
 const helpers = require('./lib/helpers')
+const { truncate } = require('../object-helpers')
 
 const ChargeCategory = require('../models/charge-category')
 
@@ -27,7 +27,7 @@ const csvToModel = data => {
     reference,
     description,
     subsistenceCharge: parseInt(subsistence_charge),
-    shortDescription: truncate(short_description, { length: 150 }),
+    shortDescription: truncate(short_description, 150),
     minVolume: parseInt(min_volume),
     maxVolume: parseInt(max_volume),
     isTidal: is_tidal,

--- a/src/lib/mappers/charge-module.js
+++ b/src/lib/mappers/charge-module.js
@@ -1,6 +1,6 @@
 'use strict'
-const { truncate } = require('lodash')
 const { combineAddressLines, getAddressObjectFromArray } = require('./lib/helpers')
+const { truncate } = require('../object-helpers.js')
 
 /**
  * @module maps service models to charge module expected schema
@@ -68,7 +68,7 @@ const extractAddress = (address, fao = null) => {
   const response = {}
 
   for (const [key, value] of Object.entries(parsedAddress)) {
-    response[key] = truncate(value, { length: 240 })
+    response[key] = truncate(value, 240)
   }
 
   let line6 = ''
@@ -82,9 +82,9 @@ const extractAddress = (address, fao = null) => {
     }
   }
 
-  response.addressLine5 = truncate(address.town, { length: 60 })
-  response.addressLine6 = truncate(line6, { length: 60 })
-  response.postcode = truncate(address.postcode, { length: 60 })
+  response.addressLine5 = truncate(address.town, 60)
+  response.addressLine6 = truncate(line6, 60)
+  response.postcode = truncate(address.postcode, 60)
 
   return response
 }

--- a/src/lib/mappers/supported-source.js
+++ b/src/lib/mappers/supported-source.js
@@ -1,6 +1,6 @@
 'use strict'
-const { truncate } = require('lodash')
 const camelCaseKeys = require('../camel-case-keys')
+const { truncate } = require('../object-helpers.js')
 
 const { createMapper } = require('../object-mapper')
 const helpers = require('./lib/helpers')
@@ -21,8 +21,8 @@ const csvToModel = data => {
   return supportedSource.fromHash({
     reference,
     order,
-    name: truncate(name, { length: 255 }),
-    region: truncate(region, { length: 255 })
+    name: truncate(name, 255),
+    region: truncate(region, 255)
   })
 }
 

--- a/src/lib/models/charge-element.js
+++ b/src/lib/models/charge-element.js
@@ -124,9 +124,9 @@ class ChargeElement extends Model {
       return this.authorisedAnnualQuantity
     } else if (typeof this.authorisedAnnualQuantity === 'undefined' || this.authorisedAnnualQuantity < 0) {
       return this.billableAnnualQuantity
-    } else {
-      return Math.max(this.billableAnnualQuantity, this.authorisedAnnualQuantity)
     }
+
+    return Math.max(this.billableAnnualQuantity, this.authorisedAnnualQuantity)
   }
 
   /**

--- a/src/lib/models/charge-element.js
+++ b/src/lib/models/charge-element.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { max } = require('lodash')
-
 const Model = require('./model')
 const AbstractionPeriod = require('./abstraction-period')
 const DateRange = require('./date-range')
@@ -122,7 +120,13 @@ class ChargeElement extends Model {
    * @return {Number}
    */
   get maxAnnualQuantity () {
-    return max([this.billableAnnualQuantity, this.authorisedAnnualQuantity])
+    if (typeof this.billableAnnualQuantity === 'undefined' || this.billableAnnualQuantity < 0) {
+      return this.authorisedAnnualQuantity
+    } else if (typeof this.authorisedAnnualQuantity === 'undefined' || this.authorisedAnnualQuantity < 0) {
+      return this.billableAnnualQuantity
+    } else {
+      return Math.max(this.billableAnnualQuantity, this.authorisedAnnualQuantity)
+    }
   }
 
   /**

--- a/src/lib/models/charge-purpose.js
+++ b/src/lib/models/charge-purpose.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { max } = require('lodash')
-
 const Model = require('./model')
 const AbstractionPeriod = require('./abstraction-period')
 const DateRange = require('./date-range')
@@ -74,7 +72,13 @@ class ChargePurpose extends Model {
    * @return {Number}
    */
   get maxAnnualQuantity () {
-    return max([this.billableAnnualQuantity, this.authorisedAnnualQuantity])
+    if (typeof this.billableAnnualQuantity === 'undefined' || this.billableAnnualQuantity < 0) {
+      return this.authorisedAnnualQuantity
+    } else if (typeof this.authorisedAnnualQuantity === 'undefined' || this.authorisedAnnualQuantity < 0) {
+      return this.billableAnnualQuantity
+    } else {
+      return Math.max(this.billableAnnualQuantity, this.authorisedAnnualQuantity)
+    }
   }
 
   /**

--- a/src/lib/models/charge-purpose.js
+++ b/src/lib/models/charge-purpose.js
@@ -76,9 +76,9 @@ class ChargePurpose extends Model {
       return this.authorisedAnnualQuantity
     } else if (typeof this.authorisedAnnualQuantity === 'undefined' || this.authorisedAnnualQuantity < 0) {
       return this.billableAnnualQuantity
-    } else {
-      return Math.max(this.billableAnnualQuantity, this.authorisedAnnualQuantity)
     }
+
+    return Math.max(this.billableAnnualQuantity, this.authorisedAnnualQuantity)
   }
 
   /**

--- a/src/lib/object-helpers.js
+++ b/src/lib/object-helpers.js
@@ -81,8 +81,26 @@ function toCamelCase (key) {
   return result
 }
 
+/**
+ * Truncates a string to a specified length, adding an ellipsis at the end to
+ * indicate that the string has been shortened.
+ *
+ * @param {string} string - The string to be truncated.
+ * @param {number} length - The maximum length to the truncated string.
+ * @returns {string} - The truncated string.
+ */
+
+function truncate (string, length) {
+  if (string.length > length) {
+    return string.slice(0, (length - 3)) + '...'
+  } else {
+    return string
+  }
+}
+
 module.exports = {
   chunk,
   partialRight,
-  toCamelCase
+  toCamelCase,
+  truncate
 }

--- a/src/lib/object-helpers.js
+++ b/src/lib/object-helpers.js
@@ -91,11 +91,11 @@ function toCamelCase (key) {
  */
 
 function truncate (string, length) {
-  if (string.length > length) {
+  if (string?.length > length) {
     return string.slice(0, (length - 3)) + '...'
-  } else {
-    return string
   }
+
+  return string
 }
 
 module.exports = {

--- a/src/modules/returns/lib/nald-returns-mapper.js
+++ b/src/modules/returns/lib/nald-returns-mapper.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const moment = require('moment')
-const { maxBy } = require('lodash')
 const abstractionHelpers = require('@envage/water-abstraction-helpers')
 
 const { mapQuantity, mapUnit, getStartDate, mapUsability } = abstractionHelpers.returns.mappers
@@ -59,7 +58,11 @@ const getWeekdayHistogram = (lines) => {
     return acc
   }, initial)
 
-  const max = maxBy(Object.values(days), day => day.freq)
+  const daysArr = Object.values(days)
+  let max = null
+  if (daysArr.length > 0) {
+    max = daysArr.reduce((prev, curr) => prev.freq > curr.freq ? prev : curr)
+  }
 
   return max.day
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/25

Lodash is used a lot in our codebase. Although we are not totally removing this module, some of the functions in the code using lodash are unnecessary. Here we are removing the unnecessary ones are replacing it with vanilla js. This PR focuses on removing 'truncate', 'max' and 'maxBy'.