### PR TITLE
Prevent error page showing for multiple return invitation requests

### DIFF
--- a/src/modules/batch-notifications/lib/send-batch.js
+++ b/src/modules/batch-notifications/lib/send-batch.js
@@ -20,6 +20,14 @@ const assertEventIsValid = (eventId, ev, issuer) => {
     throw new errors.UnauthorizedError(`Event ${eventId} issuer does not match that supplied`)
   }
 }
+/**
+ * Completing a separate check for the status as sending
+ * If true it is because there is duplicate requests sharing the same event ID, possibly due to double-clicking
+ * In this case we do not want it to error.
+ */
+const assertEventIsDuplicate = (event) => {
+  return event.status === EVENT_STATUS_SENDING
+}
 
 /**
  * Sends the processed notification with the requested event Id
@@ -29,6 +37,10 @@ const assertEventIsValid = (eventId, ev, issuer) => {
  */
 const send = async (eventId, issuer) => {
   const event = await eventsService.findOne(eventId)
+
+  if (assertEventIsDuplicate(event)) {
+    return event
+  }
 
   assertEventIsValid(eventId, event, issuer)
 

--- a/test/modules/batch-notifications/lib/send-batch.test.js
+++ b/test/modules/batch-notifications/lib/send-batch.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const { expect } = require('@hapi/code')
+const {
+  beforeEach,
+  experiment,
+  test,
+  afterEach
+} = exports.lab = require('@hapi/lab').script()
+
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const eventsService = require('../../../../src/lib/services/events.js')
+const { EVENT_STATUS_PROCESSED, EVENT_STATUS_SENDING } = require('../../../../src/modules/batch-notifications/lib/event-statuses.js')
+const messageHelpers = require('../../../../src/modules/batch-notifications/lib/message-helpers.js')
+const { MESSAGE_STATUS_SENDING } = require('../../../../src/modules/batch-notifications/lib/message-statuses.js')
+const sendBatch = require('../../../../src/modules/batch-notifications/lib/send-batch.js')
+
+let mockEvent
+const eventId = 'testEventId'
+const issuer = 'testIssuer'
+
+experiment('Send-batch', () => {
+  beforeEach(async () => {
+    mockEvent = {
+      id: eventId,
+      type: 'notification',
+      status: EVENT_STATUS_PROCESSED,
+      issuer
+    }
+
+    sandbox.stub(eventsService, 'findOne').resolves(mockEvent)
+    sandbox.stub(messageHelpers, 'updateMessageStatuses').resolves()
+    sandbox.stub(eventsService, 'updateStatus').resolves(mockEvent)
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
+  experiment('send', () => {
+    test('returns the event if it is a duplicate', async () => {
+      mockEvent.status = EVENT_STATUS_SENDING
+      const result = await sendBatch.send(eventId, issuer)
+
+      expect(result).to.equal(mockEvent)
+    })
+
+    test('throws an error if the event cannot be found', async () => {
+      eventsService.findOne.resolves(undefined)
+
+      await expect(sendBatch.send(eventId, issuer)).to.reject()
+    })
+
+    test('throws an error if the event is not of type "notification"', async () => {
+      mockEvent.type = 'otherType'
+
+      await expect(sendBatch.send(eventId, issuer)).to.reject()
+    })
+
+    test('throws an error if the event status is not EVENT_STATUS_PROCESSED', async () => {
+      mockEvent.status = 'otherStatus'
+
+      await expect(sendBatch.send(eventId, issuer)).to.reject()
+    })
+
+    test('throws an error if the issuer does not match the event issuer', async () => {
+      const invalidIssuer = 'invalidIssuer'
+
+      await expect(sendBatch.send(eventId, invalidIssuer)).to.reject()
+    })
+
+    test('updates message statuses and event status to EVENT_STATUS_SENDING', async () => {
+      const result = await sendBatch.send(eventId, issuer)
+
+      expect(result).to.equal(mockEvent)
+      sinon.assert.calledOnce(messageHelpers.updateMessageStatuses)
+      sinon.assert.calledWithExactly(messageHelpers.updateMessageStatuses, eventId, MESSAGE_STATUS_SENDING)
+      sinon.assert.calledOnce(eventsService.updateStatus)
+      sinon.assert.calledWithExactly(eventsService.updateStatus, eventId, EVENT_STATUS_SENDING)
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4104

This pull request aims to improve the handling of 'return invitation' notifications specifically that multiple requests are not being processed. Upon investigation, I can see that the legacy code already addresses multiple requests. The code examines the event's status, and if it doesn't match the 'processed' status, an error is raised.

This approach is beneficial as it guarantees that the service never sends duplicate notifications. However, it has a drawback: it displays an error page to the user, implying an issue with sending the batch, when, in fact, the batch still sends correctly. It's just that subsequent requests after the initial one aren't sent.

The changes introduced in this pull request involve an additional check. This new check examines if the event status is set to 'sending.' If this condition is met, instead of throwing an error, the system will return the data to the page and will not continue processing the request. This improvement ensures that users will see the correct page without encountering an error.

It's important to note that all other checks, including the status check, have been retained, as we want to account for any potential errors that might occur when the status is anything other than 'processing' or 'sending.'

There was no testing file for send-batch either so I have added this as well.