### PR TITLE
Lock version of moment due to breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "knex": "^0.21.1",
         "libxmljs": "^1.0.9",
         "lodash": "^4.17.21",
-        "moment": "^2.29.4",
+        "moment": "2.29.4",
         "moment-range": "^4.0.2",
         "node-cron": "^3.0.2",
         "notifications-node-client": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "knex": "^0.21.1",
     "libxmljs": "^1.0.9",
     "lodash": "^4.17.21",
-    "moment": "^2.29.4",
+    "moment": "2.29.4",
     "moment-range": "^4.0.2",
     "node-cron": "^3.0.2",
     "notifications-node-client": "^4.9.0",


### PR DESCRIPTION
> See [Bump moment from 2.29.4 to 2.30.1](https://github.com/DEFRA/water-abstraction-service/pull/2375) for Dependabot bump that exposed this issue

**Dependabot** recently tried to bump [Moment](https://github.com/moment/moment) to a new minor version. However, when it did Ci started failing with breaking tests.

When we dug in we discovered the reason was any dates we tested where the day had a leading zero, for example, `03 August 2019`. One of the changes between **Moment** 2.29.4 and 2.30 was [[bugfix] Stricter single digit date parsing](https://github.com/moment/moment/pull/5592).

[The issue](https://github.com/moment/moment/issues/5314) that got fixed was that if you specify a date format of `['D MMMM YYYY']` then test if `03 August 2019` is valid **Moment** should say no. Before the 'fix' **Moment** was allowing this through and returning true.

It turns out we are dependent on this behaviour. In `src/modules/returns/lib/csv-adapter/date-parser.js`, we use a set of formats when parsing dates (the comments were copied from the source code).

```javascript
// preferred format for dates is D MMMM YYYY, but some applications
// may output the CSV in another format. This list attempts to deal
// with the unexpected formats without risking potential
// crossovers between formats such at DD/MM/YYYY and MM/DD/YYYY
// by using a sample of potential separators.
const GDS_DATE_FORMATS = [
  ['D', 'MMMM', 'YYYY'],
  ['D', 'MMM', 'YYYY'],
  ['D', 'MM', 'YYYY'],
  ['D', 'MMMM', 'YY'],
  ['D', 'MMM', 'YY'],
  ['D', 'MM', 'YY']
].flatMap(date => ([
  date.join(' '),
  date.join('/'),
  date.join('-')
]))
```

In properly interpreting the rules, we're telling **Moment** that the only valid date formats are the ones where 'day' does not have a leading zero. **Moment** v2.30 is saying "Sir, yes sir!" and rejecting dates we expect to be valid. **Moment** v2.29 says, "It's cool daddy-o, we're all days here".

We don't fully understand the implications of updating `GDS_DATE_FORMATS` and have to take the tests at face value and that they reflect what the module needs to handle. This means we're very reluctant to start messing with the code.

So, until we do or even better, we've archived this project we're restricting the version of **Moment** we can use.