### PR TITLE
Handle failed request to system supplementary

### DIFF
--- a/src/lib/services/charge-versions.js
+++ b/src/lib/services/charge-versions.js
@@ -22,6 +22,8 @@ const ChargeVersion = require('../models/charge-version')
 
 const validators = require('../models/validators')
 
+const { logger } = require('../../logger.js')
+
 /**
  * Gets charge version by ID
  * @param {String} chargeVersionId
@@ -105,7 +107,13 @@ const persist = async chargeVersion => {
   )
   persistedChargeVersion.chargeElements = await Promise.all(tasks)
 
-  await system.flagSupplementaryBilling(persistedChargeVersion.id)
+  try {
+    // Let the water-abstraction-system know a new charge version has been added. It will then determine if the licence
+    // needs to be flagged for SROC supplementary billing based on the new charge version
+    await system.flagSupplementaryBilling(persistedChargeVersion.id)
+  } catch (error) {
+    logger.error('Flag supplementary request to system failed', error.stack)
+  }
 
   return persistedChargeVersion
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4622

> Part of the work to flag licences for SROC 2PT supplementary billing

We recently added support for sending a request to the [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) to let it know a new charge version had been added. The intent is for **water-abstraction-system** to determine if the licence needs to be flagged for SROC two-part tariff supplementary billing because of this.

The only problem is we ain't built the endpoint yet! 🤦

We've just realised we've broken the create charge version journey because the request is getting a failed response (404). We're not far away from adding the endpoint. But even so, we don't want a failure to flag the licence to cause the charge version record to get messed up.

This change adds a `try/catch` around the request so we can log and swallow any failures and let the legacy code continue doing its job.

![Screenshot 2024-08-16 at 09 18 03](https://github.com/user-attachments/assets/f276c96a-314d-4bdf-ab07-a1dcca2f64d5)
