### PR TITLE
add abstraction data columns to licence-version-purposes

### DIFF
--- a/migrations/20240423140639-add-quantity-columns-to-licence-version-purposes.js
+++ b/migrations/20240423140639-add-quantity-columns-to-licence-version-purposes.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240423140639-add-quantity-columns-to-licence-version-purposes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240423140639-add-quantity-columns-to-licence-version-purposes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240423140639-add-quantity-columns-to-licence-version-purposes-down.sql
+++ b/migrations/sqls/20240423140639-add-quantity-columns-to-licence-version-purposes-down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE water.licence_version_purposes
+    DROP column instant_quantity;
+    DROP column hourly_quantity;
+    DROP column daily_quantity;

--- a/migrations/sqls/20240423140639-add-quantity-columns-to-licence-version-purposes-up.sql
+++ b/migrations/sqls/20240423140639-add-quantity-columns-to-licence-version-purposes-up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE water.licence_version_purposes
+    ADD column instant_quantity numeric;
+    ADD column hourly_quantity numeric;
+    ADD column daily_quantity numeric;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4442

As part of the work to enable return requirements in the service we want to be able to have the different frequencies of abstraction time frames included with the licence version. This PR adds the instant, hourly and daily columns to store this values. 