### PR TITLE
Spike fix pdf generation issue

### DIFF
--- a/src/lib/services/pdf-generation/pdf.js
+++ b/src/lib/services/pdf-generation/pdf.js
@@ -13,7 +13,11 @@ const {
  */
 const createPdf = async html => {
   const browser = await puppeteer.launch({
-    args: ['--no-proxy-server']
+    executablePath: '/usr/bin/chromium',
+    args: [
+        '--no-proxy-server'
+      , '--no-sandbox'
+    ]
   })
   const page = await browser.newPage()
 


### PR DESCRIPTION
The pdf generator uses puppeteer to create a pdf.

We have an issue in our local environments where the pdf generations is failing. The issue can be found here - https://github.com/DEFRA/water-abstraction-team/issues/102.

This change proves the fix works. But does not account for our deployments and so should not be merged.

We can look for a solution to support local and a deployed state,