### PR TITLE
Add a new licence version purpose points table

### DIFF
--- a/migrations/20240827145508-water-add-licence-version-purpose-points-table.js
+++ b/migrations/20240827145508-water-add-licence-version-purpose-points-table.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240827145508-water-add-licence-version-purpose-points-table-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20240827145508-water-add-licence-version-purpose-points-table-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20240827145508-water-add-licence-version-purpose-points-table-down.sql
+++ b/migrations/sqls/20240827145508-water-add-licence-version-purpose-points-table-down.sql
@@ -1,0 +1,3 @@
+/* Revert changes */
+
+DROP TABLE IF EXISTS water.licence_version_purpose_points;

--- a/migrations/sqls/20240827145508-water-add-licence-version-purpose-points-table-up.sql
+++ b/migrations/sqls/20240827145508-water-add-licence-version-purpose-points-table-up.sql
@@ -1,0 +1,16 @@
+/* Replace with your SQL commands */
+
+CREATE TABLE water.licence_version_purpose_points (
+	id uuid PRIMARY KEY DEFAULT public.gen_random_uuid() NOT NULL,
+	licence_version_purpose_id uuid NOT NULL,
+	description text NULL,
+	ngr_1 text NOT NULL,
+	ngr_2 text NULL,
+	ngr_3 text NULL,
+	ngr_4 text NULL,
+	external_id text NULL,
+	date_created timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	date_updated timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	nald_point_id int4 NOT NULL,
+	CONSTRAINT licence_version_purpose_points_external_id_key UNIQUE (external_id)
+);


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

We've been extending and amending the import of return versions from NALD to WRLS as part of our work to switch from NALD to WRLS to manage them. To support this we [Created a return-requirement-points table](https://github.com/DEFRA/water-abstraction-service/pull/2540) and [updated the import](https://github.com/DEFRA/water-abstraction-import/pull/933) to import them.

Users select these points as part of the return requirements setup journey we've built. We extract them from the JSON blob stored in the `permit.licence` table. The problem we've encountered is the import service only populates the points for licences that.

- Have not ended
- Have a current licence version

Otherwise, `permit.licence` is not populated with the points data our journey relies on, causing it to throw an error. Places like the view licence page are also affected by this.

For example, it is perfectly valid that we have an 'ended' licence that we need to correct the historic return versions. And no matter the state, we can see what points the licence was linked to.

We don't know why the previous team never opted to extract licence points to their own table. But this change adds a new migration to create the table.