### PR TITLE
Add remove job method to QueueManager

### DIFF
--- a/src/lib/queue-manager/queue-manager.js
+++ b/src/lib/queue-manager/queue-manager.js
@@ -104,6 +104,28 @@ class QueueManager {
     return this
   }
 
+  /**
+   * Removes the given job from the queue
+   *
+   * Added when we discovered a scenario where a failed approve batch job was still in the queue. Because the job
+   * ID is based on the billing batch ID any additional requests to try the job again were failing because BullMQ
+   * was interpreting them as duplicates.
+   *
+   * So, we added this to the QueueManager in the event we need to ensure the queue is empty of any existing jobs to
+   * allow us to try it again.
+   *
+   * @param {String} jobName - identifies the queue to remove the job from
+   * @param {String} jobId  - ID of the job. Most jobs will specify this in their `createMessage()` function
+   *
+   * @returns {Number} 1 if it managed to remove the job or 0 if the job or any of its dependencies were locked.
+   */
+  async remove (jobName, jobId) {
+    const jobContainer = this._queues.get(jobName)
+    const result = await jobContainer.queue.remove(jobId)
+
+    return result
+  }
+
   async _cleanQueue (name) {
     try {
       logger.info(`Cleaning queue ${name}`)
@@ -158,7 +180,7 @@ class QueueManager {
   }
 
   /**
-   * Close all BullMQ queuse and workers
+   * Close all BullMQ queues and workers
    *
    * Called during the shutdown process for the app, when `SIGINT` is triggered or an untrapped error manages to bubble
    * to the surface.

--- a/src/modules/billing/controllers/batches.js
+++ b/src/modules/billing/controllers/batches.js
@@ -154,6 +154,16 @@ const postApproveBatch = async request => {
   const { batch } = request.pre
   const { internalCallingUser } = request.defra
   try {
+    // If a previous attempt to send the bill run has been tried but errored the logic in
+    // src/modules/billing/services/batch-service.js approveBatch() will reset the status of the bill run back to READY.
+    // We have found that subsequent attempts to send the bill run cause it to become 'stuck' This is because it seems
+    // the failed job is left in the queue. As the job ID is based on the billing batch ID when we add further approve
+    // jobs for this bill run BullMQ is ignoring them. It sees them as duplicates because they have the same key as a
+    // job already in the queue.
+    //
+    // To allow further attempts to happen we added a `remove()` method to the QueueManager which allows us to remove
+    // specific jobs. (originated with WATER-4055)
+    await request.queueManager.remove(approveBatchJobName, `${approveBatchJobName}.${batch.id}`)
     await request.queueManager.add(approveBatchJobName, batch.id, internalCallingUser)
     // set the batch status to processing
     return batchService.setStatus(batch.id, BATCH_STATUS.sending)

--- a/test/lib/queue-manager/queue-manager.test.js
+++ b/test/lib/queue-manager/queue-manager.test.js
@@ -145,6 +145,38 @@ experiment('lib/queue-manager/queue-manager', () => {
     })
   })
 
+  experiment('.remove', () => {
+    beforeEach(async () => {
+      queueManager.register(job)
+    })
+
+    experiment('when given a job name that matches to an existing queue', () => {
+      experiment('and BullMQ can remove the job', () => {
+        beforeEach(() => {
+          queueStub.remove = sandbox.stub().resolves(0)
+        })
+
+        test('returns 0', async () => {
+          const result = await queueManager.remove(job.jobName, 'job.id')
+
+          expect(result).to.equal(0)
+        })
+      })
+
+      experiment('and BullMQ can NOT remove the job', () => {
+        beforeEach(() => {
+          queueStub.remove = sandbox.stub().resolves(1)
+        })
+
+        test('returns 1', async () => {
+          const result = await queueManager.remove(job.jobName, 'job.id')
+
+          expect(result).to.equal(1)
+        })
+      })
+    })
+  })
+
   experiment('.deleteKeysByPattern', () => {
     let ev, result
     const pattern = 'foo*'

--- a/test/modules/billing/controllers/batches.test.js
+++ b/test/modules/billing/controllers/batches.test.js
@@ -938,11 +938,18 @@ experiment('modules/billing/controller', () => {
           batch
         },
         queueManager: {
-          add: sandbox.stub().resolves()
+          add: sandbox.stub().resolves(),
+          remove: sandbox.stub().resolves()
         }
       }
 
       await controller.postApproveBatch(request, h)
+    })
+
+    test('removes any previous approve job entry for this batch from the message queue', async () => {
+      const [jobName, jobId] = request.queueManager.remove.lastCall.args
+      expect(jobName).to.equal('billing.approve-batch')
+      expect(jobId).to.equal(`billing.approve-batch.${batch.id}`)
     })
 
     test('publishes a new job to the message queue with the batch ID', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4055

The need for this was discovered when an Annual bill run became stuck in 'SENDING'. The service failed with a timeout whilst firing the `/approve` and `/send` requests to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api). The fact the CHA responded with `204` to both requests immediately is a thing to look into another day!

But WRLS thought it got a timeout and then blew up. When we tested we found the first time this happens the bill run is sent back to the `READY` status. But when you try again the bill run becomes stuck in `SENDING`.

Our observation was that the controller updates the billing batch's status to `SENDING` after adding the 'approve-batch' job to the queue. Only nothing then happened. The reason is that the previous 'job' still appears to be in the queue, though in a failed state. Because `src/modules/billing/jobs/approve-batch.js` uses the billing batch ID for the job ID, BullMQ is seeing the second entry as a duplicate and ignores it.

Hence batch gets set to `SENDING`, no attempt to approve the bill run actually takes place, and the UI spins forever more.

We're actively trying to move away from message queues like BullMQ and PGBoss because of this kind of added complexity. If you don't properly understand the frameworks you get yourself into this kind of pickle, which this service is riddled with!

So, this change adds support for removing a specific job to `QueueManager`. We're just calling [BullMQ's remove()](https://api.docs.bullmq.io/classes/v4.Queue.html#remove) behind the scenes. But it solves this specific scenario and might prove useful should we find any others.