### PR TITLE
Alter name & default for versions `mod_log` field

### DIFF
--- a/migrations/20240816144249-alter-versions-mod-log-column.js
+++ b/migrations/20240816144249-alter-versions-mod-log-column.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240816144249-alter-versions-mod-log-column-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240816144249-alter-versions-mod-log-column-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240816144249-alter-versions-mod-log-column-down.sql
+++ b/migrations/sqls/20240816144249-alter-versions-mod-log-column-down.sql
@@ -1,0 +1,17 @@
+/* Revert the changes */
+
+BEGIN;
+
+ALTER TABLE water.charge_versions ALTER COLUMN mod_logs SET DEFAULT '{}'::jsonb;
+ALTER TABLE water.charge_versions RENAME COLUMN mod_logs TO mod_log;
+UPDATE water.charge_versions SET mod_log = '{}'::jsonb WHERE mod_log = '[]'::jsonb;
+
+ALTER TABLE water.licence_versions ALTER COLUMN mod_logs SET DEFAULT '{}'::jsonb;
+ALTER TABLE water.licence_versions RENAME COLUMN mod_logs TO mod_log;
+UPDATE water.licence_versions SET mod_log = '{}'::jsonb WHERE mod_log = '[]'::jsonb;
+
+ALTER TABLE water.return_versions ALTER COLUMN mod_logs SET DEFAULT '{}'::jsonb;
+ALTER TABLE water.return_versions RENAME COLUMN mod_logs TO mod_log;
+UPDATE water.return_versions SET mod_log = '{}'::jsonb WHERE mod_log = '[]'::jsonb;
+
+COMMIT;

--- a/migrations/sqls/20240816144249-alter-versions-mod-log-column-up.sql
+++ b/migrations/sqls/20240816144249-alter-versions-mod-log-column-up.sql
@@ -1,0 +1,28 @@
+/*
+  Renames the mod_log column and changes its default in each version table
+
+  In [Add mod_log fields 2 return, licence & charge ver.](https://github.com/DEFRA/water-abstraction-service/pull/2598),
+  we added a data migration to add a new `mod_log` field to the charge, licence, and return version tables in the
+  `water` schema. This field was intended to hold details from the linked NALD mod log record, such as who, when, and
+  why the version was created.
+
+  However, we've since learned that a version in NALD can have multiple mod log records. Therefore, we want to change
+  the name to make that clear. We also change the default to avoid complexity in the code. Now, it will default to an
+  empty JSONB array rather than an empty object.
+*/
+
+BEGIN;
+
+ALTER TABLE water.charge_versions RENAME COLUMN mod_log TO mod_logs;
+ALTER TABLE water.charge_versions ALTER COLUMN mod_logs SET DEFAULT '[]'::jsonb;
+UPDATE water.charge_versions SET mod_logs = '[]'::jsonb WHERE mod_logs = '{}'::jsonb;
+
+ALTER TABLE water.licence_versions RENAME COLUMN mod_log TO mod_logs;
+ALTER TABLE water.licence_versions ALTER COLUMN mod_logs SET DEFAULT '[]'::jsonb;
+UPDATE water.licence_versions SET mod_logs = '[]'::jsonb WHERE mod_logs = '{}'::jsonb;
+
+ALTER TABLE water.return_versions RENAME COLUMN mod_log TO mod_logs;
+ALTER TABLE water.return_versions ALTER COLUMN mod_logs SET DEFAULT '[]'::jsonb;
+UPDATE water.return_versions SET mod_logs = '[]'::jsonb WHERE mod_logs = '{}'::jsonb;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4563
https://eaflood.atlassian.net/browse/WATER-4564
https://eaflood.atlassian.net/browse/WATER-4565

> Part of the work to display a licence's history to users (mod log)

In [Add mod_log fields 2 return, licence & charge ver.](https://github.com/DEFRA/water-abstraction-service/pull/2598), we added a data migration to add a new `mod_log` field to the charge, licence, and return version tables in the `water` schema. This field was intended to hold details from the linked NALD mod log record, such as who, when, and why the version was created.

However, we've since learned that a version in NALD can have multiple mod log records. Therefore, we want to change the name to make that clear. We also change the default to avoid complexity in the code. Now, it will default to an empty JSONB array rather than an empty object.

This change is the data migration for that.