### PR TITLE
Add NALD point ID to return req points table

### DIFF
--- a/migrations/20240605155346-alter-return-requirement-points.js
+++ b/migrations/20240605155346-alter-return-requirement-points.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240605155346-alter-return-requirement-points-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240605155346-alter-return-requirement-points-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240605155346-alter-return-requirement-points-down.sql
+++ b/migrations/sqls/20240605155346-alter-return-requirement-points-down.sql
@@ -4,6 +4,4 @@ BEGIN;
 
 ALTER TABLE IF EXISTS water.return_requirement_points DROP COLUMN nald_point_id;
 
-ALTER TABLE IF EXISTS water.return_requirements RENAME COLUMN fifty_six_exception TO fixty_six_exception;
-
 COMMIT;

--- a/migrations/sqls/20240605155346-alter-return-requirement-points-down.sql
+++ b/migrations/sqls/20240605155346-alter-return-requirement-points-down.sql
@@ -1,0 +1,9 @@
+/* Revert change made to the tables */
+
+BEGIN;
+
+ALTER TABLE IF EXISTS water.return_requirement_points DROP COLUMN nald_point_id;
+
+ALTER TABLE IF EXISTS water.return_requirements RENAME COLUMN fifty_six_exception TO fixty_six_exception;
+
+COMMIT;

--- a/migrations/sqls/20240605155346-alter-return-requirement-points-up.sql
+++ b/migrations/sqls/20240605155346-alter-return-requirement-points-up.sql
@@ -8,9 +8,6 @@
   The submissions (returns.returns) link to `water.return_requirements` which in turn is linked to
   `water.return_requirement_points`. If that table contains the NALD point ID then they should be able to link
   submissions to specific points.
-
-  We also missed in our tidy up of that return requirement tables that one of the fields we added has a typo. So, we
-  fix that as well.
 */
 
 BEGIN;
@@ -21,8 +18,5 @@ ALTER TABLE IF EXISTS water.return_requirement_points ADD COLUMN nald_point_id I
 UPDATE water.return_requirement_points SET nald_point_id = split_part(external_id, ':', 3)::int;
 -- Now apply the NOT NULL constraint so we can ensure it is always populated in future
 ALTER TABLE IF EXISTS water.return_requirement_points ALTER COLUMN nald_point_id  SET NOT NULL;
-
--- Correct the column name typo
-ALTER TABLE IF EXISTS water.return_requirements RENAME COLUMN fixty_six_exception TO fifty_six_exception;
 
 COMMIT;

--- a/migrations/sqls/20240605155346-alter-return-requirement-points-up.sql
+++ b/migrations/sqls/20240605155346-alter-return-requirement-points-up.sql
@@ -1,0 +1,28 @@
+/*
+  Amend return_requirement_points table
+
+  We add a new column that will allow us to capture the NALD point ID. This is intended to support future reporting
+  requirements where our users need to be able to identify which specific points a return submission (return log)
+  relates to.
+
+  The submissions (returns.returns) link to `water.return_requirements` which in turn is linked to
+  `water.return_requirement_points`. If that table contains the NALD point ID then they should be able to link
+  submissions to specific points.
+
+  We also missed in our tidy up of that return requirement tables that one of the fields we added has a typo. So, we
+  fix that as well.
+*/
+
+BEGIN;
+
+-- Because we are adding the column to an existing table we can't add the NOT NULL constraint yet
+ALTER TABLE IF EXISTS water.return_requirement_points ADD COLUMN nald_point_id INTEGER;
+-- Update all the records with the point ID which we can extract from the external ID we generate
+UPDATE water.return_requirement_points SET nald_point_id = split_part(external_id, ':', 3)::int;
+-- Now apply the NOT NULL constraint so we can ensure it is always populated in future
+ALTER TABLE IF EXISTS water.return_requirement_points ALTER COLUMN nald_point_id  SET NOT NULL;
+
+-- Correct the column name typo
+ALTER TABLE IF EXISTS water.return_requirements RENAME COLUMN fixty_six_exception TO fifty_six_exception;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4493

Returns submitted to the service are sent back to NALD. There are then data reports that link the return submissions to their relevant points. But when we take over the returns functionality from NALD the link between a return submission (form log) and the point will be lost if we don't have some way of capturing the NALD unique point ID.

The submissions (returns.returns) link to `water.return_requirements` which in turn is linked to `water.return_requirement_points`. If that table contains the NALD point ID then they should be able to link submissions to specific points when creating reports.

This change adds a new column to the `water.return_requirement_points` table to hold the NALD point ID.
