### PR TITLE
Add migration for licence versions and licence versions purposes

### DIFF
--- a/migrations/20240814102304-alter-licence-version-created-and-updated-at.js
+++ b/migrations/20240814102304-alter-licence-version-created-and-updated-at.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240814102304-alter-licence-version-created-and-updated-at-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240814102304-alter-licence-version-created-and-updated-at-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20240814102304-alter-licence-version-created-and-updated-at.js
+++ b/migrations/20240814102304-alter-licence-version-created-and-updated-at.js
@@ -1,53 +1,47 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20240814102304-alter-licence-version-created-and-updated-at-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240814102304-alter-licence-version-created-and-updated-at-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20240814102304-alter-licence-version-created-and-updated-at-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240814102304-alter-licence-version-created-and-updated-at-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20240814103242-alter-licence-version-purposes-created-and-updated-at.js
+++ b/migrations/20240814103242-alter-licence-version-purposes-created-and-updated-at.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240814103242-alter-licence-version-purposes-created-and-updated-at-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20240814103242-alter-licence-version-purposes-created-and-updated-at.js
+++ b/migrations/20240814103242-alter-licence-version-purposes-created-and-updated-at.js
@@ -1,53 +1,47 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20240814103242-alter-licence-version-purposes-created-and-updated-at-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240814103242-alter-licence-version-purposes-created-and-updated-at-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/sqls/20240814102304-alter-licence-version-created-and-updated-at-down.sql
+++ b/migrations/sqls/20240814102304-alter-licence-version-created-and-updated-at-down.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_created SET NOT NULL;
-ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_updated SET NOT NULL;
+ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_created DROP DEFAULT;
+ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_updated DROP DEFAULT;
 
 COMMIT;

--- a/migrations/sqls/20240814102304-alter-licence-version-created-and-updated-at-down.sql
+++ b/migrations/sqls/20240814102304-alter-licence-version-created-and-updated-at-down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_created SET NOT NULL;
+ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_updated SET NOT NULL;
+
+COMMIT;

--- a/migrations/sqls/20240814102304-alter-licence-version-created-and-updated-at-up.sql
+++ b/migrations/sqls/20240814102304-alter-licence-version-created-and-updated-at-up.sql
@@ -1,0 +1,10 @@
+/*
+  Alters the licence_versions table to set the default created at and updated at to date now
+*/
+
+BEGIN;
+
+ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_created SET DEFAULT now();
+ALTER TABLE IF EXISTS water.licence_versions ALTER COLUMN date_updated SET DEFAULT now();
+
+COMMIT;

--- a/migrations/sqls/20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql
+++ b/migrations/sqls/20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql
@@ -1,0 +1,7 @@
+/* Replace with your SQL commands */
+BEGIN;
+
+ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_created SET NOT NULL;
+ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_updated SET NOT NULL;
+
+COMMIT;

--- a/migrations/sqls/20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql
+++ b/migrations/sqls/20240814103242-alter-licence-version-purposes-created-and-updated-at-down.sql
@@ -1,7 +1,7 @@
 /* Replace with your SQL commands */
 BEGIN;
 
-ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_created SET NOT NULL;
-ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_updated SET NOT NULL;
+ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_created DROP DEFAULT;
+ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_updated DROP DEFAULT;
 
 COMMIT;

--- a/migrations/sqls/20240814103242-alter-licence-version-purposes-created-and-updated-at-up.sql
+++ b/migrations/sqls/20240814103242-alter-licence-version-purposes-created-and-updated-at-up.sql
@@ -1,0 +1,10 @@
+/*
+  Alters the licence_version_purposes table to set the default created at and updated at to date now
+*/
+
+BEGIN;
+
+ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_created SET DEFAULT now();
+ALTER TABLE IF EXISTS water.licence_version_purposes ALTER COLUMN date_updated SET DEFAULT now();
+
+COMMIT;

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -160,6 +160,7 @@ const getLicenceInvoices = async (licenceId, page = 1, perPage = 10) => {
     temp.invoice = invoiceMapper.dbToModel(row.billingInvoice)
     temp.batch = batchMapper.dbToModel(row.billingInvoice.billingBatch)
 
+    console.log(JSON.stringify(temp.invoice))
     return temp
   })
   return { data: mappedInvoices, pagination: invoices.pagination }

--- a/src/lib/services/licences.js
+++ b/src/lib/services/licences.js
@@ -160,7 +160,6 @@ const getLicenceInvoices = async (licenceId, page = 1, perPage = 10) => {
     temp.invoice = invoiceMapper.dbToModel(row.billingInvoice)
     temp.batch = batchMapper.dbToModel(row.billingInvoice.billingBatch)
 
-    console.log(JSON.stringify(temp.invoice))
     return temp
   })
   return { data: mappedInvoices, pagination: invoices.pagination }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4579

Alters the water.licence_versions and water.licence_version_purposes to set the date_created and date_updated to default now.

This has been done as part migrating the legacy import licence service to the water-abstraction-system. Rather than adding this logic in the system code it makes sense to add the migration and have the database handle this logic for us.