### PR TITLE
Tag where permit is used

### DIFF
--- a/src/modules/ar-analysis/lib/update-licence-row.js
+++ b/src/modules/ar-analysis/lib/update-licence-row.js
@@ -88,6 +88,7 @@ const updateLicenceRow = async (licenceRef) => {
  */
 const updateAllLicences = async () => {
   const filter = getLicenceTypeFilter(abstractionReform)
+  // TODO: used here - ar analysis
   const results = await permit.licences.findAll(filter, {}, ['licence_ref'])
   for (const row of results) {
     const { licence_ref: licenceNumber } = row

--- a/src/modules/gauging-stations/jobs/sync-licence-gauging-stations-from-digitise.js
+++ b/src/modules/gauging-stations/jobs/sync-licence-gauging-stations-from-digitise.js
@@ -32,6 +32,7 @@ const handler = async () => {
   // Find out which licences need to be processed
   // Call the permit repo, and fetch any licence refs plus licence_data_value
   // where permit.licence.date_licence_version_purpose_conditions_last_copied is either null or before today
+  // TODO: permit used here
   const licences = await permitConnector.licences.getWaterLicencesThatHaveGaugingStationLinkagesThatNeedToBeCopiedFromDigitise()
 
   logger.info(`Found ${licences.length} candidate licences that have licence gauging station linkages that may be copied from digitise...`)
@@ -42,6 +43,7 @@ const handler = async () => {
     if (edits.status === 'Approved') {
       logger.info(`Processing ${eachLicence.licence_ref}: Status is approved...`)
       // Take the permit data, and put it through the Digitise reducer
+      // TODO: permit used here
       const originalLicence = await permitConnector.licences.getWaterLicence(eachLicence.licence_ref)
       const initialState = originalLicence && digitise.getInitialState(originalLicence)
       const hasData = initialState.licence.data.current_version !== undefined
@@ -128,6 +130,7 @@ const handler = async () => {
               // For the successful records,
               // mark them as processed by updating the datestamp
               // in permit.licence.date_licence_version_purpose_conditions_last_copied
+              // TODO: permit used here
               await permitConnector.licences.updateOne(eachLicence.licence_id, {
                 date_gauging_station_links_last_copied: new Date()
               })

--- a/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
+++ b/src/modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise.js
@@ -33,6 +33,7 @@ const handler = async () => {
   // Find out which licences need to be processed
   // Call the permit repo, and fetch any licence refs plus licence_data_value
   // where permit.licence.date_licence_version_purpose_conditions_last_copied is either null or before today
+  // TODO: permit used here
   const licences = await permitConnector.licences.getWaterLicencesThatHaveConditionsThatNeedToBeCopiedFromDigitise()
 
   logger.info(`Found ${licences.length} candidate licences that have licence version purpose conditions that may be copied from digitise...`)
@@ -44,6 +45,7 @@ const handler = async () => {
     if (edits.status === 'Approved') {
       logger.info(`Processing ${eachLicence.licence_ref}: Status is approved...`)
       // Take the permit data, and put it through the Digitise reducer
+      // TODO: permit used here
       const originalLicence = await permitConnector.licences.getWaterLicence(eachLicence.licence_ref)
       const initialState = originalLicence && digitise.getInitialState(originalLicence)
       const hasData = initialState.licence.data.current_version !== undefined
@@ -71,7 +73,7 @@ const handler = async () => {
             // For the successful records,
             // mark them as processed by updating the datestamp
             // in permit.licence.date_licence_version_purpose_conditions_last_copied
-
+            // TODO: permit used here
             await permitConnector.licences.updateOne(eachLicence.licence_id, {
               date_licence_version_purpose_conditions_last_copied: new Date()
             })

--- a/src/modules/licences/controllers/documents.js
+++ b/src/modules/licences/controllers/documents.js
@@ -66,7 +66,7 @@ const getLicence = async (document, includeExpired, companyId) => {
   }
 
   throwIfUnauthorised(documentHeader, companyId)
-
+  // TODO: permit used here
   const licenceResponse = await permitClient.licences.findMany({
     licence_id: documentHeader.system_internal_id,
     licence_type_id: typeId,

--- a/src/modules/returns-notifications/controller.js
+++ b/src/modules/returns-notifications/controller.js
@@ -21,7 +21,7 @@ const postPreviewReturnNotification = async (request, h) => {
 
   // Create a new set to remove any duplicate values
   const licenceRefs = [...new Set(data.map(item => item.licence_ref))]
-
+  // TODO: permit used here
   const licencesEndDates = await permitConnector.getLicenceEndDates(licenceRefs)
 
   return {

--- a/src/modules/returns/lib/xml-adapter/mapper.js
+++ b/src/modules/returns/lib/xml-adapter/mapper.js
@@ -263,6 +263,7 @@ const mapXml = async (xmlStr, user, today) => {
   // Stage 1 - get licence numbers and region codes
   const permits = getPermitsFromXml(xmlDoc)
   const licenceNumbers = getLicenceNumbersFromPermits(permits)
+  // TODO: permit used here
   const licenceRegionCodes = await permitConnector.getLicenceRegionCodes(licenceNumbers)
 
   // Stage 2 - do basic mapping of XML data to returns

--- a/src/modules/service-status/controller.js
+++ b/src/modules/service-status/controller.js
@@ -131,6 +131,7 @@ const getPermitCount = async () => {
     licence_regime_id: 1,
     licence_type_id: 8
   }
+  // TODO: permit used here
   return getCount(permitConnector.licences, filter)
 }
 
@@ -139,6 +140,7 @@ const getVersions = async () => {
     waterService: pkg.version,
     idm: await idmConnector.getServiceVersion(),
     crm: await crmServiceVersionConnector.getServiceVersion(),
+    // TODO: permit used here
     permit: await permitConnector.getServiceVersion(),
     returns: await returnsConnector.getServiceVersion(),
     import: await importConnector.getServiceVersion()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4626

We want to establish what features in the legacy code depend on the permit.licence table. For example, we know in our own code, we depend on it to identify the ‘points’ for a licence.

The NALD import creates the permit licence table and document header table during the NALD import job. 

The issue is that the permit.licence record is just a massive JSONB dump of all the NALD data related to the licence. It looks like the later licence import in [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) did a much better job of breaking the same data down into constituent tables.

We’re focusing our efforts on recreating a new licence import ready for ReSP. But until we can confirm what legacy features depend on the old permit.licence table, we can’t decide whether to drop creating permit.licence records or recreate the massive JSONB dump.