### PR TITLE
Add boolean flag columns for agreements and exceptions

### DIFF
--- a/migrations/20240522102308-water-return-requirements-add-new-boolean-flags.js
+++ b/migrations/20240522102308-water-return-requirements-add-new-boolean-flags.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240522102308-water-return-requirements-add-new-boolean-flags-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240522102308-water-return-requirements-add-new-boolean-flags-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240522102308-water-return-requirements-add-new-boolean-flags-down.sql
+++ b/migrations/sqls/20240522102308-water-return-requirements-add-new-boolean-flags-down.sql
@@ -1,0 +1,5 @@
+alter table water.return_requirements
+  drop column gravity_fill,
+  drop column reabstraction,
+  drop column two_part_tariff,
+  drop column fixty_six_exception;

--- a/migrations/sqls/20240522102308-water-return-requirements-add-new-boolean-flags-up.sql
+++ b/migrations/sqls/20240522102308-water-return-requirements-add-new-boolean-flags-up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE water.return_requirements
+  ADD gravity_fill bool NOT NULL DEFAULT false,
+  ADD reabstraction bool NOT NULL DEFAULT false,
+  ADD two_part_tariff bool NOT NULL DEFAULT false,
+  ADD fixty_six_exception bool NOT NULL DEFAULT false;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4474

As part of the work to replace NALD in handling return requirements we need to know if the use has selected any agreements or exceptions for the return. This PR adds boolean flag columns for each of the 4 and defaults it to false.