### PR TITLE
Add new `batch_type` for TPT supplementary to DB

### DIFF
--- a/migrations/20240814134405-alter-water-charge-batch-type.js
+++ b/migrations/20240814134405-alter-water-charge-batch-type.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240814134405-alter-water-charge-batch-type-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240814134405-alter-water-charge-batch-type-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240814134405-alter-water-charge-batch-type-down.sql
+++ b/migrations/sqls/20240814134405-alter-water-charge-batch-type-down.sql
@@ -1,0 +1,3 @@
+/*
+  It is not possible to remove the new batch type tpt_supplementary once it has been added
+*/

--- a/migrations/sqls/20240814134405-alter-water-charge-batch-type-up.sql
+++ b/migrations/sqls/20240814134405-alter-water-charge-batch-type-up.sql
@@ -4,6 +4,6 @@
 
 BEGIN;
 
-ALTER TYPE water.charge_batch_type ADD VALUE 'tpt_supplementary';
+ALTER TYPE water.charge_batch_type ADD VALUE IF NOT EXISTS 'tpt_supplementary';
 
 COMMIT;

--- a/migrations/sqls/20240814134405-alter-water-charge-batch-type-up.sql
+++ b/migrations/sqls/20240814134405-alter-water-charge-batch-type-up.sql
@@ -1,0 +1,9 @@
+/*
+  Alters the charge_batch_type data type to add the new batch type tpt_supplementary
+*/
+
+BEGIN;
+
+ALTER TYPE water.charge_batch_type ADD VALUE 'tpt_supplementary';
+
+COMMIT;

--- a/migrations/sqls/20240814134405-alter-water-charge-batch-type-up.sql
+++ b/migrations/sqls/20240814134405-alter-water-charge-batch-type-up.sql
@@ -4,6 +4,6 @@
 
 BEGIN;
 
-ALTER TYPE water.charge_batch_type ADD VALUE IF NOT EXISTS 'tpt_supplementary';
+ALTER TYPE water.charge_batch_type ADD VALUE IF NOT EXISTS 'two_part_supplementary';
 
 COMMIT;

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -44,7 +44,6 @@ const BATCH_ERROR_CODE = {
 const BATCH_TYPE = {
   annual: 'annual',
   supplementary: 'supplementary',
-  tptSupplementary: 'tpt_supplementary',
   twoPartTariff: 'two_part_tariff'
 }
 

--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -44,6 +44,7 @@ const BATCH_ERROR_CODE = {
 const BATCH_TYPE = {
   annual: 'annual',
   supplementary: 'supplementary',
+  tptSupplementary: 'tpt_supplementary',
   twoPartTariff: 'two_part_tariff'
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4200

In order to enable the triggering of a two-part tariff supplementary bill run we first have to create a new data type for it in our DB.

In this PR the data type is going to be updated to add a new batch type of `tpt_supplementary`. Any issues that adding this new data type may cause will also be actioned in this PR.