### PR TITLE
Update /service-status version endpoints

### DIFF
--- a/src/lib/connectors/service-version-factory.js
+++ b/src/lib/connectors/service-version-factory.js
@@ -14,7 +14,7 @@ const { URL } = require('url')
  */
 const create = (endPointUrl) => async () => {
   const urlParts = new URL(endPointUrl)
-  const url = urlJoin(urlParts.protocol, urlParts.host, 'status')
+  const url = urlJoin(urlParts.protocol, urlParts.host, 'health/info')
   const response = await serviceRequest.get(url)
   return response.version
 }

--- a/test/lib/connectors/crm/service-version.test.js
+++ b/test/lib/connectors/crm/service-version.test.js
@@ -27,7 +27,7 @@ experiment('connectors/crm/service-version', () => {
     test('calls the expected URL', async () => {
       await serviceVersionConnector.getServiceVersion()
       const [url] = serviceRequest.get.lastCall.args
-      expect(url).to.endWith('/status')
+      expect(url).to.endWith('/health/info')
     })
   })
 })

--- a/test/lib/connectors/idm.test.js
+++ b/test/lib/connectors/idm.test.js
@@ -130,7 +130,7 @@ experiment('connectors/idm', () => {
     test('calls the expected URL', async () => {
       await idmConnector.getServiceVersion()
       const [url] = helpers.serviceRequest.get.lastCall.args
-      expect(url).to.endWith('/status')
+      expect(url).to.endWith('/health/info')
     })
   })
 

--- a/test/lib/connectors/import/index.test.js
+++ b/test/lib/connectors/import/index.test.js
@@ -28,7 +28,7 @@ experiment('connectors/import', () => {
     test('calls the expected URL', async () => {
       await importConnector.getServiceVersion()
       const [url] = serviceRequest.get.lastCall.args
-      expect(url).to.endWith('/status')
+      expect(url).to.endWith('/health/info')
     })
   })
 

--- a/test/lib/connectors/permit.test.js
+++ b/test/lib/connectors/permit.test.js
@@ -161,7 +161,7 @@ experiment('connectors/permit', () => {
     test('calls the expected URL', async () => {
       await permit.getServiceVersion()
       const [url] = serviceRequest.get.lastCall.args
-      expect(url).to.endWith('/status')
+      expect(url).to.endWith('/health/info')
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4096

Currently, the `/service-status` endpoint in the UI is getting the versions for the various services from their `/status` endpoints. As these endpoints are going to be updated to just return a static response of `{ "status": "alive" }`, this has been updated to `/health/info` which is an endpoint created for each repo a while ago to serve the repo's version.

This work is the first task in the issue: https://github.com/DEFRA/water-abstraction-team/issues/67