### PR TITLE
Stop filtering cancel bill runs in results

### DIFF
--- a/src/lib/connectors/repos/billing-batches.js
+++ b/src/lib/connectors/repos/billing-batches.js
@@ -24,7 +24,6 @@ const findOne = async (id) => {
 const findPage = async (page, pageSize) => {
   const result = await BillingBatch
     .forge()
-    .where('status', '<>', 'cancel')
     .orderBy('date_created', 'DESC')
     .fetchPage({
       page,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4387

We need to add this to support our work to make cancelling bill runs visible to users.

Cancelling a bill run, especially a large one, can impact the service and take a considerable amount of time (30 minutes for the largest ones!) We want to let users know when a bill run is being cancelled so that they can make a more informed decision as to when it is best to try creating a new bill run.

When the [water-abstraction-ui](https://github.com/DEFRA/waterr-abstraction-ui) returns the list of bill runs for the bill runs page this service was filtering out any that had a status of 'cancel'. We can't make them visible if they are not returned!

So, this change updates the project to stop the filtering.