### PR TITLE
Delete bugged licence

### DIFF
--- a/migrations/20231102122939-delete-broken-licence.js
+++ b/migrations/20231102122939-delete-broken-licence.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20231102122939-delete-broken-licence-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20231102122939-delete-broken-licence-down.sql-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20231102122939-delete-broken-licence-down.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -29,7 +29,7 @@ DELETE FROM water.licence_version_purposes WHERE licence_version_id IN (
 
 DELETE FROM water.licence_versions WHERE licence_id IN (
   SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
-)
+);
 
 DELETE FROM water.return_requirement_purposes WHERE return_requirement_id IN (
   SELECT return_requirement_id  FROM water.return_requirements WHERE return_version_id IN (

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -9,13 +9,11 @@ DO $$
             )
         THEN
           DELETE FROM "crm_v2"."document_roles" WHERE document_id IN (
-            SELECT document_id FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+            SELECT document_id FROM "crm_v2"."documents" WHERE document_ref = 'NW/072/0417/002/R01' || CHR(13)
           );
-
-          DELETE FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
         END IF ;
     END
-   $$ ;
+  $$ ;
 
 DO $$
     BEGIN
@@ -26,10 +24,10 @@ DO $$
               AND    table_name = 'documents'
             )
         THEN
-          DELETE FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+          DELETE FROM "crm_v2"."documents" WHERE document_ref = 'NW/072/0417/002/R01' || CHR(13);
         END IF ;
     END
-   $$ ;
+  $$ ;
 
 DO $$
     BEGIN
@@ -40,10 +38,10 @@ DO $$
               AND    table_name = 'document_header'
             )
         THEN
-          DELETE FROM crm.document_header WHERE system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
+          DELETE FROM crm.document_header WHERE system_external_id = 'NW/072/0417/002/R01' || CHR(13);
         END IF ;
     END
-   $$ ;
+  $$ ;
 
 DO $$
     BEGIN
@@ -54,59 +52,59 @@ DO $$
               AND    table_name = 'licence'
             )
         THEN
-          DELETE FROM permit.licence WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+          DELETE FROM permit.licence WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13);
         END IF ;
     END
-   $$ ;
+  $$ ;
 
 DO $$
- BEGIN
-     IF EXISTS
-         ( SELECT 1
-           FROM   information_schema.tables
-           WHERE  table_schema = 'returns'
-           AND    table_name = 'returns'
-         )
-     THEN
-       DELETE FROM "returns"."returns" WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
-     END IF ;
- END
-$$ ;
+  BEGIN
+      IF EXISTS
+          ( SELECT 1
+            FROM   information_schema.tables
+            WHERE  table_schema = 'returns'
+            AND    table_name = 'returns'
+          )
+      THEN
+        DELETE FROM "returns"."returns" WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13);
+      END IF ;
+  END
+  $$ ;
 
 DELETE FROM water.licence_version_purpose_conditions WHERE licence_version_purpose_id IN (
   SELECT licence_version_purpose_id FROM water.licence_version_purposes WHERE licence_version_id IN (
     SELECT licence_version_id FROM water.licence_versions WHERE licence_id IN (
-      SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+      SELECT licence_id FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13)
     )
   )
 );
 
 DELETE FROM water.licence_version_purposes WHERE licence_version_id IN (
   SELECT licence_version_id FROM water.licence_versions WHERE licence_id IN (
-    SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+    SELECT licence_id FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13)
   )
 );
 
 DELETE FROM water.licence_versions WHERE licence_id IN (
-  SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+  SELECT licence_id FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13)
 );
 
 DELETE FROM water.return_requirement_purposes WHERE return_requirement_id IN (
   SELECT return_requirement_id  FROM water.return_requirements WHERE return_version_id IN (
     SELECT return_version_id FROM water.return_versions WHERE licence_id IN (
-      SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+      SELECT licence_id FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13)
     )
   )
 );
 
 DELETE FROM water.return_requirements WHERE return_version_id IN (
   SELECT return_version_id FROM water.return_versions WHERE licence_id IN(
-    SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+    SELECT licence_id FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13)
   )
 );
 
 DELETE FROM water.return_versions WHERE licence_id IN (
-  SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+  SELECT licence_id FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13)
 );
 
-DELETE FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM water.licences WHERE licence_ref = 'NW/072/0417/002/R01' || CHR(13);

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,6 +1,6 @@
 /* This query is deleting a bad licence data that has a carriage return at the end of it */
 
