### PR TITLE
Add new licence changes table

### DIFF
--- a/migrations/20250105142302-create-licence-end-date-changes.js
+++ b/migrations/20250105142302-create-licence-end-date-changes.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250105142302-create-licence-end-date-changes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250105142302-create-licence-end-date-changes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250105142302-create-licence-end-date-changes-down.sql
+++ b/migrations/sqls/20250105142302-create-licence-end-date-changes-down.sql
@@ -1,0 +1,7 @@
+/* Revert previous change */
+
+BEGIN;
+
+DROP TABLE IF EXISTS water.licence_end_date_changes;
+
+COMMIT;

--- a/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
+++ b/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
@@ -29,8 +29,8 @@ CREATE TABLE water.licence_end_date_changes (
   id uuid PRIMARY KEY DEFAULT public.gen_random_uuid(),
   licence_id uuid NOT NULL,
   date_type text NOT NULL,
-  nald_date date NOT NULL,
-  wrls_date date NOT NULL,
+  nald_date date NULL,
+  wrls_date date NULL,
   created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
   updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL
 );

--- a/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
+++ b/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
@@ -1,0 +1,36 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-4546
+
+  > Part of the work to migrate management of return versions to WRLS from NALD
+
+  During the import from NALD, if a licence end date is changed, for example, it has been revoked in NALD our return
+  versions functionality needs to know about it. This is so we can reissue the return logs for the licence in order to
+  match the changed end date.
+
+  We are actively trying to move away from the legacy code base, so this work was always going to be done in
+  [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).
+
+  When the [NALD import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#nald-import) has
+  completed downloading and extracting the NALD data, it will trigger an endpoint in
+  [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) that will compare the NALD licence end
+  dates to the WRLS licence end dates.
+
+  Where these differ, the results will be captured in this table.
+
+  Then when the [Licence import
+  job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#licence-import) runs it will trigger
+  another endpoint in water-abstraction-system that will using this information to
+
+  - set supplementary billing flags
+  - reissue return logs
+
+*/
+CREATE TABLE water.licence_end_date_changes (
+  id uuid PRIMARY KEY DEFAULT public.gen_random_uuid(),
+  licence_id uuid NOT NULL,
+  date_type text NOT NULL,
+  nald_date date NOT NULL,
+  wrls_date date NOT NULL,
+  created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL
+);

--- a/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
+++ b/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
@@ -32,5 +32,6 @@ CREATE TABLE water.licence_end_date_changes (
   nald_date date NULL,
   wrls_date date NULL,
   created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL
+  updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT licence_end_date_changes_unique UNIQUE (licence_id, date_type)
 );

--- a/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
+++ b/migrations/sqls/20250105142302-create-licence-end-date-changes-up.sql
@@ -29,6 +29,7 @@ CREATE TABLE water.licence_end_date_changes (
   id uuid PRIMARY KEY DEFAULT public.gen_random_uuid(),
   licence_id uuid NOT NULL,
   date_type text NOT NULL,
+  change_date date NOT NULL,
   nald_date date NULL,
   wrls_date date NULL,
   created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4546

> Part of the work to migrate management of return versions to WRLS from NALD

During the import from NALD, if a licence end date is changed, for example, if it has been revoked in NALD, our return version functionality needs to know about it. This is so we can reissue the return logs for the licence to match the changed end date.

We are actively trying to move away from the legacy code base, so this work was always going to be done in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). Initially, it would be triggered by our [own import process due to replace the legacy one](https://eaflood.atlassian.net/browse/WATER-4535). But that was when we thought ReSP would be taking over from NALD.

Now, the plan is for WRLS to encompass the final abstraction leg and take over from NALD. There is little point in replacing a complex import we intend to switch off in the next year.

But, knowing we'd need something in the interim, we created the [/jobs/licence-changes job](https://github.com/DEFRA/water-abstraction-system/pull/1593). The intent was to schedule this after the first [NALD import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#nald-import) had completed (the one that downloads and extracts the NALD data) but before the main [licence import
  job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#licence-import). That way, our job could compare the NALD and WRLS licence records to determine if an end date has changed.

But then we had our 'doh!' moment.

Our reissue return logs engine expects to be given a licence ID and the date the change applies. However, the WRLS licence record needs to have been updated for it to determine the start and end dates of the new return logs.

If we schedule `/jobs/licence-changes` before the licence import job, it will see the change but won't reissue anything because the WRLS record won't have been updated. If we schedule it after, it won't see any difference and won't trigger the reissue.

Doh!

So, we've needed to change tact on this completely. Now, we intend to

- _trigger_ `/jobs/licence-changes` (though we'll move it to a different endpoint as it will no longer be a job) from the [NALD import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#nald-import) rather than schedule it
- update `/jobs/licence-changes` to store the details of changed licences in a new table
- add a new endpoint that processes these 'licence change' records, and which can be triggered from the [licence import job](https://github.com/DEFRA/water-abstraction-team/blob/main/jobs/import.md#licence-import)

This change is needed to create the new table in the `water` schema.