### PR TITLE
Empty supplementary bill run showing a credit bill

### DIFF
--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -44,8 +44,20 @@ const handler = async job => {
   // Check the batch isn't empty
   const numberOfTransactionsInBatch = await billingTransactionsRepo.findByBatchId(batchId)
   if (numberOfTransactionsInBatch.length === 0) {
-    logger.info(`Batch ${batchId} is empty - WRLS will mark is as Empty, and will not ask the Charging module to generate it.`)
-    await billingBatchesRepo.update(batchId, { status: BATCH_STATUS.empty })
+    logger.info(
+      `Batch ${batchId} is empty - WRLS will mark is as Empty, and will not ask the Charging module to generate it.`
+    )
+    await billingBatchesRepo.update(
+      batchId,
+      {
+        status: BATCH_STATUS.empty,
+        invoiceCount: null,
+        creditNoteCount: null,
+        netTotal: null,
+        invoiceValue: null,
+        creditNoteValue: null
+      }
+    )
   } else {
     // Check CM batch in "generated" or "billed" status
     // This indicates that our job is done and can move onto refreshing invoices

--- a/test/modules/billing/jobs/refresh-totals.test.js
+++ b/test/modules/billing/jobs/refresh-totals.test.js
@@ -111,6 +111,25 @@ experiment('modules/billing/jobs/refresh-totals', () => {
       })
     })
 
+    experiment('when the batch is empty', () => {
+      beforeEach(async () => {
+        billingTransactionsRepo.findByBatchId.resolves([])
+        await refreshTotals.handler(job)
+      })
+
+      test('logs an info message', async () => {
+        expect(batchJob.logHandling.calledWith(job)).to.be.true()
+      })
+
+      test('updates the billing batch record', async () => {
+        expect(billingBatchesRepo.update.called).to.be.true()
+      })
+
+      test('no error is logged', async () => {
+        expect(batchJob.logHandlingError.called).to.be.false()
+      })
+    })
+
     experiment('when the batch is not "processing"', () => {
       beforeEach(async () => {
         batch.status = Batch.BATCH_STATUS.error


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4000

When a bill run is created that contains invoices, and those invoices are then removed from the bill run. Upon removal of the final invoice from the bill run it is correctly set to "empty" but still shows 1 bill in the bill run along with the value of the last invoice.

When invoices are removed it checks to see if there are any left in the batch. If the number of invoices was 0 it was setting the batch status to “empty” but that was it, it didn’t update any of the values. So the billing batch record retained the values of the last invoice it was linked to since these weren’t cleared out.

This PR will fix this by clearing the remaining invoice data at the same time as setting the billing batch `status` to "empty".