### PR TITLE
Fix missing invoice account address records

### DIFF
--- a/migrations/20240104130338-fix-missing-invoice-account-addresses.js
+++ b/migrations/20240104130338-fix-missing-invoice-account-addresses.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240104130338-fix-missing-invoice-account-addresses-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240104130338-fix-missing-invoice-account-addresses-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240104130338-fix-missing-invoice-account-addresses-down.sql
+++ b/migrations/sqls/20240104130338-fix-missing-invoice-account-addresses-down.sql
@@ -1,0 +1,7 @@
+/*
+ * Add missing invoice_account_address records
+ *
+ * https://eaflood.atlassian.net/browse/WATER-4318
+ *
+ * The up script is dealing with bad data. It is adding missing records. We wouldn't want to revert that.
+*/

--- a/migrations/sqls/20240104130338-fix-missing-invoice-account-addresses-up.sql
+++ b/migrations/sqls/20240104130338-fix-missing-invoice-account-addresses-up.sql
@@ -1,0 +1,41 @@
+/*
+ * Add missing invoice_account_address records
+ *
+ * https://eaflood.atlassian.net/browse/WATER-4318
+ *
+ * When testing WATER-4223 we found 36 billing accounts (out of 38K) which didn't have a crm_v2.invoice_account_address
+ * record. Every billing account (crm_v2.invoice_accounts) should have at least one of these. This script will
+ * dynamically add the missing records.
+ *
+ * It populates the missing record using existing data. Every crm_v2.invoice_accounts record has to have a company_id.
+ * We can look this up in the crm_v2.company_addresses table, which will have a corresponding address_id. This, plus
+ * the invoice account ID, start, created and updated dates are all we need to create the missing records.
+ *
+ * The complication we have is crm_v2.company_addresses will have multiple entries per company. It, like
+ * invoice_account_addresses has the concept of a start and end date. So, we only care about the last created that also
+ * has a NULL end date (meaning it is the current record.)
+ *
+ * But a company can also appear multiple times due to the role assigned to the crm_v2.company_addresses record. We only
+ * care for those where the role is 'billing'.
+*/
+
+INSERT INTO crm_v2.invoice_account_addresses(
+	invoice_account_id, address_id, start_date, date_created, date_updated
+)
+SELECT
+	ia.invoice_account_id, car.address_id, ia.start_date, ia.date_created, ia.date_updated
+FROM crm_v2.invoice_accounts ia
+INNER JOIN (
+  -- The data we are dealing with being rubbish there is the possibility of the query returning 2 records with a NULL
+  -- end date, matching company_id and a role of 'billing'. We can exploit a feature of PostgreSQL in this case.
+  -- DISTINCT ON keeps only the first row from the results. So, should this query hit that scenario, by ordering by
+  -- date_created DESC we'll pluck the address_id from the most recently created record thanks to DISTINCT ON
+	SELECT DISTINCT ON (ca.company_id) ca.company_id, ca.address_id
+	FROM crm_v2.company_addresses ca
+	WHERE ca.end_date IS NULL
+	AND ca.role_id = (SELECT ro.role_id FROM crm_v2.roles ro WHERE ro.name = 'billing')
+	ORDER BY ca.company_id, ca.date_created DESC
+) car ON car.company_id = ia.company_id
+WHERE ia.invoice_account_id NOT IN (
+  SELECT DISTINCT iaa.invoice_account_id FROM crm_v2.invoice_account_addresses iaa
+);


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4223

We are replacing the legacy bill run view with one we have developed in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). During testing, it was found that there are examples of bill runs where a bill is missing from the view. When we checked the legacy version the bill was present so this was an issue just in our version of the page.

When we looked into the reason why, we found it was because the bill (`water.billing_invoice`) was linked to a billing account (`crm_v2.invoice_account`) that has no account address record (`crm_v2.invoice_account_address`). Since starting with the service we have been working under the assumption this should _never_ be the case; each billing account should have at least **one** account address record.

The legacy code is catering for this but when we checked we found only 38 records were affected. So, rather than add complexity to our code to handle 'duff' data it would be better to fix the root cause.

So, this fix migration creates the missing `crm_v2.invoice_account_address` records for the billing accounts affected.