### PR TITLE
Fix return req frequency fields being imported

### DIFF
--- a/migrations/20240610104955-alter-return-requirements.js
+++ b/migrations/20240610104955-alter-return-requirements.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240610104955-alter-return-requirements-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240610104955-alter-return-requirements-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240610104955-alter-return-requirements-down.sql
+++ b/migrations/sqls/20240610104955-alter-return-requirements-down.sql
@@ -1,0 +1,7 @@
+/* revert changes made */
+
+BEGIN;
+
+ALTER TABLE water.return_requirements DROP COLUMN reporting_frequency;
+
+COMMIT;

--- a/migrations/sqls/20240610104955-alter-return-requirements-up.sql
+++ b/migrations/sqls/20240610104955-alter-return-requirements-up.sql
@@ -1,0 +1,29 @@
+/*
+  Adds a column to allow us to capture all 3 NALD reporting frequencies
+
+  We recently extended the import of return requirements from NALD to include the frequency with which returns need to
+  be collected. We thought with this and `returns_frequency` we would have the data we need to support the return
+  requirements setup journey.
+
+  However, we now realise we made an incorrect assumption about what `returns_frequency` represents. We thought it was
+  the reporting frequency; however it turns out NALD has 3 frequency levels.
+
+  - Return to agency (`ARTC_RET_FREQ_CODE`)
+  - Recording (`ARTC_REC_FREQ_CODE`)
+  - Collection (`ARTC_CODE`)
+
+  Because we assumed `ARTC_RET_FREQ_CODE` was reporting, we're importing `ARTC_REC_FREQ_CODE` as collection. Now we know
+  it should have been
+
+  - `ARTC_REC_FREQ_CODE` is reporting frequency
+  - `ARTC_CODE` is collection frequency
+
+  We don't want to touch `ARTC_RET_FREQ_CODE` because we're still not 100% sure that nothing in the legacy code is using
+  these tables. So, this adds a new `reporting_frequency` column to `water.return_requirements`.
+*/
+
+BEGIN;
+
+ALTER TABLE water.return_requirements ADD reporting_frequency text NOT NULL DEFAULT 'day';
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4473

We recently extended the import of return requirements from NALD to include the frequency with which returns need to be collected. We thought with this and `returns_frequency` we would have the data we need to support the return requirements setup journey.

However, we now realise we made an incorrect assumption about what `returns_frequency` represents. We thought it was the reporting frequency; however it turns out NALD has 3 frequency levels.

- Return to agency (`ARTC_RET_FREQ_CODE`)
- Recording (`ARTC_REC_FREQ_CODE`)
- Collection (`ARTC_CODE`)

Because we assumed `ARTC_RET_FREQ_CODE` was reporting, we're importing `ARTC_REC_FREQ_CODE` as collection. Now we know it should have been

- `ARTC_REC_FREQ_CODE` is reporting frequency
- `ARTC_CODE` is collection frequency

We don't want to touch `ARTC_RET_FREQ_CODE` because we're still not 100% sure that nothing in the legacy code is using these tables. So, this change adds a migration to add a new `reporting_frequency` field to `water.return_requirements`.