### PR TITLE
Fix type defaults on the water notes table

### DIFF
--- a/migrations/20240812135353-alter-water-notes.js
+++ b/migrations/20240812135353-alter-water-notes.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240812135353-alter-water-notes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240812135353-alter-water-notes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240812135353-alter-water-notes-down.sql
+++ b/migrations/sqls/20240812135353-alter-water-notes-down.sql
@@ -1,0 +1,7 @@
+/* Revert changes made. */
+BEGIN;
+
+ALTER TABLE IF EXISTS water.notes ALTER COLUMN type_id SET NOT NULL;
+ALTER TABLE IF EXISTS water.notes ALTER COLUMN "type" DROP default;
+
+COMMIT;

--- a/migrations/sqls/20240812135353-alter-water-notes-up.sql
+++ b/migrations/sqls/20240812135353-alter-water-notes-up.sql
@@ -1,0 +1,22 @@
+/*
+During the creation of the licence history page, we noticed we were missing the model and helper for the notes table.
+This is being referenced when extracting charge versions for a licence and any relating notes created.
+This is being worked on in the [Create notes table model, helper, and view]
+(https://github.com/DEFRA/water-abstraction-system/pull/1240) in the water-abstraction-system repo.
+
+While working on the change we realised the notes table has fields that are unused:
+
+- `licence_id` - is never populated
+- `type` - is always set to 'charge-version'
+- `type_id` - is set to the charge version's id and is not needed to link the two together
+
+We do not these fields included in the view for the notes table that we will add to [water-abstraction-system]
+(https://github.com/DEFRA/water-abstraction-system). However, `type` and `type_id` are set as not-nullable.
+This change defaults type to 'charge-version' and`type_id` will remove the constraint.
+*/
+BEGIN;
+
+ALTER TABLE IF EXISTS water.notes ALTER COLUMN type_id DROP NOT NULL;
+ALTER TABLE IF EXISTS water.notes ALTER COLUMN "type" SET DEFAULT 'charge_version';
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4566

During the creation of the licence history page, we noticed we were missing the model and helper for the notes table. This is being referenced when extracting charge versions for a licence and any relating notes created. This is being worked on in the [Create notes table model, helper, and view](https://github.com/DEFRA/water-abstraction-system/pull/1240) in the water-abstraction-system repo.

While working on the change we realised the notes table has fields that are unused:

- `licence_id` - is never populated
- `type` - is always set to 'charge-version'
- `type_id` - is set to the charge version's id and is not needed to link the two together

We do not these fields included in the view for the notes table that we will add to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). However, `type` and `type_id` are set as not-nullable. This change defaults type to 'charge-version' and`type_id` will remove the constraint.