### PR TITLE
Fix refresh totals job

### DIFF
--- a/src/modules/billing/jobs/refresh-totals.js
+++ b/src/modules/billing/jobs/refresh-totals.js
@@ -23,7 +23,12 @@ const createMessage = batchId => ([
     batchId
   },
   {
-    jobId: `${JOB_NAME}.${batchId}.${uuid()}`
+    jobId: `${JOB_NAME}.${batchId}.${uuid()}`,
+    attempts: 10,
+    backoff: {
+      type: 'exponential',
+      delay: 5000
+    }
   }
 ])
 

--- a/test/modules/billing/jobs/refresh-totals.test.js
+++ b/test/modules/billing/jobs/refresh-totals.test.js
@@ -74,6 +74,11 @@ experiment('modules/billing/jobs/refresh-totals', () => {
       expect(data).to.equal({ batchId: BATCH_ID })
 
       expect(options.jobId).to.startWith(`billing.refresh-totals.${BATCH_ID}.`)
+      expect(options.attempts).to.equal(10)
+      expect(options.backoff).to.equal({
+        type: 'exponential',
+        delay: 5000
+      })
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4345

In [Fix broken send bill run functionality](https://github.com/DEFRA/water-abstraction-service/pull/2446) we removed some config from the `src/modules/billing/jobs/refresh-totals.js` job that allowed it to be retried within BullMQ.

We figured this exponential retry is why the job gets stuck in the background. But actually, we were just displaying our ignorance. Because it can take a moment for the CHA to complete the 'send' process, it likely won't have a status of `billed` if immediately queried after sending it.

It turns out the previous team used the BullMQ mechanism for retrying to get the CHA bill run summary rather than their own for this job. So, removing the config broke the process. We didn't spot this until put it in one of our AWS environments where the CHA takes a little longer than it does locally.

This change puts the config back.