### PR TITLE
Update SROC integration test data

### DIFF
--- a/integration-tests/billing/fixtures/sroc-licences.yaml
+++ b/integration-tests/billing/fixtures/sroc-licences.yaml
@@ -3,8 +3,8 @@
   fields:
     chargeRegionId: S
     naldRegionId: 9
-    name: Sroc Supplementary Bill (Test)
-    displayName: Sroc Supplementary Bill (Test)
+    name: Test Region
+    displayName: Test Region
     isTest: true
 
 - ref: $srocLicence01
@@ -29,6 +29,8 @@
       regionalChargeArea: 'Southern'
     isWaterUndertaker: true
     startDate: '2019-01-01'
+    includeInSupplementary_billing: 'yes'
+    includeInSrocSupplementaryBilling: true
     isTest: true
 
 - ref: $srocLicence03

--- a/integration-tests/billing/fixtures/sroc-users.yaml
+++ b/integration-tests/billing/fixtures/sroc-users.yaml
@@ -33,3 +33,25 @@
     application: 'water_admin'
     roles: []
     groups: ['super']
+
+- ref: $billingDataUser
+  model: User
+  fields:
+    user_name: 'acceptance-test.internal.billing_and_data@defra.gov.uk'
+    password: 'P@55word'
+    reset_required: 0
+    application: 'water_admin'
+    bad_logins: 0
+    enabled: true
+    user_data: >
+      {
+        "source": "acceptance-test-setup"
+      }
+
+- ref: $billingDataUserRoles
+  model: Roles
+  fields:
+    userId: $billingDataUser.user_id
+    application: 'water_admin'
+    roles: []
+    groups: ['billing_and_data']


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4034

Since making changes to the billing process to support SROC supplementary billing some of our acceptance tests have broken. We've had to rewrite the tests to use the SROC billing data set we created to get them working again.

2 key bits it was missing were flagging licences for supplementary billing, and access to the billing & data user. Whilst running the tests we came to the conclusion the region name was causing confusion so we also change that as well.