### PR TITLE
Fix error in Batch Notifications Refresh event job

### DIFF
--- a/src/modules/batch-notifications/lib/event-helpers.js
+++ b/src/modules/batch-notifications/lib/event-helpers.js
@@ -72,7 +72,11 @@ const markAsProcessed = async (eventId, licenceNumbers, recipientCount) => {
  */
 const getStatusCount = (statuses, status) => {
   const foundStatus = statuses.find((o) => o.status === status)
-  const count = foundStatus.count ?? 0
+
+  // Statuses only contains results if there is a scheduled_notification with that status linked to the event. So, this
+  // method may be asked for the count of notifications with a status of 'sent' but `statuses` contains no result for
+  // 'sent'. In this case find() will return `undefined` which is why we need optional chaining.
+  const count = foundStatus?.count ?? 0
 
   return parseInt(count)
 }

--- a/test/modules/batch-notifications/lib/event-helpers.test.js
+++ b/test/modules/batch-notifications/lib/event-helpers.test.js
@@ -224,10 +224,12 @@ experiment('batch notifications event helpers', () => {
           )
         })
 
-        test('should not update the event', async () => {
+        test("updates the event with a status of 'sending'", async () => {
           await refreshEventStatus('testId')
 
-          expect(eventsService.update.callCount).to.equal(0)
+          const [ev] = eventsService.update.lastCall.args
+
+          expect(ev.status).to.equal(EVENT_STATUS_SENDING)
         })
       })
 
@@ -243,10 +245,12 @@ experiment('batch notifications event helpers', () => {
           )
         })
 
-        test('should not update the event', async () => {
+        test("updates the event with a status of 'completed'", async () => {
           await refreshEventStatus('testId')
 
-          expect(eventsService.update.callCount).to.equal(0)
+          const [ev] = eventsService.update.lastCall.args
+
+          expect(ev.status).to.equal(EVENT_STATUS_COMPLETED)
         })
       })
     })

