### PR TITLE
Add System config for Supplementary billing flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ PERMIT_URI=
 CRM_URI=
 RETURNS_URI=
 IDM_URI=
+SYSTEM_URI=
 
 # URL origin for the charging module
 CHARGE_MODULE_ORIGIN=https://charging.defra.com

--- a/config.js
+++ b/config.js
@@ -188,7 +188,8 @@ module.exports = {
     idm: process.env.IDM_URI || 'http://127.0.0.1:8003/idm/1.0',
     permits: process.env.PERMIT_URI || 'http://127.0.0.1:8004/API/1.0/',
     returns: process.env.RETURNS_URI || 'http://127.0.0.1:8006/returns/1.0',
-    import: process.env.IMPORT_URI || 'http://127.0.0.1:8007/import/1.0'
+    import: process.env.IMPORT_URI || 'http://127.0.0.1:8007/import/1.0',
+    system: process.env.SYSTEM_URI || 'http://127.0.0.1:8013'
   },
 
   chargeModule: {

--- a/src/lib/connectors/system/supplementary-billing.js
+++ b/src/lib/connectors/system/supplementary-billing.js
@@ -4,7 +4,7 @@ const config = require('../../../../config')
 const { serviceRequest } = require('@envage/water-abstraction-helpers')
 
 /**
- * Posts to
+ * Posts to system repo to flag new charge versions for SROC supplementary billing
  * @return {Promise}
  */
 const flagSupplementaryBilling = (chargeVersionId) => {

--- a/src/lib/connectors/system/supplementary-billing.js
+++ b/src/lib/connectors/system/supplementary-billing.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const config = require('../../../../config')
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+
+/**
+ * Posts to
+ * @return {Promise}
+ */
+const flagSupplementaryBilling = (chargeVersionId) => {
+  console.log('Charge Version Id :', chargeVersionId)
+  const url = `${config.services.system}/licences/supplementary-flag`
+  const options = {
+    body: {
+      chargeVersionId
+    }
+  }
+
+  return serviceRequest.post(url, options)
+}
+
+exports.flagSupplementaryBilling = flagSupplementaryBilling

--- a/src/lib/connectors/system/supplementary-billing.js
+++ b/src/lib/connectors/system/supplementary-billing.js
@@ -8,7 +8,6 @@ const { serviceRequest } = require('@envage/water-abstraction-helpers')
  * @return {Promise}
  */
 const flagSupplementaryBilling = (chargeVersionId) => {
-  console.log('Charge Version Id :', chargeVersionId)
   const url = `${config.services.system}/licences/supplementary-flag`
   const options = {
     body: {

--- a/src/lib/services/charge-versions.js
+++ b/src/lib/services/charge-versions.js
@@ -5,6 +5,7 @@ const DATE_FORMAT = 'YYYY-MM-DD'
 
 // Repos
 const chargeVersionRepo = require('../connectors/repos/charge-versions')
+const system = require('../connectors/system/supplementary-billing.js')
 const chargeVersionMapper = require('../mappers/charge-version')
 
 const noteRepo = require('../connectors/repos/notes')
@@ -104,6 +105,11 @@ const persist = async chargeVersion => {
   )
   persistedChargeVersion.chargeElements = await Promise.all(tasks)
 
+  console.log('Charge Version', persistedChargeVersion)
+  console.log('AHHHH Im in service!!!!')
+  await system.flagSupplementaryBilling(persistedChargeVersion.id)
+
+  // Here we can add the system endpoint
   return persistedChargeVersion
 }
 

--- a/src/lib/services/charge-versions.js
+++ b/src/lib/services/charge-versions.js
@@ -107,7 +107,6 @@ const persist = async chargeVersion => {
 
   await system.flagSupplementaryBilling(persistedChargeVersion.id)
 
-  // Here we can add the system endpoint
   return persistedChargeVersion
 }
 

--- a/src/lib/services/charge-versions.js
+++ b/src/lib/services/charge-versions.js
@@ -105,8 +105,6 @@ const persist = async chargeVersion => {
   )
   persistedChargeVersion.chargeElements = await Promise.all(tasks)
 
-  console.log('Charge Version', persistedChargeVersion)
-  console.log('AHHHH Im in service!!!!')
   await system.flagSupplementaryBilling(persistedChargeVersion.id)
 
   // Here we can add the system endpoint

--- a/test/lib/services/charge-versions.test.js
+++ b/test/lib/services/charge-versions.test.js
@@ -17,6 +17,7 @@ const licencesService = require('../../../src/lib/services/licences')
 const notesService = require('../../../src/lib/services/notes-service')
 const chargeVersionService = require('../../../src/lib/services/charge-versions')
 const chargeElementService = require('../../../src/lib/services/charge-elements')
+const system = require('../../../src/lib/connectors/system/supplementary-billing.js')
 const invoiceAccountsService = require('../../../src/lib/services/invoice-accounts-service')
 
 // Models
@@ -51,6 +52,7 @@ experiment('lib/services/charge-versions', () => {
     sandbox.stub(notesService, 'decorateWithNote').resolves({ ...data, note })
     sandbox.stub(licencesService, 'flagForSupplementaryBilling')
     sandbox.stub(chargeElementService, 'create')
+    sandbox.stub(system, 'flagSupplementaryBilling')
     sandbox.stub(invoiceAccountsService, 'decorateWithInvoiceAccount').resolves({
       id: 'test-charge-version-id',
       invoiceAccount: { id: 'test-invoice-account-id' }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4622

As part of the work for two-part tariff supplementary billing, we need to add the system config for the service repo to hit a new endpoint we have created. The endpoint is to flag a licence for supplementary billing. As there are 5 different ways a licence can get flagged with 3 of them triggered from the service repo, this PR will allow us to hit the system endpoint and add the flag if necessary.