### PR TITLE
Delete errant licence version

### DIFF
--- a/migrations/20240819214901-fix-errant-licence-version.js
+++ b/migrations/20240819214901-fix-errant-licence-version.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240819214901-fix-errant-licence-version-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240819214901-fix-errant-licence-version-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240819214901-fix-errant-licence-version-down.sql
+++ b/migrations/sqls/20240819214901-fix-errant-licence-version-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to correct data being missing */

--- a/migrations/sqls/20240819214901-fix-errant-licence-version-up.sql
+++ b/migrations/sqls/20240819214901-fix-errant-licence-version-up.sql
@@ -1,0 +1,28 @@
+/*
+  Fix errant licence version record
+
+  We had a report that when creating a new charge version for licence **AN/033/0058/018/R01** and selecting use
+  abstraction data, the service used an old abstraction volume.
+
+  We tracked the issue down to the fact that there are 2 'current' licence versions linked to the licence (only one
+  should ever be current). When the user selects the 'use abstraction data' option, the legacy code selects the first
+  'current' licence version connected to the licence. This explains why the value is coming from an older version.
+
+  We think the version got in there from a 'blip', probably caused by the licence in NALD being duplicated and _then_
+  corrected with the updated data. Then we believe the import happened in the middle of this, hence the 'blip'.
+
+  Simply put, the errant licence version belongs to the duplicated licence, but all the licence versions for that are
+  correct. So, to get **AN/033/0058/018/R01** back into shape, we just need to delete the errant licence version.
+*/
+
+BEGIN;
+
+DELETE FROM water.licence_version_purpose_conditions lvpc WHERE lvpc.licence_version_purpose_id IN (
+  SELECT lvp.licence_version_purpose_id FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id = '8dce95fd-3654-48af-8649-69eafcb192bc'
+);
+
+DELETE FROM water.licence_version_purposes lvp WHERE lvp.licence_version_id = '8dce95fd-3654-48af-8649-69eafcb192bc';
+
+DELETE FROM water.licence_versions lv WHERE lv.licence_version_id = '8dce95fd-3654-48af-8649-69eafcb192bc';
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4625

We had a report that when creating a new charge version for licence **AN/033/0058/018/R01** and selecting use abstraction data, the service used an old abstraction volume.

We tracked the issue down to the fact that there are 2 'current' licence versions linked to the licence (only one should ever be current). When the user selects the 'use abstraction data' option, the legacy code selects the first 'current' licence version connected to the licence. This explains why the value is coming from an older version.

We think the version got in there from a 'blip', probably caused by the licence in NALD being duplicated and _then_ corrected with the updated data. Then we believe the import happened in the middle of this, hence the 'blip'.

Simply put, the errant licence version belongs to the duplicated licence, but all the licence versions for that are correct. So, to get **AN/033/0058/018/R01** back into shape, we just need to delete the errant licence version.