### PR TITLE
Add column to `licences` table to flag for 2PT supplementary billing

### DIFF
--- a/migrations/20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag.js
+++ b/migrations/20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag-down.sql
+++ b/migrations/sqls/20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.licences DROP COLUMN include_in_sroc_tpt_supplementary_billing;

--- a/migrations/sqls/20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag-up.sql
+++ b/migrations/sqls/20240429132856-add-include-in-sroc-tpt-supplementary-billing-flag-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.licences ADD include_in_sroc_tpt_supplementary_billing bool NOT NULL DEFAULT false;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4216

Part of the ticket to remove a two-part tariff licence from a bill run is to flag that licence for supplementary billing once removed.

No column exists in the database to flag a licence for two-part tariff supplementary billing. So in this PR a migration will be created to add it to the licence table.

The migrations to update the view and legacy tables will be done in the `system` repo as part of the work to remove the licence from a 2PT bill run in this PR https://github.com/DEFRA/water-abstraction-system/pull/927