### PR TITLE
Create return-requirement-points table

### DIFF
--- a/migrations/20240524080831-water-add-return-requirement-points-table.js
+++ b/migrations/20240524080831-water-add-return-requirement-points-table.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240524080831-water-add-return-requirement-points-table-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240524080831-water-add-return-requirement-points-table-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240524080831-water-add-return-requirement-points-table-down.sql
+++ b/migrations/sqls/20240524080831-water-add-return-requirement-points-table-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS water.return_requirement_points;

--- a/migrations/sqls/20240524080831-water-add-return-requirement-points-table-up.sql
+++ b/migrations/sqls/20240524080831-water-add-return-requirement-points-table-up.sql
@@ -1,0 +1,11 @@
+create table water.return_requirement_points (
+    id uuid primary key default public.gen_random_uuid(),
+    return_requirement_id uuid not null,
+    description text,
+    ngr_1 text not null,
+    ngr_2 text,
+    ngr_3 text,
+    ngr_4 text,
+    external_id text not null,
+    unique(external_id)
+);


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4475

As part of our plan to replace NALD we need to be able to store the detail of the points of abstraction. This PR creates the table that will store the data. 