### PR TITLE
Fix - Delete licence with invalid leading space

### DIFF
--- a/migrations/20240207123613-delete-broken-licence.js
+++ b/migrations/20240207123613-delete-broken-licence.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240207123613-delete-broken-licence-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240207123613-delete-broken-licence-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240207123613-delete-broken-licence-down.sql
+++ b/migrations/sqls/20240207123613-delete-broken-licence-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to remove bad data from the db. We don't want that bad data put back in!!!! */

--- a/migrations/sqls/20240207123613-delete-broken-licence-up.sql
+++ b/migrations/sqls/20240207123613-delete-broken-licence-up.sql
@@ -1,0 +1,122 @@
+/*
+  Fix duplicate licence record caused by leading space in 2nd NALD
+
+  https://eaflood.atlassian.net/browse/WATER-4357
+
+  Searching for NW/075/0012/011 is crashing the service. It is because there are 2 of them in the DB. One of the records
+  has a leading space in front of the licence reference.
+
+  Clearly, water-abstraction-import is not stripping whitespace. So, the computer sees these as completely different
+  values, meaning it has imported both.
+
+  This migration removes the problem record.
+*/
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'crm_v2'
+              AND    table_name = 'document_roles'
+            )
+        THEN
+          DELETE FROM "crm_v2"."document_roles" WHERE document_id IN (
+            SELECT document_id FROM "crm_v2"."documents" WHERE document_ref = ' NW/075/0012/011'
+          );
+        END IF ;
+    END
+  $$ ;
+
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'crm_v2'
+              AND    table_name = 'documents'
+            )
+        THEN
+          DELETE FROM "crm_v2"."documents" WHERE document_ref = ' NW/075/0012/011';
+        END IF ;
+    END
+  $$ ;
+
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'crm'
+              AND    table_name = 'document_header'
+            )
+        THEN
+          DELETE FROM crm.document_header WHERE system_external_id = ' NW/075/0012/011';
+        END IF ;
+    END
+  $$ ;
+
+DO $$
+    BEGIN
+        IF EXISTS
+            ( SELECT 1
+              FROM   information_schema.tables
+              WHERE  table_schema = 'permit'
+              AND    table_name = 'licence'
+            )
+        THEN
+          DELETE FROM permit.licence WHERE licence_ref = ' NW/075/0012/011';
+        END IF ;
+    END
+  $$ ;
+
+DO $$
+  BEGIN
+      IF EXISTS
+          ( SELECT 1
+            FROM   information_schema.tables
+            WHERE  table_schema = 'returns'
+            AND    table_name = 'returns'
+          )
+      THEN
+        DELETE FROM "returns"."returns" WHERE licence_ref = ' NW/075/0012/011';
+      END IF ;
+  END
+  $$ ;
+
+DELETE FROM water.licence_version_purpose_conditions WHERE licence_version_purpose_id IN (
+  SELECT licence_version_purpose_id FROM water.licence_version_purposes WHERE licence_version_id IN (
+    SELECT licence_version_id FROM water.licence_versions WHERE licence_id IN (
+      SELECT licence_id FROM water.licences WHERE licence_ref = ' NW/075/0012/011'
+    )
+  )
+);
+
+DELETE FROM water.licence_version_purposes WHERE licence_version_id IN (
+  SELECT licence_version_id FROM water.licence_versions WHERE licence_id IN (
+    SELECT licence_id FROM water.licences WHERE licence_ref = ' NW/075/0012/011'
+  )
+);
+
+DELETE FROM water.licence_versions WHERE licence_id IN (
+  SELECT licence_id FROM water.licences WHERE licence_ref = ' NW/075/0012/011'
+);
+
+DELETE FROM water.return_requirement_purposes WHERE return_requirement_id IN (
+  SELECT return_requirement_id  FROM water.return_requirements WHERE return_version_id IN (
+    SELECT return_version_id FROM water.return_versions WHERE licence_id IN (
+      SELECT licence_id FROM water.licences WHERE licence_ref = ' NW/075/0012/011'
+    )
+  )
+);
+
+DELETE FROM water.return_requirements WHERE return_version_id IN (
+  SELECT return_version_id FROM water.return_versions WHERE licence_id IN(
+    SELECT licence_id FROM water.licences WHERE licence_ref = ' NW/075/0012/011'
+  )
+);
+
+DELETE FROM water.return_versions WHERE licence_id IN (
+  SELECT licence_id FROM water.licences WHERE licence_ref = ' NW/075/0012/011'
+);
+
+DELETE FROM water.licences WHERE licence_ref = ' NW/075/0012/011';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4357

It looks like the [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) has managed to import a duplicate NALD licence record (again!) this time because it differs from an existing one due to a leading space.

The Billing & Data team can clean up NALD by removing the problem record. But now it's been created in our DB the only way to remove it is with a migration. Until we remove it any searches where `NW/075/0012/011` appears in the results cause an error.