### PR TITLE
Alter fix script for miss-tagged credited trans.

### DIFF
--- a/migrations/20241012131720-fix-is-credited-back-flags-pt2.js
+++ b/migrations/20241012131720-fix-is-credited-back-flags-pt2.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241012131720-fix-is-credited-back-flags-pt2-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20241012131720-fix-is-credited-back-flags-pt2-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20241012131720-fix-is-credited-back-flags-pt2-down.sql
+++ b/migrations/sqls/20241012131720-fix-is-credited-back-flags-pt2-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+/* No down script due to migration being used to correct invalid data */

--- a/migrations/sqls/20241012131720-fix-is-credited-back-flags-pt2-up.sql
+++ b/migrations/sqls/20241012131720-fix-is-credited-back-flags-pt2-up.sql
@@ -1,0 +1,40 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-4710
+
+  See previous fix migration migrations/sqls/20241009153943-fix-is-credited-back-flags-up.sql for background on why this
+  fix is needed.
+
+  Specifically, this migration runs a query to fix transactions with a populated `source_transaction_id`, but the source
+  transaction does not have its `is_credited_back` flag set to true.
+ */
+
+-- Set true any transactions not flagged as `is_credited_back` but do appear in `source_transaction_id`. This normally
+-- is applied when a bill run is 'sent'. So, we limit the fix only to those transactions linked to 'sent' bill runs.
+UPDATE water.billing_transactions SET is_credited_back = TRUE
+WHERE
+  billing_transaction_id IN (
+    SELECT
+      bt.billing_transaction_id
+    FROM
+      water.billing_transactions bt
+    INNER JOIN
+      water.billing_invoice_licences bil
+      ON bil.billing_invoice_licence_id  = bt.billing_invoice_licence_id
+    INNER JOIN
+      water.billing_invoices bi
+      ON bi.billing_invoice_id = bil.billing_invoice_id
+    INNER JOIN
+      water.billing_batches bb
+      ON bb.billing_batch_id = bi.billing_batch_id
+    WHERE
+      bb.status = 'sent'
+      AND bt.is_credited_back = FALSE
+      AND EXISTS (
+        SELECT 1
+        FROM
+          water.billing_transactions bt2
+        WHERE
+          bt2.source_transaction_id = bt.billing_transaction_id
+          AND bt2.source_transaction_id IS NOT NULL
+      )
+  );


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4710

In the last change, we added a [Data fix migration for miss-flagged transactions](https://github.com/DEFRA/water-abstraction-service/pull/2644). In the legacy PRESROC supplementary billing engine, a flag is added to the debit: `is_credited_back` when a debit is reversed and used as a credit. It also sets `source_transaction_id` on the new transaction so it is possible to see the link between the two.

We found that the PRESROC supplementary can mess up these flags when it fails. We found

- transactions with `is_credited_back` set to true, even though their IDs do not appear in any `source_transaction_id`
- transactions with a populated `source_transaction_id`, but the source transaction does not have its `is_credited_back` flag set to true

The script we added was supposed to fix the state of the `is_credited_back` flag on these transactions, and then the correct bills would be generated for the licences reported to us by Billing & Data.

However, this was not the case. One licence for which we were not expecting a bill was still generating one. After working through all the transactions and matching up historic to new transactions, we found our fix for the second issue had been based on an invalid assumption.

We assumed it was always a historic debit reversed as a credit. In this case, however, it was a credit reversed as a debit.

In this change, we're going to alter the original migration and move the second part to a new migration. This avoids manually correcting any environment where the migration has already been run.

In the new migration, we'll remove our where clause `AND bt2.is_credit = TRUE` from the update query. This means _all_ transactions with a populated `source_transaction_id` but the source transaction does not have its `is_credited_back` flag set to true will be corrected. We've also confirmed in testing that this resolves the issue for the licence (no bill is raised when the supplementary is run).