### PR TITLE
Fix acceptance test account number clashes

### DIFF
--- a/integration-tests/billing/fixtures/sroc-crm-v2.yaml
+++ b/integration-tests/billing/fixtures/sroc-crm-v2.yaml
@@ -180,7 +180,7 @@
 - ref: $invoiceAccount01
   model: InvoiceAccount
   fields:
-    invoiceAccountNumber: A00000001A
+    invoiceAccountNumber: A99999991A
     startDate: '2022-04-01'
     endDate: null
     companyId: $company01.companyId
@@ -189,7 +189,7 @@
 - ref: $invoiceAccount02
   model: InvoiceAccount
   fields:
-    invoiceAccountNumber: A00000002A
+    invoiceAccountNumber: A99999992A
     startDate: '2019-01-01'
     endDate: null
     companyId: $company02.companyId
@@ -198,7 +198,7 @@
 - ref: $invoiceAccount03
   model: InvoiceAccount
   fields:
-    invoiceAccountNumber: A00000003A
+    invoiceAccountNumber: A99999993A
     startDate: '2015-01-01'
     endDate: null
     companyId: $company03.companyId
@@ -207,7 +207,7 @@
 - ref: $invoiceAccount04
   model: InvoiceAccount
   fields:
-    invoiceAccountNumber: A00000004A
+    invoiceAccountNumber: A99999994A
     startDate: '2022-04-01'
     endDate: null
     companyId: $company04.companyId


### PR DESCRIPTION
When we run our [acceptance-tests](https://github.com/DEFRA/water-abstraction-acceptance-tests) they trigger the legacy test data setup process found in this service. We create records in the DB based on yml files.

So that the tests have consistency a number of the references are hardcoded, for example, billing account numbers. The problem is within the service these are dynamically generated. Some of the team have encountered clashes when trying to run the test data setup processes. Other actions within their environment have created accounts that clash with those the test setup process is trying to create.

We think when the process was set up, the previous team knew that the service was always doing the last account + 1 to determine the next account number. So, they opted for a very low test account number. However, we had to fix an issue where due to 'skips' in the sequence this service had rolled over from `99999999` to `100000000`. The validation that is written into the service doesn't allow this hence new billing accounts were blocked.

We fixed it by having the service start from `00000001` and then increment until it finds the next available account number. That means the dynamic generation is creating new billing accounts in the same range as the test accounts.

The only fix we have at this time is to move the hard-coded test account numbers to the end of the range, where in our non-prod environments the dynamic process shouldn't reach for a good few years!