### PR TITLE
Fix remove bill not flagging licences for supp.

### DIFF
--- a/test/modules/billing/services/batch-service.test.js
+++ b/test/modules/billing/services/batch-service.test.js
@@ -1282,7 +1282,11 @@ experiment('modules/billing/services/batch-service', () => {
       test('throws a NotFoundError if the original invoice is not found', async () => {
         const originalBillingInvoiceId = 'dfedb43e-379a-427e-97b9-41f5185fdbb6'
         const rebillInvoiceId = uuid()
-        newRepos.billingInvoices.findOne.resolves({ billingInvoiceId: uuid(), originalBillingInvoice: null })
+        newRepos.billingInvoices.findOne.resolves({
+          billingInvoiceId: uuid(),
+          originalBillingInvoice: null,
+          billingInvoiceLicences: []
+        })
         const func = () => batchService.deleteBatchInvoice(batch, invoiceId, originalBillingInvoiceId, rebillInvoiceId)
         const err = await expect(func()).to.reject()
         expect(err.message).to.equal('Original Invoice dfedb43e-379a-427e-97b9-41f5185fdbb6 not found')
@@ -1294,7 +1298,8 @@ experiment('modules/billing/services/batch-service', () => {
         const rebillInvoiceId = 'dfedb43e-379a-427e-97b9-41f5185fdec6'
         newRepos.billingInvoices.findOne.onCall(0).resolves({
           billingInvoiceId: uuid(),
-          originalBillingInvoice: { billingInvoiceId: uuid() }
+          originalBillingInvoice: { billingInvoiceId: uuid() },
+          billingInvoiceLicences: []
         })
         const func = () => batchService.deleteBatchInvoice(batch, invoiceId, originalBillingInvoiceId, rebillInvoiceId)
         const err = await expect(func()).to.reject()
@@ -1488,7 +1493,8 @@ experiment('modules/billing/services/batch-service', () => {
             },
             linkedBillingInvoices: [],
             originalBillingInvoiceId: null,
-            rebillingState: null
+            rebillingState: null,
+            billingInvoiceLicences: []
           })
           newRepos.billingTransactions.findByBatchId.resolves([])
           chargeModuleBillRunConnector.deleteInvoiceFromBillRun.rejects(new Error('oh no!'))


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4416

We spotted that our new billing views had dropped the button that allows a user to remove a licence from a bill run (only applies to `READY` bill runs and bills with more than one licence).

We put the button back in and even gave the confirmation page a refresh. But we're not in a position to migrate the actual work yet. So, our page like the old one pings the same legacy endpoint as [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui).

Our QA team being as conscientious as always double-checked all aspects, following up on the message that both the old and new pages display stating the licence will be flagged for the next supplementary bill run. They found it always flags them for PRESROC, when it should have been flagging some for SROC supplementary billing.

Which is where this fix comes in. We display the same message on the confirm remove bill page. Only this time testing found the legacy code doesn't flag anything at all! 😩🤦

This change fixes the endpoint so now when it's pinged it will flag the licences correctly. If the bill run the bill is being removed from is SROC then all licences in the bill need to be flagged for the next SROC supplementary bill run. If the bill run is PRESROC, then they need to be flagged for the next PRESROC supplementary bill run.