### PR TITLE
Add mod_log fields 2 return, licence & charge ver.

### DIFF
--- a/migrations/20240809155344-water-versions-add-mod-log-column.js
+++ b/migrations/20240809155344-water-versions-add-mod-log-column.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240809155344-water-versions-add-mod-log-column-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240809155344-water-versions-add-mod-log-column-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240809155344-water-versions-add-mod-log-column-down.sql
+++ b/migrations/sqls/20240809155344-water-versions-add-mod-log-column-down.sql
@@ -1,0 +1,9 @@
+/* revert changes made */
+
+BEGIN;
+
+ALTER TABLE water.charge_versions DROP COLUMN mod_log;
+ALTER TABLE water.return_versions DROP COLUMN mod_log;
+ALTER TABLE water.licence_versions DROP COLUMN mod_log;
+
+COMMIT;

--- a/migrations/sqls/20240809155344-water-versions-add-mod-log-column-up.sql
+++ b/migrations/sqls/20240809155344-water-versions-add-mod-log-column-up.sql
@@ -1,0 +1,15 @@
+/*
+  Adds a column to allow us to record imported mod log info
+
+  Mod log is the record in NALD why a charge, licence or return version was added. By importing the information for
+  historic charge and return versions, and licences till we switch from NALD, we can build this information into
+  new pages that display the changes made to a licence over time.
+*/
+
+BEGIN;
+
+ALTER TABLE water.charge_versions ADD mod_log JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE water.return_versions ADD mod_log JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE water.licence_versions ADD mod_log JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4563
https://eaflood.atlassian.net/browse/WATER-4564
https://eaflood.atlassian.net/browse/WATER-4565

> Part of the work to display a licence's history to users (mod log)

NALD has a concept called 'mod log'. Essentially, when someone creates a new licence, charge or return version, they are required to provide a reason and can also add a note.

Rather than this being stored against each record, the 'mod log' is stored in a single place. Users can then view a licence's 'mod logs' to get a sense of the history of the licence.

When charging switched from NALD to WRLS, we (the previous team) built the ability to record a reason and note against a new charge version but didn't import any historic data. With return requirements also soon to switch from NALD to WRLS there is a concern that this view of changes made to a licence will be lost.

Having reviewed how the information is held in NALD we've confirmed that we can extract this information and import it as part of the licence import. The first step is ensuring we have somewhere to put it.

This change adds a migration that adds a new `mod_log` field to `charge_versions`, `licence_versions`, and `return_versions`. The intent is to retain the source mod log data so we can extract details from it for historic records (imported from NALD). New charge and return versions created in WRLS already capture this data in other ways.