### PR TITLE
Fix remove bill licence supplementary flagging

### DIFF
--- a/src/modules/billing/services/invoice-licences-service.js
+++ b/src/modules/billing/services/invoice-licences-service.js
@@ -56,7 +56,7 @@ const deleteByInvoiceLicenceId = async invoiceLicenceId => {
   await validateInvoiceLicenceIsDeletable(billingInvoiceLicence)
 
   // Validation complete
-  const { billingBatchId: batchId } = billingInvoiceLicence.billingInvoice.billingBatch
+  const { billingBatchId: batchId, scheme } = billingInvoiceLicence.billingInvoice.billingBatch
 
   try {
     // Set batch to "processing" status while processing takes place
@@ -67,7 +67,7 @@ const deleteByInvoiceLicenceId = async invoiceLicenceId => {
     await deleteWRLSInvoiceLicence(invoiceLicenceId)
 
     // Flag for supplementary billing
-    await licencesService.flagForSupplementaryBilling(billingInvoiceLicence.licenceId)
+    await licencesService.flagForSupplementaryBilling(billingInvoiceLicence.licenceId, scheme)
 
     // Publish refresh totals job
     return queueManager.getQueueManager().add(refreshTotalsJob.jobName, batchId)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4415

We spotted that our new billing views had dropped the button that allows a user to remove a licence from a bill run (only applies to `READY`` bill runs and bills with more than one licence).

We put the button back in and even gave the confirmation page a refresh. But we're not in a position to migrate the actual work yet. So, our page like the old one pings the same legacy endpoint as [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui).

Our QA team being as conscientious as always double-checked all aspects, following up on the message that both the old and new pages display stating the licence will be flagged for the next supplementary bill run.

They have found it only flags it for the old (PRESROC) charge scheme.

We need to be looking at the scheme of the bill run we are removing the licence from and then set the appropriate supplementary billing flag on the licence.