### PR TITLE
Treat supplementary billing as a background job

### DIFF
--- a/src/lib/services/charge-versions.js
+++ b/src/lib/services/charge-versions.js
@@ -105,7 +105,7 @@ const persist = async chargeVersion => {
   )
   persistedChargeVersion.chargeElements = await Promise.all(tasks)
 
-  await system.flagSupplementaryBilling(persistedChargeVersion.id)
+  system.flagSupplementaryBilling(persistedChargeVersion.id)
 
   return persistedChargeVersion
 }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-service/pull/2600
https://eaflood.atlassian.net/browse/WATER-4622
https://eaflood.atlassian.net/browse/WATER-4588

During some feedback on the supplementary billing flag services created, we decided the flagging service should be treated as a background job that gets kicked off but doesn't need to await any results. Hence this PR is to remove the await before the call to the system repo.