### PR TITLE
Supplementary Billing - Too many previous years

### DIFF
--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -297,6 +297,8 @@ const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
     fromFinancialYearEnding = toFinancialYearEnding
   }
 
+  toFinancialYearEnding = scheme === 'alcs' ? _alcsToFinancialYearEnding(toFinancialYearEnding) : toFinancialYearEnding
+
   const batch = await getExistingOrDuplicateSentBatch(regionId, batchType, toFinancialYearEnding, isSummer, scheme)
 
   if (batch) {
@@ -305,8 +307,6 @@ const create = async (regionId, batchType, toFinancialYearEnding, isSummer) => {
     err.output.payload.batch = batch
     throw err
   }
-
-  toFinancialYearEnding = scheme === 'alcs' ? _alcsToFinancialYearEnding(toFinancialYearEnding) : toFinancialYearEnding
 
   const { billingBatchId } = await newRepos.billingBatches.create({
     status: Batch.BATCH_STATUS.queued,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3944

The initial fix for this bug created a new issue where you could re-create another “old scheme” bill run when there was one already sitting in `READY` status for that region.

This was caused by moving the code which calculates the ALCS `toFinancialYearEnding` below where it checks if the batch already exists. This results in `getExistingOrDuplicateSentBatch` function using the wrong `toFinancialYearEnding` value to check for an existing batch.