### PR TITLE
Update SROC test data to always include annual

### DIFF
--- a/integration-tests/billing/fixtures/sets.json
+++ b/integration-tests/billing/fixtures/sets.json
@@ -441,6 +441,7 @@
       }
     }
   ],
+  "sroc-billing-previous": [
     {
       "service": "idm",
       "file": "sroc-users.yaml"
@@ -468,6 +469,14 @@
     {
       "service": "water",
       "file": "sroc-charge-info.yaml"
+    },
+    {
+      "service": "water",
+      "file": "sroc-annual-bill-run.yaml",
+      "config": {
+        "fromFinancialYearEnding": "$previousFromFinancialYearEnding",
+        "toFinancialYearEnding": "$previousToFinancialYearEnding"
+      }
     }
   ]
 }

--- a/integration-tests/billing/fixtures/sets.json
+++ b/integration-tests/billing/fixtures/sets.json
@@ -403,7 +403,44 @@
       }
     }
   ],
-  "sroc-billing-data": [
+  "sroc-billing-current": [
+    {
+      "service": "idm",
+      "file": "sroc-users.yaml"
+    },
+    {
+      "service": "water",
+      "file": "sroc-purposes.yaml"
+    },
+    {
+      "service": "permits",
+      "file": "sroc-permits.yaml"
+    },
+    {
+      "service": "crmV1",
+      "file": "sroc-crm-v1.yaml"
+    },
+    {
+      "service": "crmV2",
+      "file": "sroc-crm-v2.yaml"
+    },
+    {
+      "service": "water",
+      "file": "sroc-licences.yaml"
+    },
+    {
+      "service": "water",
+      "file": "sroc-charge-info.yaml"
+    },
+    {
+      "service": "water",
+      "file": "sroc-annual-bill-run.yaml",
+      "config": {
+        "fromFinancialYearEnding": "$currentFromFinancialYearEnding",
+        "toFinancialYearEnding": "$currentToFinancialYearEnding"
+      }
+    }
+  ],
     {
       "service": "idm",
       "file": "sroc-users.yaml"

--- a/integration-tests/billing/fixtures/sroc-annual-bill-run.yaml
+++ b/integration-tests/billing/fixtures/sroc-annual-bill-run.yaml
@@ -1,0 +1,12 @@
+- ref: $annualBatch
+  model: BillingBatch
+  fields:
+    regionId: $region.regionId
+    batchType: annual
+    fromFinancialYearEnding: '$$[fromFinancialYearEnding]'
+    toFinancialYearEnding: '$$[toFinancialYearEnding]'
+    scheme: 'sroc'
+    status: sent
+    isSummer: false
+    source: wrls
+    metadata: { source: "acceptance-test-setup" }

--- a/integration-tests/billing/services/fixture-loader/FixtureLoader.js
+++ b/integration-tests/billing/services/fixture-loader/FixtureLoader.js
@@ -45,6 +45,11 @@ const calcValue = (value, index = 0, startDate = '01-04-2022') => {
 
   const previousYearsLessIndexFinancialDateRange = getFinancialDateRange(previousYearsDateLessIndex)
 
+  const currentBillingPeriod = getFinancialDateRange(new Date())
+  const previousBillingPeriod = getFinancialDateRange(new Date())
+  previousBillingPeriod.startDate.subtract(1, 'year')
+  previousBillingPeriod.endDate.subtract(1, 'year')
+
   switch (value) {
     case '$previousYearsDateLessIndex': {
       return previousYearsDateLessIndex.format('YYYY-MM-DD')
@@ -57,6 +62,18 @@ const calcValue = (value, index = 0, startDate = '01-04-2022') => {
     }
     case '$previousYearLessIndex': {
       return previousYearsLessIndexFinancialDateRange.endDate.year()
+    }
+    case '$currentFromFinancialYearEnding': {
+      return currentBillingPeriod.startDate.year()
+    }
+    case '$currentToFinancialYearEnding': {
+      return currentBillingPeriod.endDate.year()
+    }
+    case '$previousFromFinancialYearEnding': {
+      return previousBillingPeriod.startDate.year()
+    }
+    case '$previousToFinancialYearEnding': {
+      return previousBillingPeriod.endDate.year()
     }
     case '$annualInvoice': return `TEST00${index}1`
     case '$2PT2Invoice': return `TEST00${index}2`


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4403

In [Bump supplementary end year if no annual bill run](https://github.com/DEFRA/water-abstraction-system/pull/875) we amended our billing engine for supplementary. We made it possible for users to generate supplementary bill runs in years where no annual has yet been created and sent.

Previously, the Billing & Data team would have to put a block on creating bill runs until the annuals were generated. This is because supplementary takes into account previous transactions whereas annual doesn't. Without the change creating a supplementary followed by an annual bill run would result in the customer getting charged twice.

We now determine when the last annual bill run was sent and use its financial end year as the end year for the supplementary bill run. Annual created in this billing period? Then the supplementary will start there and work back 5 years. If the last sent annual was for the previous billing period the supplementary will start _there_ and work back 5 years.

The problem is this means our billing engine is working on the assumption there is _always_ at least one 'sent' annual bill run for a region. This is the case in our live service but not in our test setup.

This updates the `FixtureLoader` to generate the current and previous billing period start and end years. We then update our existing SROC fixtures to include creating a current annual bill run. We also create a copy of the fixture that will include creating an annual bill run for the previous year.

These changes will mean our current supplementary test will start working again plus we have the scope to add a new test of this feature.