### PR TITLE
Fix external change user email journey

### DIFF
--- a/src/modules/change-email/controller.js
+++ b/src/modules/change-email/controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const event = require('../../lib/event')
+const Events = require('../../lib/services/events.js')
 const idm = require('../../lib/connectors/idm')
 const crmEntities = require('../../lib/connectors/crm/entities')
 const changeEmailHelpers = require('./lib/helpers')
@@ -90,9 +90,8 @@ const postSecurityCode = async (request, h) => {
     await crmEntities.updateEntityEmail(entityId, newEmail)
 
     const evt = changeEmailHelpers.createEventObject(oldEmail, entityId, newEmail, userId)
-    await event.save(evt)
 
-    // const result = await event.repo.create(evt);
+    await Events.create(evt)
     return { data: evt, error: null }
   } catch (err) {
     return errorHandler(err, h)

--- a/src/modules/change-email/lib/helpers.js
+++ b/src/modules/change-email/lib/helpers.js
@@ -1,22 +1,25 @@
-const { v4: uuid } = require('uuid')
-const event = require('../../../lib/event')
+const Event = require('../../../lib/models/event.js')
 
 /**
  * create event object to be inserted into event log
  */
 const createEventObject = (userName, entityId, newEmail, userId) => {
-  return event.create({
-    eventId: uuid(),
+  const ev = new Event()
+
+  ev.fromHash({
     type: 'user-account',
     subtype: 'email-change',
     issuer: userName,
-    entities: [entityId],
+    entities: [{ entityId }],
     metadata: {
       oldEmail: userName,
       newEmail,
       userId
-    }
+    },
+    status: 'completed'
   })
+
+  return ev
 }
 
 exports.createEventObject = createEventObject

--- a/test/modules/change-email/controller.test.js
+++ b/test/modules/change-email/controller.test.js
@@ -14,7 +14,6 @@ const idm = require('../../../src/lib/connectors/idm')
 const crmEntities = require('../../../src/lib/connectors/crm/entities')
 const notifications = require('../../../src/lib/notifications/emails')
 const { logger } = require('../../../src/logger')
-// const event = require('../../../src/lib/event')
 const Event = require('../../../src/lib/services/events.js')
 
 const userId = 123

--- a/test/modules/change-email/lib/helpers.test.js
+++ b/test/modules/change-email/lib/helpers.test.js
@@ -1,32 +1,26 @@
 const { expect } = require('@hapi/code')
 const {
-  beforeEach,
-  afterEach,
   experiment,
   test
 } = exports.lab = require('@hapi/lab').script()
 
-const sinon = require('sinon')
-const sandbox = sinon.createSandbox()
-
 const helpers = require('../../../../src/modules/change-email/lib/helpers')
-const event = require('../../../../src/lib/event')
-
-const guidRegex = /[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}/
+const Event = require('../../../../src/lib/models/event.js')
 
 experiment('createEventObject', () => {
-  beforeEach(() => {
-    sandbox.stub(event, 'create')
-  })
+  test('it creates a new event model instance', () => {
+    const result = helpers.createEventObject(
+      'old@example.co.uk', '0b082764-39df-41a8-8c61-11ea395da7e2', 'new@domain.com', '1234'
+    )
 
-  afterEach(async () => sandbox.restore())
-
-  test('it calls event.create with the expected arguments', () => {
-    helpers.createEventObject('test-username', 'test-id', 'teset-email@domain.com', '1234')
-    const [args] = event.create.lastCall.args
-    expect(args.eventId).to.match(guidRegex)
-    expect(args.issuer).to.equal('test-username')
-    expect(args.entities).to.equal(['test-id'])
-    expect(args.metadata.oldEmail).to.equal('test-username')
+    expect(result).to.be.an.instanceOf(Event)
+    expect(result.type).to.equal('user-account')
+    expect(result.subtype).to.equal('email-change')
+    expect(result.issuer).to.equal('old@example.co.uk')
+    expect(result.entities).to.equal([{ entityId: '0b082764-39df-41a8-8c61-11ea395da7e2' }])
+    expect(result.metadata).to.equal({
+      oldEmail: 'old@example.co.uk', newEmail: 'new@domain.com', userId: '1234'
+    })
+    expect(result.status).to.equal('completed')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4632

We received a report that the external app's change email journey was broken. We quickly confirmed this.

The [first part of the fix](https://github.com/DEFRA/water-abstraction-tactical-idm/pull/886) was some mis-ordered logic in the **water-abstraction-tactical-idm** project.

After spotting this, we thought we were done. However, the feature was breaking at the point you entered the security code.

We tracked it down to an issue in this project. It seems we create a `water.event` record upon confirmation of the change being verified. Or we would if it didn't blow up.

We first spotted that it was using a deprecated method for creating the event (the method and the deprecation were all created by the previous team!)

It also saved the record using [Bookshelf](https://bookshelfjs.org). By this point, we were a little fed up, so forgive us for not digging into the history.

But we found the problem was the helper was generating an event object with an `event_id`. That event object was then getting passed to [Bookshelf's save() method](https://bookshelfjs.org/api.html#Model-instance-save). In **Bookshelf** `save()` is used for both updates and inserts. It seems **Bookshelf** determines which by checking if the thing it's saving has an ID. If it does, it uses an update. No ID, then it uses insert.

Setting the ID in the object was making **Bookshelf** think it was doing an update. However, when the DB returned 0 for the update count **Bookshelf**, it was blowing up. Much like [the fix](https://github.com/DEFRA/water-abstraction-tactical-idm/pull/886), this appears to have been a broken journey from the start.

In this change, we first switch to the non-deprecated process for creating event records. We then ensure that the helper doesn't generate an ID, which means **Bookshelf** makes an insert call instead.

All seems fine locally, but we're adding a [new external user change email test](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/131) just to be sure.