### PR TITLE
Fix `update-invoices-worker` for sroc reissuing

### DIFF
--- a/src/modules/billing/jobs/lib/update-invoices-worker.js
+++ b/src/modules/billing/jobs/lib/update-invoices-worker.js
@@ -54,10 +54,17 @@ const mapTransaction = (transactionMap, cmTransaction, scheme) => {
       waterCompanyCharge: cmTransaction.calculation.WRLSChargingResponse.waterCompanyCharge
     }
 
+    // If the CM transaction has a clientId then this is the billingTransactionId of our transaction record. If it
+    // doesn't have a clientId (which happens if one isn't set when creating the transaction, eg. if it was created by
+    // the CM during reissuing) then we need to take the CM transaction's id and pull the matching record from
+    // transactionMap (which is indexed by those CM transaction ids). We can then read the id value of the record, which
+    // (confusingly!) is the field that the billingTransactionId has been mapped to.
+    const billingTransactionId = cmTransaction.clientId ?? transactionMap.get(cmTransaction.id).id
+
     return {
       ...(srocTransaction),
+      billingTransactionId,
       scheme: 'sroc',
-      billingTransactionId: cmTransaction.clientId,
       netAmount: cmTransaction.chargeValue,
       chargeType: cmTransaction.compensationCharge ? 'compensation' : 'standard',
       calcS126Factor: srocTransaction.calcS126Factor ? (srocTransaction.calcS126Factor.trim()).split('x')[1] || null : null,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4036

When `update-invoices-worker` handles sroc transactions, it maps the CM transaction to a billing transaction then updates some sroc-specific fields. This fails when handlng transactions created during reissuing.

The problem lies in the way that it determines the transaction's `billingTransactionId`: it takes the field `clientId` on the CM transaction (ie. our own billing transaction id), which is fine when we have sent a "create transaction" request across, as we include this in the request. However if the transaction was created by the CM itself during reissuing, it won't have a client id and therefore we would be trying to work with a transaction that has no transaction id!

The fix for this is straightforward. Our `mapTransaction` function already receives a map of all our transactions on the invoice, indexed by CM transaction id. We can therefore take the CM transaction we're mapping and use its id to pull our transaction from the map of transactions, which then lets us get our transaction's id.

In theory we could always do this; however for the sake of performance we only look this up if the client id isn't specific in the CM transaction.