### PR TITLE
Fix charge versions 2pt flagging mechanism

### DIFF
--- a/src/lib/connectors/system/charge-version-supplementary-billing.js
+++ b/src/lib/connectors/system/charge-version-supplementary-billing.js
@@ -7,11 +7,13 @@ const { serviceRequest } = require('@envage/water-abstraction-helpers')
  * Posts to system repo to flag new charge versions for SROC supplementary billing
  * @return {Promise}
  */
-const chargeVersionFlagSupplementaryBilling = (chargeVersionId) => {
+const chargeVersionFlagSupplementaryBilling = (chargeVersionId, licenceId, startDate) => {
   const url = `${config.services.system}/licences/supplementary`
   const options = {
     body: {
-      chargeVersionId
+      chargeVersionId,
+      licenceId,
+      startDate
     }
   }
 

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -235,8 +235,11 @@ const approve = async (chargeVersionWorkflow, approvedBy) => {
     // Let the water-abstraction-system know a new charge version has been added. It will then determine if the licence
     // needs to be flagged for supplementary billing based on the new charge version and how long the licence was in
     // workflow
-    const { id, licence, dateRange } = persistedChargeVersion
-    await systemChargeVersionConnector.chargeVersionFlagSupplementaryBilling(id, licence.id, dateRange.startDate)
+    await systemChargeVersionConnector.chargeVersionFlagSupplementaryBilling(
+      persistedChargeVersion.id,
+      licence.id,
+      persistedChargeVersion.dateRange.startDate
+    )
     await systemWorkflowConnector.workflowFlagSupplementaryBilling(chargeVersionWorkflow.id)
   } catch (error) {
     logger.error('Flag supplementary request to system failed', error.stack)

--- a/src/modules/charge-versions/services/charge-version-workflows.js
+++ b/src/modules/charge-versions/services/charge-version-workflows.js
@@ -235,7 +235,8 @@ const approve = async (chargeVersionWorkflow, approvedBy) => {
     // Let the water-abstraction-system know a new charge version has been added. It will then determine if the licence
     // needs to be flagged for supplementary billing based on the new charge version and how long the licence was in
     // workflow
-    await systemChargeVersionConnector.chargeVersionFlagSupplementaryBilling(persistedChargeVersion.id)
+    const { id, licence, dateRange } = persistedChargeVersion
+    await systemChargeVersionConnector.chargeVersionFlagSupplementaryBilling(id, licence.id, dateRange.startDate)
     await systemWorkflowConnector.workflowFlagSupplementaryBilling(chargeVersionWorkflow.id)
   } catch (error) {
     logger.error('Flag supplementary request to system failed', error.stack)

--- a/test/modules/charge-versions/services/charge-version-workflows.test.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.test.js
@@ -38,6 +38,7 @@ const LicenceVersion = require('../../../../src/lib/models/licence-version')
 
 // Mappers
 const chargeVersionWorkflowMapper = require('../../../../src/lib/mappers/charge-version-workflow')
+const { date } = require('joi')
 
 const roleId = uuid()
 
@@ -398,6 +399,7 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
       chargeVersionWorkflow.createdBy = new User(456, 'someone-else@example.com')
       chargeVersionWorkflow.licence = new Licence(uuid())
       chargeVersionWorkflow.chargeVersion = new ChargeVersion(uuid())
+      chargeVersionWorkflow.chargeVersion.dateRange = new DateRange('2019-01-01', null)
 
       chargeVersionService.create.resolves(chargeVersionWorkflow.chargeVersion)
     })
@@ -414,7 +416,9 @@ experiment('modules/charge-versions/services/charge-version-workflows', () => {
       await chargeVersionWorkflowService.approve(chargeVersionWorkflow, approvingUser)
 
       expect(systemChargeVersionConnector.chargeVersionFlagSupplementaryBilling.calledWith(
-        chargeVersionWorkflow.chargeVersion.id
+        chargeVersionWorkflow.chargeVersion.id,
+        chargeVersionWorkflow.licence.id,
+        chargeVersionWorkflow.chargeVersion.dateRange.startDate
       )).to.be.true()
 
       expect(systemWorkflowConnector.workflowFlagSupplementaryBilling.calledWith(

--- a/test/modules/charge-versions/services/charge-version-workflows.test.js
+++ b/test/modules/charge-versions/services/charge-version-workflows.test.js
@@ -38,7 +38,6 @@ const LicenceVersion = require('../../../../src/lib/models/licence-version')
 
 // Mappers
 const chargeVersionWorkflowMapper = require('../../../../src/lib/mappers/charge-version-workflow')
-const { date } = require('joi')
 
 const roleId = uuid()
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4951

Recent work has been completed to consolidate code where licences should be flagged for pre-sroc, sroc and two-part tariff supplementary billing. In the new flagging process a bug has been raised. The bug deals explicitly with changes on a charge version. If a charge version was 2pt and is being changed to be a non-2pt charge version then the flagging logic is incorrect and the licence isn't being flagged when it should be. Equally, the flagging logic doesn't consider non-chargeable charge versions as well. A PR in the system fixes the incorrect flagging issue whilst this PR accommodates new parameters being passed to the flagging service.