### PR TITLE
Add migration to unflag non-SROC licences

### DIFF
--- a/migrations/20230516165807-unflag-non-sroc-licences.js
+++ b/migrations/20230516165807-unflag-non-sroc-licences.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230516165807-unflag-non-sroc-licences-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230516165807-unflag-non-sroc-licences-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20230516165807-unflag-non-sroc-licences-down.sql
+++ b/migrations/sqls/20230516165807-unflag-non-sroc-licences-down.sql
@@ -1,0 +1,1 @@
+-- We do not have a rollback for this migration.

--- a/migrations/sqls/20230516165807-unflag-non-sroc-licences-up.sql
+++ b/migrations/sqls/20230516165807-unflag-non-sroc-licences-up.sql
@@ -1,0 +1,11 @@
+-- Remove the include in SROC supplementary billing flag for licences with no charge versions
+-- that start after 2022-04-01, or no charge versions at all!
+UPDATE water.licences l
+SET include_in_sroc_supplementary_billing = FALSE
+WHERE
+  l.include_in_sroc_supplementary_billing = TRUE
+  AND l.licence_id NOT IN (
+  SELECT DISTINCT cv.licence_id
+  FROM water.charge_versions cv
+  WHERE cv.start_date >= '2022-04-01'::Date
+)


### PR DESCRIPTION
When we made the change [Migration to flag sroc supp. billing invoices](https://github.com/DEFRA/water-abstraction-service/pull/2088) we just assumed that all licences by now would have an SROC charge version. In testing, we have found there are licences

- with only PRESROC charge versions
- with no charge versions at all!

This means our premise that the flags would be cleared once a bill run has been run is invalid. Some licences will never be cleared! 🤦

So, we're adding this migration to clean up our mess. It will unflag any licence flagged for SROC supplementary that doesn't have at least 1 charge version with a start date >= 2022-04-01.