### PR TITLE
Stop duplicate paper forms

### DIFF
--- a/src/modules/batch-notifications/config/paper-returns/index.js
+++ b/src/modules/batch-notifications/config/paper-returns/index.js
@@ -37,7 +37,8 @@ const schema = Joi.object({
     }).unknown().allow(null).required(),
     returns: Joi.array().items(Joi.object({
       returnId: Joi.string().regex(returnIDRegex).required()
-    }).unknown()).required()
+    }).unknown()).required(),
+    uniqueJobId: Joi.string()
   }))
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4106

This pull request primarily addresses the prevention of multiple requests being processed for paper return forms. In the current system, if multiple requests are made, such as by a user double-clicking, all these requests get processed, resulting in multiple sets of paper return forms being sent out. The changes introduced in this pull request involve the creation of a uniqueJobId within the (UI repository https://github.com/DEFRA/water-abstraction-ui/pull/2458) when a user starts entering their information. This unique ID is then passed across all pages and is included in the event record stored in the database. A new check is now performed at the start of handling send requests to verify whether the same ID already exists in the database. If it does, the system returns early, preventing the event from sending out paper forms once again.