### PR TITLE
Tell Got to retry PATCH requests

### DIFF
--- a/src/lib/connectors/charge-module/lib/got-with-proxy.js
+++ b/src/lib/connectors/charge-module/lib/got-with-proxy.js
@@ -47,8 +47,8 @@ const gotWithProxy = got.extend({
     // We ensure that the only network errors Got retries are timeout errors
     errorCodes: ['ETIMEDOUT'],
     // By default, Got does not retry POST requests. As we only retry timeouts there is no risk in retrying POST
-    // requests. So, we set methods to be Got's defaults plus 'POST'
-    methods: ['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
+    // requests. So, we set methods to be Got's defaults plus 'PATCH' and 'POST'
+    methods: ['GET', 'PATCH', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'],
     // The only status code we want to retry is 401 Unauthorized. We do not believe there is value in retrying others
     statusCodes: [401]
   },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4055

We spotted this when an annual bill run after being 'sent' appeared to become stuck. The service failed with a timeout whilst firing the `/approve` and `/send` requests to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api). The fact the CHA responded with `204` to both requests immediately is a thing to look into another day!

But WRLS thought it got a timeout and then blew up, leaving the bill run in a state of sending but the bill run in the Charging Module flagged as 'billed' and on its merry way to be sent out.

Things _might_ have been ok if it could have retried the request. If nothing else it brings the config in line with what we do in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

Hence we're making this change.