### PR TITLE
Add defaults to unused `returns` & `lines` table columns

### DIFF
--- a/migrations/20231122170046-add-defaults-to-returns-tables.js
+++ b/migrations/20231122170046-add-defaults-to-returns-tables.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20231122170046-add-defaults-to-returns-tables-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20231122170046-add-defaults-to-returns-tables-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20231122170046-add-defaults-to-returns-tables-down.sql
+++ b/migrations/sqls/20231122170046-add-defaults-to-returns-tables-down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE returns.returns ALTER COLUMN regime DROP DEFAULT;
+
+ALTER TABLE returns.returns ALTER COLUMN licence_type DROP DEFAULT;
+
+ALTER TABLE returns.lines ALTER COLUMN substance DROP DEFAULT;
+
+ALTER TABLE returns.lines ALTER COLUMN unit DROP DEFAULT;

--- a/migrations/sqls/20231122170046-add-defaults-to-returns-tables-up.sql
+++ b/migrations/sqls/20231122170046-add-defaults-to-returns-tables-up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE returns.returns ALTER COLUMN regime SET DEFAULT 'water';
+
+ALTER TABLE returns.returns ALTER COLUMN licence_type SET DEFAULT 'abstraction';
+
+ALTER TABLE returns.lines ALTER COLUMN substance SET DEFAULT 'water';
+
+ALTER TABLE returns.lines ALTER COLUMN unit SET DEFAULT 'm³';


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/106

As part of making the migrations work in `water-abstraction-system` we have been creating DB Views of the legacy Returns data that better represent the data as we use it in our new service. Part of this exercise is pruning out the unused columns that exist in the legacy tables that are not utilised.

However, we have found that for some of the columns in the legacy data, whilst pointless, still need to be populated as they are set to Not Nullable in the legacy database tables. Therefore, we will set a default value for these columns in the legacy DB so that they are always populated even when they do not exist in our new Views.

The table columns that will be affected by this PR are:
- `returns.regime` - this is always "water" so it will default to "water"
- `returns.licence_type` - this is always "abstraction" so it will default to "abstraction"
- `lines.substance` - surprise, surprise, this is always "water" so it will default to "water"
- `lines.unit` - This is always "m³" so it will default to "m³"