### PR TITLE
Stop marking bill runs as ready when they are not

### DIFF
--- a/src/modules/billing/jobs/lib/update-invoices-worker.js
+++ b/src/modules/billing/jobs/lib/update-invoices-worker.js
@@ -131,7 +131,7 @@ const getAllCmTransactionsForInvoice = async (cmBillRunId, invoiceId) => {
   }
 }
 
-async function updateInvoices (job, logger) {
+async function updateInvoices (job) {
   const startTime = process.hrtime.bigint()
 
   logger.info(`onHandler: ${job.id} - started update of invoices from CHA`)

--- a/src/modules/billing/jobs/update-invoices.js
+++ b/src/modules/billing/jobs/update-invoices.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// const fork = require('child_process').fork
 const { v4: uuid } = require('uuid')
 
 // Utils

--- a/src/modules/billing/jobs/update-invoices.js
+++ b/src/modules/billing/jobs/update-invoices.js
@@ -21,7 +21,7 @@ const createMessage = data => ([
 ])
 
 const handler = async job => {
-  await UpdateInvoicesWorker.updateInvoices(job, logger)
+  await UpdateInvoicesWorker.updateInvoices(job)
 }
 
 const onComplete = async (job) => {

--- a/src/modules/billing/services/batch-service.js
+++ b/src/modules/billing/services/batch-service.js
@@ -481,7 +481,7 @@ const updateWithCMSummary = async (batchId, cmResponse) => {
   const cmCompletedStatuses = ['billed', 'billing_not_required']
 
   const batch = await newRepos.billingBatches.findOne(batchId)
-  const status = cmCompletedStatuses.includes(cmStatus) && batch.status !== 'cancel' ? Batch.BATCH_STATUS.sent : Batch.BATCH_STATUS.ready
+  const status = cmCompletedStatuses.includes(cmStatus) && batch.status !== 'cancel' ? Batch.BATCH_STATUS.sent : Batch.BATCH_STATUS.processing
 
   // Get transaction count in local DB
   // if 0, the batch will be set to "empty" status

--- a/test/modules/billing/services/batch-service.test.js
+++ b/test/modules/billing/services/batch-service.test.js
@@ -849,9 +849,9 @@ experiment('modules/billing/services/batch-service', () => {
         })
       })
 
-      test('the batch is updated correctly with "ready" status', async () => {
+      test('the batch is updated correctly with "processing" status', async () => {
         expect(newRepos.billingBatches.update.calledWith(BATCH_ID, {
-          status: Batch.BATCH_STATUS.ready,
+          status: Batch.BATCH_STATUS.processing,
           invoiceCount,
           creditNoteCount,
           invoiceValue,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4345

We have been working on replacing the legacy SROC annual billing engine with one in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). That engine is based on the one we built for supplementary billing which is also in **water-a
bstraction-system**.

We needed to deliver supplementary billing as soon as we could so only replaced part of the work the legacy service was doing. The new engines extract the transaction information and send it to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api). They even tell it to generate the bill run. But they then send a request to this legacy service's `/water/1.0/billing/batches/{id}/refresh` endpoint. This does the job of querying the CHA for the updated invoice and transaction information after
r the bill run has been generated. It then updates the WRLS records based on this.

At the time it was deemed out of scope to allow us to focus on getting the bill run generated. But what we've learned over time is that this project is immediately marking the bill run as `READY` once it sees the CHA has finished generating before it ha
s finished updating itself.

Those of us who have access to the logs can see the service is still busy working. Users of the service will experience this if they compare a download of the bill run generated straight away to one generated later.
    
We believe this confusion is contributing to the problems we experience during annual billing. For example, users may believe it is fine to start the next bill run unaware this project is busy hammering the CHA for billing information.
    
So, this change stops the legacy service marking the bill run as ready _until_ the 'update-invoices' process is complete. It will make the billing process appear to take longer but it at least will be honest and hopefully reduce the issues users experience.