### PR TITLE
Add migration to delete empty & errored bill runs

### DIFF
--- a/migrations/20230517070041-delete-empty-error-bill-runs.js
+++ b/migrations/20230517070041-delete-empty-error-bill-runs.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230517070041-delete-empty-error-bill-runs-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230517070041-delete-empty-error-bill-runs-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20230517070041-delete-empty-error-bill-runs-down.sql
+++ b/migrations/sqls/20230517070041-delete-empty-error-bill-runs-down.sql
@@ -1,0 +1,1 @@
+-- We do not have a rollback for this migration.

--- a/migrations/sqls/20230517070041-delete-empty-error-bill-runs-up.sql
+++ b/migrations/sqls/20230517070041-delete-empty-error-bill-runs-up.sql
@@ -1,0 +1,34 @@
+-- Working back from the transactions, delete all data related to empty or errored billing batches including the
+-- billing_batch records
+DELETE FROM water.billing_transactions WHERE billing_transaction_id IN (
+  SELECT bt.billing_transaction_id  FROM water.billing_transactions bt
+  INNER JOIN water.billing_invoice_licences bil ON bil.billing_invoice_licence_id = bt.billing_invoice_licence_id
+  INNER JOIN water.billing_invoices bi ON bi.billing_invoice_id = bil.billing_invoice_id
+  INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bi.billing_batch_id
+  WHERE bb.status IN ('error', 'empty')
+);
+DELETE FROM water.billing_invoice_licences WHERE billing_invoice_licence_id IN (
+  SELECT bil.billing_invoice_licence_id FROM water.billing_invoice_licences bil
+  INNER JOIN water.billing_invoices bi ON bi.billing_invoice_id = bil.billing_invoice_id
+  INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bi.billing_batch_id
+  WHERE bb.status IN ('error', 'empty')
+);
+DELETE FROM water.billing_invoices WHERE billing_invoice_id IN (
+  SELECT bi.billing_invoice_id FROM water.billing_invoices bi
+  INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bi.billing_batch_id
+  WHERE bb.status IN ('error', 'empty')
+);
+DELETE FROM water.billing_batch_charge_version_years WHERE billing_batch_charge_version_year_id IN (
+  SELECT bbcvy.billing_batch_charge_version_year_id  FROM water.billing_batch_charge_version_years bbcvy
+  INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bbcvy.billing_batch_id
+  WHERE bb.status IN ('error', 'empty')
+);
+DELETE FROM water.billing_volumes WHERE billing_volume_id IN (
+  SELECT bv.billing_volume_id  FROM water.billing_volumes bv
+  INNER JOIN water.billing_batches bb ON bb.billing_batch_id = bv.billing_batch_id
+  WHERE bb.status IN ('error', 'empty')
+);
+DELETE FROM water.billing_batches WHERE billing_batch_id IN (
+  SELECT bb.billing_batch_id  FROM water.billing_batches bb
+  WHERE bb.status IN ('error', 'empty')
+);


### PR DESCRIPTION
We made a change to the UI that finally allows users to [delete empty and errored bill runs](https://github.com/DEFRA/water-abstraction-ui/pull/2349).

So any new ones that get added can be dealt with. Unfortunately, we have loads of existing ones that unnecessarily drag down the performance of the bill runs page and make it harder to find meaningful bill runs.

So, this change adds a migration that will do a 'clean-up' of these empty and errored billing batches when deployed. It will be on the users then to delete any new ones created.