-DELETE FROM crm_v2.document_roles WHERE document_id IN (
+DELETE FROM "crm_v2".document_roles WHERE document_id IN (
   SELECT document_id FROM crm_v2.documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,17 +1,77 @@
 /* This query is deleting a bad licence data that has a carriage return at the end of it */
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'crm_v2'
+              AND    table_name = 'document_roles'
+            )
+        THEN
+          DELETE FROM "crm_v2"."document_roles" WHERE document_id IN (
+            SELECT document_id FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+          );
 
-DELETE FROM "crm_v2"."document_roles" WHERE document_id IN (
-  SELECT document_id FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
-);
+          DELETE FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+        END IF ;
+    END
+   $$ ;
 
-DELETE FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'crm_v2'
+              AND    table_name = 'documents'
+            )
+        THEN
+          DELETE FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+        END IF ;
+    END
+   $$ ;
 
-DELETE FROM crm.document_header WHERE system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'crm'
+              AND    table_name = 'document_header'
+            )
+        THEN
+          DELETE FROM crm.document_header WHERE system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
+        END IF ;
+    END
+   $$ ;
 
-DELETE FROM permit.licence WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'permit'
+              AND    table_name = 'licence'
+            )
+        THEN
+          DELETE FROM permit.licence WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+        END IF ;
+    END
+   $$ ;
 
