### PR TITLE
Fix up the water schema Return requirement tables

### DIFF
--- a/migrations/20240604163239-alter-return-requirement-tables.js
+++ b/migrations/20240604163239-alter-return-requirement-tables.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240604163239-alter-return-requirement-tables-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240604163239-alter-return-requirement-tables-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240604163239-alter-return-requirement-tables-down.sql
+++ b/migrations/sqls/20240604163239-alter-return-requirement-tables-down.sql
@@ -1,0 +1,19 @@
+/* Revert changes made to make working with the tables easier */
+
+ALTER TABLE IF EXISTS water.return_versions ALTER COLUMN date_created DROP DEFAULT;
+ALTER TABLE IF EXISTS water.return_versions ALTER COLUMN date_updated DROP NOT NULL;
+ALTER TABLE IF EXISTS water.return_versions ALTER COLUMN date_updated DROP DEFAULT;
+
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN is_summer DROP DEFAULT;
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN is_upload DROP DEFAULT;
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN date_created DROP DEFAULT;
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN date_updated DROP NOT NULL;
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN date_updated DROP DEFAULT;
+
+ALTER TABLE IF EXISTS water.return_requirement_points ALTER COLUMN external_id SET NOT NULL;
+ALTER TABLE IF EXISTS water.return_requirement_points DROP COLUMN date_created;
+ALTER TABLE IF EXISTS water.return_requirement_points DROP COLUMN date_updated;
+
+ALTER TABLE IF EXISTS water.return_requirement_purposes ALTER COLUMN date_created DROP DEFAULT;
+ALTER TABLE IF EXISTS water.return_requirement_purposes ALTER COLUMN date_updated DROP NOT NULL;
+ALTER TABLE IF EXISTS water.return_requirement_purposes ALTER COLUMN date_updated DROP DEFAULT;

--- a/migrations/sqls/20240604163239-alter-return-requirement-tables-up.sql
+++ b/migrations/sqls/20240604163239-alter-return-requirement-tables-up.sql
@@ -1,0 +1,19 @@
+/* Add in missing fields or defaults to make working with the tables easier */
+
+ALTER TABLE IF EXISTS water.return_versions ALTER COLUMN date_created SET DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_versions ALTER COLUMN date_updated SET DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_versions ALTER COLUMN date_updated SET NOT NULL;
+
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN is_summer SET DEFAULT false;
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN is_upload SET DEFAULT false;
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN date_created SET DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN date_updated SET DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_requirements ALTER COLUMN date_updated SET NOT NULL;
+
+ALTER TABLE IF EXISTS water.return_requirement_points ALTER COLUMN external_id DROP NOT NULL;
+ALTER TABLE IF EXISTS water.return_requirement_points ADD COLUMN date_created timestamp NOT NULL DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_requirement_points ADD COLUMN date_updated timestamp NOT NULL DEFAULT NOW();
+
+ALTER TABLE IF EXISTS water.return_requirement_purposes ALTER COLUMN date_created SET DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_requirement_purposes ALTER COLUMN date_updated SET DEFAULT NOW();
+ALTER TABLE IF EXISTS water.return_requirement_purposes ALTER COLUMN date_updated SET NOT NULL;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4467

In recent changes, we have either added new fields to the `water.return_requirement[..]` tables or added a whole new one (`return_requirement_points`). But as we have come to use them in [water-abstraction-system] (https://github.com/DEFRA/water-abstraction-system) we have found there are some further corrections and fix-ups we can do to make our lives easier.

This change is those fix-ups.