### PR TITLE
Use the correct values from CM to populate DB

### DIFF
--- a/src/modules/billing/jobs/lib/update-invoices-worker.js
+++ b/src/modules/billing/jobs/lib/update-invoices-worker.js
@@ -49,7 +49,9 @@ const mapTransaction = (transactionMap, cmTransaction, scheme) => {
 
     const grossValuesCalculated = {
       ...cmTransaction.calculation.WRLSChargingResponse.decisionPoints,
-      supportedSourceCharge: cmTransaction.calculation.WRLSChargingResponse.supportedSourceCharge
+      baselineCharge: cmTransaction.calculation.WRLSChargingResponse.baselineCharge,
+      supportedSourceCharge: cmTransaction.calculation.WRLSChargingResponse.supportedSourceCharge,
+      waterCompanyCharge: cmTransaction.calculation.WRLSChargingResponse.waterCompanyCharge
     }
 
     return {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4056

Upon investigation, it has been found that when a bill run is created and sent that the values for the `baselineCharge` and `waterCompanyCharge` that are written to our DBs `billing_transactions` table are incorrect. These values are being taken from the Charging Modules `decisionPoints` data which should not be used, instead the values in the main `WRLSChargingResponse` should be used instead.

This PR will correct this issue for future bill runs. A script will need to be run separately to correct the data that is already in the DB.