### PR TITLE
Add reason column to water.return_versions table

### DIFF
--- a/migrations/20240518095436-water-return-versions-add-reason-column.js
+++ b/migrations/20240518095436-water-return-versions-add-reason-column.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240518095436-water-return-versions-add-reason-column-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240518095436-water-return-versions-add-reason-column-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240518095436-water-return-versions-add-reason-column-down.sql
+++ b/migrations/sqls/20240518095436-water-return-versions-add-reason-column-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.return_versions DROP COLUMN reason;

--- a/migrations/sqls/20240518095436-water-return-versions-add-reason-column-up.sql
+++ b/migrations/sqls/20240518095436-water-return-versions-add-reason-column-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.return_versions ADD column reason text;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4470

The new return requirements setup journey captures a reason for the requirement, and we don't currently have a place to store it. This change adds a column to the `water.return _versions` table to store it. 