### PR TITLE
Add abstraction method to lic. purpose points

### DIFF
--- a/migrations/20241002152917-alter-points.js
+++ b/migrations/20241002152917-alter-points.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241002152917-alter-points-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241002152917-alter-points-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20241002152917-alter-points-down.sql
+++ b/migrations/sqls/20241002152917-alter-points-down.sql
@@ -1,3 +1,3 @@
 /* Revert change made to the schema */
 
-ALTER TABLE IF EXISTS water.points DROP COLUMN abstraction_method;
+ALTER TABLE IF EXISTS water.licence_version_purpose_points DROP COLUMN abstraction_method;

--- a/migrations/sqls/20241002152917-alter-points-down.sql
+++ b/migrations/sqls/20241002152917-alter-points-down.sql
@@ -1,0 +1,3 @@
+/* Revert change made to the schema */
+
+ALTER TABLE IF EXISTS water.points DROP COLUMN abstraction_method;

--- a/migrations/sqls/20241002152917-alter-points-up.sql
+++ b/migrations/sqls/20241002152917-alter-points-up.sql
@@ -1,0 +1,16 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-4645
+
+  > Part of the work to migrate return versions from NALD to WRLS
+
+  We recently added new points and sources tables to the service. This not only supports our work on return versions, it
+  means we can move away from abstracting point information from the licence JSON blob in `permit.licence`.
+
+  We thought we'd captured everything 'point' related in the change but have since spotted 'Means of abstraction'.
+
+  This is linked to a point in NALD and gives how water will be abstracted there, for example, "Surface Mounted Pump
+  (Fixed)". We must capture this information as we import the point information from NALD. So, adds a column to the
+  `water.points` table to store this information.
+ */
+
+ALTER TABLE IF EXISTS water.points ADD COLUMN abstraction_method text;

--- a/migrations/sqls/20241002152917-alter-points-up.sql
+++ b/migrations/sqls/20241002152917-alter-points-up.sql
@@ -8,9 +8,9 @@
 
   We thought we'd captured everything 'point' related in the change but have since spotted 'Means of abstraction'.
 
-  This is linked to a point in NALD and gives how water will be abstracted there, for example, "Surface Mounted Pump
-  (Fixed)". We must capture this information as we import the point information from NALD. So, adds a column to the
-  `water.points` table to store this information.
+  This is linked to an abstraction purpose in NALD and gives how water will be abstracted there, for example, "Surface
+  Mounted Pump (Fixed)". We must capture this information as we import the point information from NALD. So, this adds a
+  column to the `water.licence_version_purpose_points` table to store this information.
  */
 
-ALTER TABLE IF EXISTS water.points ADD COLUMN abstraction_method text;
+ALTER TABLE IF EXISTS water.licence_version_purpose_points ADD COLUMN abstraction_method text;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

We recently [Added new points and sources tables & amend existing](https://github.com/DEFRA/water-abstraction-service/pull/2638) to the service. This not only supports our work on return versions, it means we can move away from abstracting point information from the licence JSON blob in `permit.licence`.

We're also looking to migrate the pages linked to from the view licence summary, which are currently in the legacy [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui). One of them is information on points. We thought we'd captured everything 'point' related in the change but have since spotted 'Means of abstraction'.

This is linked to an abstraction purpose point in NALD and gives how water will be abstracted there, for example, "Surface Mounted Pump (Fixed)". We must capture this information as we import a licence's point information from NALD. So, the first step is to update the `water.licence_version_purpose_points` table to add a new `method` field that will allow us to store this information.
