### PR TITLE
Expired Licence Communications Bug

### DIFF
--- a/src/modules/communications/controller.js
+++ b/src/modules/communications/controller.js
@@ -54,7 +54,7 @@ const formatEvent = evt => {
 }
 
 const getLicenceDocuments = async licenceNumbers => {
-  const documents = await crmDocumentConnector.getDocumentsByLicenceNumbers(licenceNumbers)
+  const documents = await crmDocumentConnector.getDocumentsByLicenceNumbers(licenceNumbers, true)
 
   if (!documents.length) {
     throw Boom.notFound(`No document found for ${licenceNumbers.join()}`)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4246

In the service, it is possible to click on the communications tab within a licence and view all the previous letters and emails that have been sent. When you click onto the link for an email or letter with an expired/lapsed or revoked licence instead of viewing the communication this errors and sends the user to a reject URL page. 

Upon investigation, this is because a default parameter called `includeExpired?` is set to false. This parameter is linked to the documents table in CRM. It's referring to the metadata column and the property `isCurrent`. When the parameter is set to false, it uses this as a filter and will ignore any documents that are not current. This means when we are trying to view communications for expired/lapsed and revoked licences this has been defaulted to false and when it tries to find the document (for the licence) it cannot find any. This is the reason it then returns an error. Simply setting this parameter to be true fixes this bug. 