--- a/test/modules/batch-notifications/lib/event-helpers.test.js
+++ b/test/modules/batch-notifications/lib/event-helpers.test.js
@@ -51,11 +51,6 @@ experiment('batch notifications event helpers', () => {
     event = createEventModel()
     sandbox.stub(eventsService, 'findOne').resolves(event)
     sandbox.stub(eventsService, 'update').resolves(event)
-
-    sandbox.stub(queries, 'getMessageStatuses').resolves([
-      { status: MESSAGE_STATUS_SENT, count: 5 },
-      { status: MESSAGE_STATUS_ERROR, count: 2 }
-    ])
   })
 
   afterEach(async () => {
@@ -64,6 +59,13 @@ experiment('batch notifications event helpers', () => {
 
   experiment('createEvent ', () => {
     let createdEvent
+
+    beforeEach(async () => {
+      sandbox.stub(queries, 'getMessageStatuses').resolves([
+        { status: MESSAGE_STATUS_SENT, count: 5 },
+        { status: MESSAGE_STATUS_ERROR, count: 2 }
+      ])
+    })
 
     experiment('should create an event', () => {
       beforeEach(async () => {
@@ -104,6 +106,11 @@ experiment('batch notifications event helpers', () => {
     const recipients = 10
 
     beforeEach(async () => {
+      sandbox.stub(queries, 'getMessageStatuses').resolves([
+        { status: MESSAGE_STATUS_SENT, count: 5 },
+        { status: MESSAGE_STATUS_ERROR, count: 2 }
+      ])
+
       await markAsProcessed('testEventId', licenceNumbers, recipients)
     })
 
@@ -135,58 +142,113 @@ experiment('batch notifications event helpers', () => {
   })
 
   experiment('refreshEventStatus', () => {
-    test('loads the event with the specified ID', async () => {
-      await refreshEventStatus('testId')
-      expect(eventsService.findOne.firstCall.args[0]).to.equal('testId')
+    experiment('when the event has both an error and sent scheduled notification record', () => {
+      beforeEach(async () => {
+        sandbox.stub(queries, 'getMessageStatuses').resolves([
+          { status: MESSAGE_STATUS_SENT, count: 5 },
+          { status: MESSAGE_STATUS_ERROR, count: 2 }
+        ])
+      })
+
+      test('loads the event with the specified ID', async () => {
+        await refreshEventStatus('testId')
+        expect(eventsService.findOne.firstCall.args[0]).to.equal('testId')
+      })
+
+      test('should not update the event unless status is "sending"', async () => {
+        eventsService.findOne.resolves(
+          createEventModel().fromHash({ status: 'wrongStatus' })
+        )
+        await refreshEventStatus('testId')
+        expect(eventsService.update.callCount).to.equal(0)
+      })
+
+      test('updates the event when status is "sending"', async () => {
+        eventsService.findOne.resolves(
+          createEventModel().fromHash({
+            metadata: {
+              recipients: 8
+            },
+            status: EVENT_STATUS_SENDING
+          })
+        )
+
+        await refreshEventStatus('testId')
+
+        const [ev] = eventsService.update.lastCall.args
+
+        expect(ev.status).to.equal(EVENT_STATUS_SENDING)
+        expect(ev.metadata.sent).to.equal(5)
+        expect(ev.metadata.error).to.equal(2)
+      })
+
+      test('updates event status to "completed" when all messages are sent/errored', async () => {
+        eventsService.findOne.resolves(
+          createEventModel().fromHash({
+            metadata: {
+              recipients: 7
+            },
+            status: EVENT_STATUS_SENDING
+          })
+        )
+
+        await refreshEventStatus('testId')
+
+        const [ev] = eventsService.update.lastCall.args
+        expect(ev.status).to.equal(EVENT_STATUS_COMPLETED)
+      })
+
+      test('resolves with the event object', async () => {
+        const result = await refreshEventStatus('testId')
+        expect(result).to.be.an.object()
+        expect(result.eventId).to.equal('testEventId')
+      })
     })
 
-    test('should not update the event unless status is "sending"', async () => {
-      eventsService.findOne.resolves(
-        createEventModel().fromHash({ status: 'wrongStatus' })
-      )
-      await refreshEventStatus('testId')
-      expect(eventsService.update.callCount).to.equal(0)
-    })
+    experiment('when the event has only error scheduled notification records', () => {
+      beforeEach(async () => {
+        sandbox.stub(queries, 'getMessageStatuses').resolves([
+          { status: MESSAGE_STATUS_ERROR, count: 2 }
+        ])
+      })
 
-    test('updates the event when status is "sending"', async () => {
-      eventsService.findOne.resolves(
-        createEventModel().fromHash({
-          metadata: {
-            recipients: 8
-          },
-          status: EVENT_STATUS_SENDING
+      experiment('and a different number of recipients', () => {
+        beforeEach(() => {
+          eventsService.findOne.resolves(
+            createEventModel().fromHash({
+              metadata: {
+                recipients: 7
+              },
+              status: EVENT_STATUS_SENDING
+            })
+          )
         })
-      )
 
-      await refreshEventStatus('testId')
+        test('should not update the event', async () => {
+          await refreshEventStatus('testId')
 
-      const [ev] = eventsService.update.lastCall.args
-
-      expect(ev.status).to.equal(EVENT_STATUS_SENDING)
-      expect(ev.metadata.sent).to.equal(5)
-      expect(ev.metadata.error).to.equal(2)
-    })
-
-    test('updates event status to "completed" when all messages are sent/errored', async () => {
-      eventsService.findOne.resolves(
-        createEventModel().fromHash({
-          metadata: {
-            recipients: 7
-          },
-          status: EVENT_STATUS_SENDING
+          expect(eventsService.update.callCount).to.equal(0)
         })
-      )
+      })
 
-      await refreshEventStatus('testId')
+      experiment('and the same number of recipients', () => {
+        beforeEach(() => {
+          eventsService.findOne.resolves(
+            createEventModel().fromHash({
+              metadata: {
+                recipients: 2
+              },
+              status: EVENT_STATUS_SENDING
+            })
+          )
+        })
 
-      const [ev] = eventsService.update.lastCall.args
-      expect(ev.status).to.equal(EVENT_STATUS_COMPLETED)
-    })
+        test('should not update the event', async () => {
+          await refreshEventStatus('testId')
 
-    test('resolves with the event object', async () => {
-      const result = await refreshEventStatus('testId')
-      expect(result).to.be.an.object()
-      expect(result.eventId).to.equal('testEventId')
+          expect(eventsService.update.callCount).to.equal(0)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3976

We've just spotted that the `src/modules/batch-notifications/lib/jobs/refresh-event.js` job is generating thousands of error notifications in our [Errbit](https://github.com/errbit/errbit) instance.

When we checked our production logs we found this error reported

```
2023-04-24T12:10:03.900Z - [31merror[39m: Error refreshing batch message event stack=TypeError: Cannot read property 'count' of undefined
    at getStatusCount (/srv/app/node/water-abstraction-service/releases/20230405_073950/src/modules/batch-notifications/lib/event-helpers.js:75:29)
    at Object.refreshEventStatus (/srv/app/node/water-abstraction-service/releases/20230405_073950/src/modules/batch-notifications/lib/event-helpers.js:96:16)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async handleRefreshEvent (/srv/app/node/water-abstraction-service/releases/20230405_073950/src/modules/batch-notifications/lib/jobs/refresh-event.js:26:5)
    at async Promise.all (index 4)
    at async Worker.handler [as processFn] (/srv/app/node/water-abstraction-service/releases/20230405_073950/src/modules/batch-notifications/lib/jobs/refresh-event.js:37:5)
    at async Worker.processJob (/srv/app/node/water-abstraction-service/releases/20230405_073950/node_modules/bullmq/dist/cjs/classes/worker.js:333:28)
    at async Worker.retryIfFailed (/srv/app/node/water-abstraction-service/releases/20230405_073950/node_modules/bullmq/dist/cjs/classes/worker.js:455:24)
    at async Worker.run (/srv/app/node/water-abstraction-service/releases/20230405_073950/node_modules/bullmq/dist/cjs/classes/worker.js:140:46), component=/modules/batch-notifications/lib/jobs/refresh-event.js:28:12, eventId=102e6e34-4cb6-4d7c-b0c0-89cbb0cc80c2
```

We've located where this happens.

```javascript
// Get breakdown of statuses of messages in this event
const statuses = await queries.getMessageStatuses(eventId)
const sent = getStatusCount(statuses, MESSAGE_STATUS_SENT)
const error = getStatusCount(statuses, MESSAGE_STATUS_ERROR)

const getStatusCount = (statuses, status) => {
  const foundStatus = statuses.find((o) => o.status === status)
  const count = foundStatus.count ?? 0

  return parseInt(count)
}

// src/modules/batch-notifications/lib/event-helpers.js
```

The problem is how that code handles the results of this query.

```sql
const getMessageStatuses = async eventId => {
  const query = `SELECT DISTINCT status, COUNT(id) AS "count"
    FROM water.scheduled_notification
    WHERE event_id=$1
    GROUP BY status
  `
  const params = [eventId]

  const { rows } = await pool.query(query, params)
  return rows
}
```

If an `event` is only linked to one `scheduled_notification` with a status of **error** then that is the only status returned in the results. `getStatusCount()` is called and asked to return the count for `sent`. This means `find()` returns `undefined` and then we call `.count()` on `undefined` at which point 💥!

So, this change updates `getStatusCount()` to handle this situation.