### PR TITLE
Add notes column to return-versions table

### DIFF
--- a/migrations/20240521125247-water-return-versions-add-notes-column.js
+++ b/migrations/20240521125247-water-return-versions-add-notes-column.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240521125247-water-return-versions-add-notes-column-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240521125247-water-return-versions-add-notes-column-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240521125247-water-return-versions-add-notes-column-down.sql
+++ b/migrations/sqls/20240521125247-water-return-versions-add-notes-column-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.return_versions DROP COLUMN notes;

--- a/migrations/sqls/20240521125247-water-return-versions-add-notes-column-up.sql
+++ b/migrations/sqls/20240521125247-water-return-versions-add-notes-column-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.return_versions ADD notes text;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4472

As part of the work to replace NALD we want to be able to store a note against the return version rather than the return requirements. This PR is to create that notes column on the return_versions table. 