### PR TITLE
Migration to flag sroc supp. billing invoices

### DIFF
--- a/migrations/20230331071630-flag-include-sroc-supplementary.js
+++ b/migrations/20230331071630-flag-include-sroc-supplementary.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230331071630-flag-include-sroc-supplementary-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230331071630-flag-include-sroc-supplementary-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20230331071630-flag-include-sroc-supplementary-down.sql
+++ b/migrations/sqls/20230331071630-flag-include-sroc-supplementary-down.sql
@@ -1,0 +1,3 @@
+-- We do not have a rollback for this migration. The only one we could provide would be to set
+-- include_in_sroc_supplementary_billing to false for all licences. But as we would not know when the rollback would
+-- be applied we may revert ones that were done after the up migration was run.

--- a/migrations/sqls/20230331071630-flag-include-sroc-supplementary-up.sql
+++ b/migrations/sqls/20230331071630-flag-include-sroc-supplementary-up.sql
@@ -1,0 +1,1 @@
+UPDATE water.licences SET include_in_sroc_supplementary_billing = TRUE WHERE include_in_supplementary_billing = 'yes';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3951

We had an issue that the current `include_in_supplementary_billing` flag was added when there was only 1 charge scheme. A licence gets flagged irrespective of whether the change relates to PRESROC or SROC.

Where that has impacted us is when sending a billing batch. When it gets sent it clears the flag for _all_ licences included. But if we cancel one, for example, the PRESROC bill run, and send the SROC one we lose which licences still need to be processed on the PRESROC one.

[Our solution](https://github.com/DEFRA/water-abstraction-service/pull/2077) was to add a new `include_in_sroc_supplementary_billing` flag to the `licences` table and only set it to 'true' when an SROC charge version is approved. That is all now working for new charge versions created and approved.

The remaining issue is existing charge versions that have been processed. When this change goes live there will be some SROC charge versions that have been approved and should be considered. But when they were approved only the `include_in_supplementary_billing` flag existed.

We could try and do something clever, and look at all the SROC charge versions that have been approved this year and then only set the flag against their connect licences. But we've decided instead to set `include_in_sroc_supplementary_billing` to true for those licences where `include_in_supplementary_billing` is true.

It might result in some empty SROC bill runs. But it's far simpler, so there is less chance we'll get something wrong and miss licences.

So, this change adds a migration that will set the flags when first deployed.