### PR TITLE
Add migration to unflag non-PRESROC licences

### DIFF
--- a/migrations/20230522064721-unflag-non-presroc-licences.js
+++ b/migrations/20230522064721-unflag-non-presroc-licences.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230522064721-unflag-non-presroc-licences-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20230522064721-unflag-non-presroc-licences-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20230522064721-unflag-non-presroc-licences-down.sql
+++ b/migrations/sqls/20230522064721-unflag-non-presroc-licences-down.sql
@@ -1,0 +1,1 @@
+-- We do not have a rollback for this migration.

--- a/migrations/sqls/20230522064721-unflag-non-presroc-licences-up.sql
+++ b/migrations/sqls/20230522064721-unflag-non-presroc-licences-up.sql
@@ -1,0 +1,11 @@
+-- Remove the include in supplementary billing flag for licences with charge versions
+-- that only start after 2022-04-01, or no charge versions at all!
+UPDATE water.licences l
+SET include_in_supplementary_billing = 'no'
+WHERE
+  l.include_in_supplementary_billing = 'yes'
+  AND l.licence_id NOT IN (
+  SELECT DISTINCT cv.licence_id
+  FROM water.charge_versions cv
+  WHERE cv.start_date < '2022-04-01'::Date
+)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3995

We added a migration recently to [unflag non-SROC licences](https://github.com/DEFRA/water-abstraction-service/pull/2150). At the same time, we learnt that the [water-import-service](https://github.com/DEFRA/water-abstraction-import) was setting `include_in_supplementary_billing` for any licence where a change in the revoked, lapsed or expired date was noticed. It wasn't checking if the licence has only SROC charge versions, or if it had none.

This causes the same problem our previous migration was fixing; licences get flagged for PRESROC supplementary billing but there is no way to clear it because they'll never be processed when billing runs.

We've [updated the water-abstraction-import](https://github.com/DEFRA/water-abstraction-import/pull/631) to be more intelligent in how it flags licences. This migration will remove the flag from those licences that should never have been flagged in the first place.