### PR TITLE
Rename misspelt column on return-requirements table

### DIFF
--- a/migrations/20240531093133-return-requirements-alter-column-name.js
+++ b/migrations/20240531093133-return-requirements-alter-column-name.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240531093133-return-requirements-alter-column-name-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240531093133-return-requirements-alter-column-name-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240531093133-return-requirements-alter-column-name-down.sql
+++ b/migrations/sqls/20240531093133-return-requirements-alter-column-name-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE water.return_requirements
+RENAME COLUMN fifty_six_exception TO fixty_six_exception

--- a/migrations/sqls/20240531093133-return-requirements-alter-column-name-up.sql
+++ b/migrations/sqls/20240531093133-return-requirements-alter-column-name-up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE water.return_requirements
+RENAME COLUMN fixty_six_exception TO fifty_six_exception


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4474

As part of the work to replace NALD in handling return requirements we need to know if the use has selected any agreements or exceptions for the return. This PR renames a misspelt column name.