### PR TITLE
Improve Bill Run Queue Handling to Prevent Duplicate Jobs

### DIFF
--- a/src/modules/billing/jobs/approve-batch.js
+++ b/src/modules/billing/jobs/approve-batch.js
@@ -8,13 +8,17 @@ const { logger } = require('../../../logger')
 const { jobName: refreshTotalsJobName } = require('./refresh-totals')
 
 const createMessage = (batchId, user) => ([
+// We set `removeOnComplete` to 500 to briefly retain completed bill run jobs, preventing duplicate bill runs,
+// while `removeOnFail` is set to true to prevent bill runs from becoming stuck on the queue, allowing for re-runs.
   JOB_NAME,
   {
     batchId,
     user
   },
   {
-    jobId: `${JOB_NAME}.${batchId}`
+    jobId: `${JOB_NAME}.${batchId}`,
+    removeOnComplete: 500,
+    removeOnFail: true
   }
 ])
 

--- a/src/modules/billing/jobs/approve-batch.js
+++ b/src/modules/billing/jobs/approve-batch.js
@@ -4,8 +4,8 @@ const JOB_NAME = 'billing.approve-batch'
 
 const batchService = require('../services/batch-service')
 const batchJob = require('./lib/batch-job')
-const { logger } = require('../../../logger')
 const { jobName: refreshTotalsJobName } = require('./refresh-totals')
+const helpers = require('./lib/helpers')
 
 const createMessage = (batchId, user) => ([
 // We set `removeOnComplete` to 500 to briefly retain completed bill run jobs, preventing duplicate bill runs,
@@ -44,22 +44,8 @@ const onComplete = async (job, queueManager) => {
   }
 }
 
-const onFailedHandler = async (job, err) => {
-  // If a previous attempt to send the bill run has been tried but errored the logic in
-  // src/modules/billing/services/batch-service.js approveBatch() will reset the status of the bill run back to READY.
-  // We have found that subsequent attempts to send the bill run cause it to become 'stuck' This is because it seems
-  // the failed job is left in the queue. As the job ID is based on the billing batch ID when we add further approve
-  // jobs for this bill run BullMQ is ignoring them. It sees them as duplicates because they have the same key as a
-  // job already in the queue.
-  //
-  // To allow further attempts to happen we call 'remove()' on the job if it fails. This will remove the
-  // the job from the queue and allow a new job with the same ID to be processed.
-  logger.error(`Job ${job.name} ${job.id} failed`, err.stack)
-  await job.remove()
-}
-
 exports.jobName = JOB_NAME
 exports.createMessage = createMessage
 exports.handler = handler
 exports.onComplete = onComplete
-exports.onFailed = onFailedHandler
+exports.onFailed = helpers.onFailedHandler

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -210,7 +210,7 @@ const approveBatch = async (batch, internalCallingUser) => {
   } catch (err) {
     logger.error('Failed to approve the batch', err.stack, batch)
     // set the status back to ready so the user can retry
-    // await setStatus(batch.id, BATCH_STATUS.ready)
+    await setStatus(batch.id, BATCH_STATUS.ready)
     await saveEvent('billing-batch:approve', 'error', internalCallingUser, batch)
     throw err
   }

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -210,7 +210,7 @@ const approveBatch = async (batch, internalCallingUser) => {
   } catch (err) {
     logger.error('Failed to approve the batch', err.stack, batch)
     // set the status back to ready so the user can retry
-    await setStatus(batch.id, BATCH_STATUS.ready)
+    // await setStatus(batch.id, BATCH_STATUS.ready)
     await saveEvent('billing-batch:approve', 'error', internalCallingUser, batch)
     throw err
   }

--- a/test/modules/billing/jobs/approve-batch.test.js
+++ b/test/modules/billing/jobs/approve-batch.test.js
@@ -132,36 +132,4 @@ experiment('modules/billing/jobs/approve-batch', () => {
       })
     })
   })
-
-  experiment('.onFailed', () => {
-    let err, job, removeJobStub
-
-    beforeEach(async () => {
-      job = {
-        name: 'name',
-        id: '123',
-        remove: () => {}
-      }
-
-      err = new Error('oops')
-      removeJobStub = sandbox.stub(job, 'remove').resolves()
-
-      await approveBatchJob.onFailed(job, err)
-    })
-
-    afterEach(async () => {
-      sandbox.restore()
-    })
-
-    test('a message is logged', async () => {
-      expect(logger.error.calledWith(
-        `Job ${job.name} ${job.id} failed`,
-        err.stack
-      )).to.be.true()
-    })
-
-    test('the job.remove() is called', async () => {
-      expect(removeJobStub.calledOnce).to.be.true()
-    })
-  })
 })


### PR DESCRIPTION
In our current codebase, we utilize BullMQ for queuing bill-run jobs, with each bill run assigned a unique ID that doubles as the job ID within the queue. BullMQ's behavior prevents the existence of two jobs with the same ID in the queue. Initially, we believed that double-clicking the "Send to Bill Run" button would result in the second request being ignored, as the subsequent job would share the same ID and BullMQ would naturally dismiss it.

However, upon closer examination, we realized that the job processes on the queue with remarkable speed, allowing it to be removed from the queue before the same job can re-enter when the user inadvertently double-clicks the button. This rapid processing has led to bill runs getting stuck, as the queue attempts to process the second request, which triggers a conflict request in the charging module (due to the bill having already been successfully billed). Consequently, the approveBatch function encounters an error, causing the status to revert from 'sent' to 'ready'.

This pull request addresses the issue by changing the configuration of the queue, specifically for the approveBatch queue. 
This PR is changing the settings to maintain a record of completed bill-run jobs and remove any jobs that have failed. Keeping completed jobs in the queue allows BullMQ to identify duplicate bill runs and ignore them instead of processing them. Additionally, removing failed jobs enables the bill run to re-enter the queue if it fails without being flagged as a duplicate job.