### PR TITLE
Add new TPT supplementary batch type

### DIFF
--- a/src/lib/models/batch.js
+++ b/src/lib/models/batch.js
@@ -44,7 +44,8 @@ const BATCH_ERROR_CODE = {
 const BATCH_TYPE = {
   annual: 'annual',
   supplementary: 'supplementary',
-  twoPartTariff: 'two_part_tariff'
+  twoPartTariff: 'two_part_tariff',
+  tptSupplementary: 'two_part_supplementary'
 }
 
 const BATCH_SOURCE = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff bill runs

We are working on adding support for two-part tariff supplementary bill runs to the service. We've [spiked the logic](https://github.com/DEFRA/water-abstraction-system/pull/1412) to understand how we can do this, but when doing it was being flagged as an error.

No errors were thrown within [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), so we looked at this project. That's when we spotted, after triggering `src/modules/billing/jobs/refresh-totals.js`, an error was being thrown. This was because of the previous team's decision to validate all data both to and from the DB, and it not knowing about the new `two_part_supplementary` batch type.