-DELETE FROM "returns"."returns" WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
-
+DO $$
+ BEGIN
+     IF EXISTS
+         ( SELECT 1
+           FROM   information_schema.tables
+           WHERE  table_schema = 'returns'
+           AND    table_name = 'returns'
+         )
+     THEN
+       DELETE FROM "returns"."returns" WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+     END IF ;
+ END
+$$ ;
 
 DELETE FROM water.licence_version_purpose_conditions WHERE licence_version_purpose_id IN (
   SELECT licence_version_purpose_id FROM water.licence_version_purposes WHERE licence_version_id IN (

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,52 +1,52 @@
 /* This query is deleting a bad licence data that has a carriage return at the end of it */
 
-DELETE FROM crm_v2.document_roles dr WHERE dr.document_id IN (
-  SELECT document_id FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM crm_v2.document_roles WHERE document_id IN (
+  SELECT document_id FROM crm_v2.documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 
-DELETE FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM crm_v2.documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
 
-DELETE FROM crm.document_header dh WHERE dh.system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM crm.document_header WHERE system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
 
-DELETE FROM permit.licence l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM permit.licence WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
 
-DELETE FROM "returns"."returns" r  WHERE r.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM "returns"."returns" WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
 
 
-DELETE FROM water.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id IN (
-  SELECT lvp.licence_version_purpose_id FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id IN (
-    SELECT lv.licence_version_id FROM water.licence_versions lv WHERE lv.licence_id IN (
-      SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM water.licence_version_purpose_conditions WHERE licence_version_purpose_id IN (
+  SELECT licence_version_purpose_id FROM water.licence_version_purposes WHERE licence_version_id IN (
+    SELECT licence_version_id FROM water.licence_versions WHERE licence_id IN (
+      SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
     )
   )
 );
 
-DELETE FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id IN (
-  SELECT lv.licence_version_id FROM water.licence_versions lv WHERE lv.licence_id IN (
-    SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM water.licence_version_purposes WHERE licence_version_id IN (
+  SELECT licence_version_id FROM water.licence_versions WHERE licence_id IN (
+    SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
   )
 );
 
-DELETE FROM water.licence_versions lv WHERE lv.licence_id IN (
-  SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM water.licence_versions WHERE licence_id IN (
+  SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 )
 
-DELETE FROM water.return_requirement_purposes rrp WHERE rrp.return_requirement_id IN (
-  SELECT rr.return_requirement_id  FROM water.return_requirements rr WHERE rr.return_version_id IN (
-    SELECT rv.return_version_id FROM water.return_versions rv WHERE rv.licence_id IN (
-      SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM water.return_requirement_purposes WHERE return_requirement_id IN (
+  SELECT return_requirement_id  FROM water.return_requirements WHERE return_version_id IN (
+    SELECT return_version_id FROM water.return_versions WHERE licence_id IN (
+      SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
     )
   )
 );
 
-DELETE FROM water.return_requirements rr WHERE rr.return_version_id IN (
-  SELECT return_version_id FROM water.return_versions rv WHERE rv.licence_id IN(
-    SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM water.return_requirements WHERE return_version_id IN (
+  SELECT return_version_id FROM water.return_versions WHERE licence_id IN(
+    SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
   )
 );
 
-DELETE FROM water.return_versions rv WHERE rv.licence_id IN (
-  SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM water.return_versions WHERE licence_id IN (
+  SELECT licence_id FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 
-DELETE FROM water.licences l WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM water.licences WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,10 +1,10 @@
 /* This query is deleting a bad licence data that has a carriage return at the end of it */
 
 DELETE FROM "crm_v2".document_roles WHERE document_id IN (
-  SELECT document_id FROM crm_v2.documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+  SELECT document_id FROM "crm_v2".documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 
-DELETE FROM crm_v2.documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM "crm_v2".documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
 
 DELETE FROM crm.document_header WHERE system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
 

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,10 +1,10 @@
 /* This query is deleting a bad licence data that has a carriage return at the end of it */
 
-DELETE FROM "crm_v2".document_roles WHERE document_id IN (
-  SELECT document_id FROM "crm_v2".documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+DELETE FROM "crm_v2"."document_roles" WHERE document_id IN (
+  SELECT document_id FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 
-DELETE FROM "crm_v2".documents WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+DELETE FROM "crm_v2"."documents" WHERE document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
 
 DELETE FROM crm.document_header WHERE system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
 

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,0 +1,52 @@
+-- crm_v2
+DELETE FROM crm_v2.document_roles dr WHERE dr.document_id IN (
+  SELECT document_id FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+);
+
+DELETE FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+-- crm schema
+DELETE FROM crm.document_header dh WHERE dh.system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
+
+-- Permit Schema
+DELETE FROM permit.licence l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+-- Returns Schema
+DELETE FROM "returns"."returns" r  WHERE r.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+
+-- Water Schema
+DELETE FROM water.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id IN (
+  SELECT lvp.licence_version_purpose_id FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id IN (
+    SELECT lv.licence_version_id FROM water.licence_versions lv WHERE lv.licence_id IN (
+      SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+    )
+  )
+);
+
+DELETE FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id IN (
+  SELECT lv.licence_version_id FROM water.licence_versions lv WHERE lv.licence_id IN (
+    SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+  )
+);
+
+DELETE FROM water.licence_versions lv WHERE lv.licence_id IN (
+  SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+)
+
+DELETE FROM water.return_requirement_purposes rrp WHERE rrp.return_requirement_id IN (
+  SELECT rr.return_requirement_id  FROM water.return_requirements rr WHERE rr.return_version_id IN (
+    SELECT rv.return_version_id FROM water.return_versions rv WHERE rv.licence_id IN (
+      SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+    )
+  )
+);
+
+DELETE FROM water.return_requirements WHERE rr.return_version_id IN (
+  SELECT return_version_id FROM water.return_versions rv WHERE rv.licence_id IN(
+    SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+  )
+);
+
+DELETE FROM water.return_versions rv WHERE rv.licence_id IN (
+  SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
+);
+
+DELETE FROM water.licences l WHERE licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,18 +1,18 @@
--- crm_v2
+/* This query is deleting a bad licence data that has a carriage return at the end of it */
+
 DELETE FROM crm_v2.document_roles dr WHERE dr.document_id IN (
   SELECT document_id FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 
 DELETE FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
--- crm schema
+
 DELETE FROM crm.document_header dh WHERE dh.system_external_id LIKE 'NW/072/0417/002/R01' || CHR(13);
 
--- Permit Schema
 DELETE FROM permit.licence l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
--- Returns Schema
+
 DELETE FROM "returns"."returns" r  WHERE r.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
 
--- Water Schema
+
 DELETE FROM water.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id IN (
   SELECT lvp.licence_version_purpose_id FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id IN (
     SELECT lv.licence_version_id FROM water.licence_versions lv WHERE lv.licence_id IN (

--- a/migrations/sqls/20231102122939-delete-broken-licence-up.sql
+++ b/migrations/sqls/20231102122939-delete-broken-licence-up.sql
@@ -1,6 +1,6 @@
 -- crm_v2
 DELETE FROM crm_v2.document_roles dr WHERE dr.document_id IN (
-  SELECT document_id FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
+  SELECT document_id FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
 );
 
 DELETE FROM crm_v2.documents d WHERE d.document_ref LIKE 'NW/072/0417/002/R01' || CHR(13);
@@ -39,7 +39,7 @@ DELETE FROM water.return_requirement_purposes rrp WHERE rrp.return_requirement_i
   )
 );
 
-DELETE FROM water.return_requirements WHERE rr.return_version_id IN (
+DELETE FROM water.return_requirements rr WHERE rr.return_version_id IN (
   SELECT return_version_id FROM water.return_versions rv WHERE rv.licence_id IN(
     SELECT licence_id FROM water.licences l WHERE l.licence_ref LIKE 'NW/072/0417/002/R01' || CHR(13)
   )


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4182

This PR contains the migrations to remove a licence that is containing a carriage return at the end of the licence ref. This is causing the UI to error and our acceptance tests to fail.