### PR TITLE
Make bulk upload work for quarterly

### DIFF
--- a/src/lib/connectors/returns.js
+++ b/src/lib/connectors/returns.js
@@ -66,6 +66,9 @@ const getActiveReturns = async returnIds => {
  * @return {Promise<Array>}        - all returns matching criteria
  */
 const getCurrentDueReturns = async (excludeLicences, returnCycle) => {
+
+  console.log("return cycle = " + returnCycle)
+
   const { startDate, endDate, isSummer, dueDate } = returnCycle
 
   const filter = {

--- a/src/modules/companies/controller.js
+++ b/src/modules/companies/controller.js
@@ -21,6 +21,7 @@ const rowMapper = ret => {
     returnId: ret.return_id,
     startDate: ret.start_date,
     endDate: ret.end_date,
+    dueDate: ret.due_date,
     frequency: ret.returns_frequency,
     returnRequirement: ret.return_requirement,
     status: ret.status,
@@ -44,12 +45,12 @@ const getReturns = async (request, h) => {
   // Get returns matching the documents and other filter params supplied
   // in request GET params
   const returnsFilter = returnsHelper.createReturnsFilter(request, documents)
-  const columms = [
-    'return_id', 'licence_ref', 'start_date', 'end_date',
+  const columns = [
+    'return_id', 'licence_ref', 'start_date', 'end_date', 'due_date',
     'returns_frequency', 'return_requirement', 'status', 'metadata'
   ]
-  const returns = await returnsConnector.returns.findAll(returnsFilter, null, columms)
-
+  const returns = await returnsConnector.returns.findAll(returnsFilter, null, columns)
+//console.log("get returns " + JSON.stringify(returns))
   // Map returns
   return returns.map(rowMapper)
 }

--- a/src/modules/companies/routes.js
+++ b/src/modules/companies/routes.js
@@ -19,6 +19,7 @@ module.exports = {
         query: Joi.object().keys({
           startDate: Joi.string().isoDate(),
           endDate: Joi.string().isoDate(),
+          dueDate: Joi.string().isoDate(),
           isSummer: Joi.boolean(),
           status: Joi.string().valid(...statuses),
           excludeNaldReturns: Joi.boolean().default(true)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4704

This was some exploratory work by @chris-barrett-ddts to understand how the bulk upload could work for quarterly returns.

It also encompasses some improvements that allow _all_ due returns to be provided in the CSV download, not just the current ones.

> These and the changes in [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui/pull/2645) are needed for this to work.