### PR TITLE
Add created_by to return versions table

### DIFF
--- a/migrations/20240619194829-alter-return-versions.js
+++ b/migrations/20240619194829-alter-return-versions.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240619194829-alter-return-versions-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240619194829-alter-return-versions-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240619194829-alter-return-versions-down.sql
+++ b/migrations/sqls/20240619194829-alter-return-versions-down.sql
@@ -1,0 +1,7 @@
+/* revert changes made */
+
+BEGIN;
+
+ALTER TABLE water.return_versions DROP COLUMN created_by;
+
+COMMIT;

--- a/migrations/sqls/20240619194829-alter-return-versions-up.sql
+++ b/migrations/sqls/20240619194829-alter-return-versions-up.sql
@@ -1,0 +1,12 @@
+/*
+  Adds a column to allow us to capture who created the version
+
+  We capture the user_id so we can link to the idm.users record of the use who created the return version and
+  accompanying records
+*/
+
+BEGIN;
+
+ALTER TABLE water.return_versions ADD created_by integer;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4522

> Part of the work to replace NALD for handling return requirements

When we take control of the setup of return requirements, we'll be persisting them in the same tables that they are currently imported into.

One omission though, is that there is no means to identify who created the return version. Admittedly there is nothing in NALD to indicate this hence nothing to import. But we intend to capture this information when we start persisting the records.

This adds a migration to add `created_by` to `water.return_versions`.