### PR TITLE
Start doing the minimum in /status checks

### DIFF
--- a/src/routes/background.js
+++ b/src/routes/background.js
@@ -2,14 +2,11 @@
 
 const healthRoutes = require('../modules/health/routes')
 
-const pkg = require('../../package.json')
-const { version } = pkg
-
 module.exports = [
   {
     method: 'GET',
     path: '/status',
-    handler: () => ({ version }),
+    handler: () => ({ status: 'alive' }),
     config: { auth: false, description: 'Check service status' }
   },
   ...Object.values(healthRoutes)

--- a/src/routes/water.js
+++ b/src/routes/water.js
@@ -10,9 +10,6 @@ const taskConfigRoutes = require('../controllers/task-config')
 const moduleRoutes = require('../modules/routes')
 const arAnalysisLicencesRoutes = require('../controllers/ar-analysis-licences')
 
-const pkg = require('../../package.json')
-const { version } = pkg
-
 module.exports = [
   ...sessionRoutes,
   ...eventsRoutes,
@@ -24,7 +21,7 @@ module.exports = [
   {
     method: 'GET',
     path: '/status',
-    handler: () => ({ version }),
+    handler: () => ({ status: 'alive' }),
     config: { auth: false, description: 'Check service status' }
   }
 ]

--- a/test/routes/background.test.js
+++ b/test/routes/background.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { server, start } = require('../../index-background')
 
 const { experiment, test, beforeEach, before } = exports.lab = require('@hapi/lab').script()
@@ -19,7 +21,7 @@ experiment('/status (background)', () => {
     expect(response.statusCode).to.equal(200)
   })
 
-  test('responds with an object containing the application version', async () => {
-    expect(response.result.version).to.match(/\d*\.\d*\.\d*/g)
+  test('responds with an object containing the application status', async () => {
+    expect(response.result.status).to.equal('alive')
   })
 })

--- a/test/routes/water.test.js
+++ b/test/routes/water.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { server, start } = require('../../index')
 
 const { experiment, test, beforeEach, before } = exports.lab = require('@hapi/lab').script()
@@ -19,7 +21,7 @@ experiment('/status (water)', () => {
     expect(response.statusCode).to.equal(200)
   })
 
-  test('responds with an object containing the application version', async () => {
-    expect(response.result.version).to.match(/\d*\.\d*\.\d*/g)
+  test('responds with an object containing the application status', async () => {
+    expect(response.result.status).to.equal('alive')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4096

AWS ELBs require an endpoint they can hit to confirm whether an app is running. They are commonly referred to as health checks and are used to determine whether the ELB should route traffic through to an app instance. In our apps, it is the `/status` endpoint.

The endpoint in all our repos currently reads in the `package.json` file to get the app's version number. This information is then used to support the `/service-status` page in the water-abstraction-ui. Some of the repos also include a test query to the DB to confirm it can connect.

Having checks that confirm you can connect to dependent services (databases, other apps etc) is a good thing. But the ELB health checks are made multiple times a second across all instances. They only care whether an app is up or not. So if, for example, you include querying your DB in  `/status` you're hitting your DB with multiple connections per second, multiplied by the number of server instances you have running.

Including reading a file from disk each time means we're adding an unnecessary load on a service that already has performance and resource usage issues.

We've already added a new `/health/info` endpoint to each repo and we do DB connection checks elsewhere. So, we can reduce the work of our `/status` endpoint across all the repos to the bare minimum; returning a static `{ "status": "alive" }` response.

This issue was originally raised in https://github.com/DEFRA/water-abstraction-team/issues/67