### PR TITLE
Add multiple_upload column to return_versions table

### DIFF
--- a/migrations/20240520074017-water-return-versions-add-multiple-upload-column.js
+++ b/migrations/20240520074017-water-return-versions-add-multiple-upload-column.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240520074017-water-return-versions-add-multiple-upload-column-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240520074017-water-return-versions-add-multiple-upload-column-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240520074017-water-return-versions-add-multiple-upload-column-down.sql
+++ b/migrations/sqls/20240520074017-water-return-versions-add-multiple-upload-column-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.return_versions DROP COLUMN multiple_upload;

--- a/migrations/sqls/20240520074017-water-return-versions-add-multiple-upload-column-up.sql
+++ b/migrations/sqls/20240520074017-water-return-versions-add-multiple-upload-column-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.return_versions ADD multiple_upload bool NOT NULL DEFAULT false;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4471

As part of our work in replacing NALD for use for returns we need to identify if a return is part of a multiple upload. This PR adds a boolean column to do just that.