### PR TITLE
Supplementary Billing - Too many previous years

### DIFF
--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -287,7 +287,6 @@ const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
   let fromFinancialYearEnding, scheme
   if (batchType !== 'annual') {
     scheme = 'alcs'
-    toFinancialYearEnding = _alcsToFinancialYearEndingCheck(toFinancialYearEnding)
     if (batchType === 'supplementary') {
       fromFinancialYearEnding = config.billing.alcsEndYear - (config.billing.supplementaryYears + (config.billing.alcsEndYear - toFinancialYearEnding))
     } else {
@@ -306,6 +305,8 @@ const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
     err.output.payload.batch = batch
     throw err
   }
+
+  toFinancialYearEnding = scheme === 'alcs' ? _alcsToFinancialYearEnding(toFinancialYearEnding) : toFinancialYearEnding
 
   const { billingBatchId } = await newRepos.billingBatches.create({
     status: Batch.BATCH_STATUS.queued,
@@ -328,7 +329,7 @@ const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
  *
  * @returns {number} the financial year ending to use
  */
-function _alcsToFinancialYearEndingCheck (selectedFinancialYearEnding) {
+function _alcsToFinancialYearEnding (selectedFinancialYearEnding) {
   if (selectedFinancialYearEnding > config.billing.alcsEndYear) {
     return config.billing.alcsEndYear
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3944

A bug has been found in calculating the number of years to go back for ALCS supplementary billing.

The issue was caused because the `toFinancialYearEnding` variable was being modified for alcs if it was greater than 2022. Unfortunately, this value was then being used to calculate the number of years to process for alcs which was incorrect as the variable's value had been changed to 2022 prior to this step.

This fix moves the step of modifying the variable to below where it is used to calculate the number of financial years to process.