### PR TITLE
Add enable batch notification job feature toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,8 @@ WATER_SERVICE_MAILBOX=
 NALD_SERVICE_MAILBOX=
 
 ENABLE_DELETE_ALL_BILLING_DATA_FEATURE=
+# Set to false to turn off the old batch notifications job
+ENABLE_BATCH_NOTIFICATIONS_JOB=
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/config.js
+++ b/config.js
@@ -15,7 +15,6 @@ const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 const isRedisLazy = !!process.env.LAZY_REDIS
 
 module.exports = {
-
   frontEnds: {
     viewMyLicence: {
       baseUrl: process.env.BASE_URL || 'http://localhost:8000'
@@ -60,7 +59,7 @@ module.exports = {
   log: {
     // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
     // converting the env var to a boolean
-    logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false,
+    logInTest: String(process.env.LOG_IN_TEST) === 'true' || false,
     level: process.env.WRLS_LOG_LEVEL || 'warn'
   },
 
@@ -214,7 +213,7 @@ module.exports = {
       host: process.env.REDIS_HOST || '127.0.0.1',
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD || '',
-      ...(isTlsConnection) && { tls: {} },
+      ...(isTlsConnection && { tls: {} }),
       db: process.env.NODE_ENV === 'test' ? 4 : 2,
       lazyConnect: isRedisLazy,
       maxRetriesPerRequest: null,
@@ -223,7 +222,8 @@ module.exports = {
   },
 
   featureToggles: {
-    deleteAllBillingData: process.env.ENABLE_DELETE_ALL_BILLING_DATA_FEATURE === 'true' && !isProduction
+    deleteAllBillingData: process.env.ENABLE_DELETE_ALL_BILLING_DATA_FEATURE === 'true' && !isProduction,
+    batchNotificationsJob: process.env.ENABLE_BATCH_NOTIFICATIONS_JOB === 'true'
   },
 
   slackHook: process.env.SLACK_HOOK

--- a/src/lib/queue-manager/start-up-jobs-service.js
+++ b/src/lib/queue-manager/start-up-jobs-service.js
@@ -1,7 +1,6 @@
 'use strict'
 
 // Config
-
 const config = require('../../../config.js')
 
 // Batch Notifications

--- a/src/lib/queue-manager/start-up-jobs-service.js
+++ b/src/lib/queue-manager/start-up-jobs-service.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// Config
+
+const config = require('../../../config.js')
+
 // Batch Notifications
 const checkStatus = require('../../modules/batch-notifications/lib/jobs/check-status')
 const refreshEvent = require('../../modules/batch-notifications/lib/jobs/refresh-event')
@@ -16,7 +20,10 @@ const syncLicenceVersionPurposeConditionsFromDigitise = require('../../modules/g
 
 class StartUpJobsService {
   static go (queueManager) {
-    this._batchNotificationsJobs(queueManager)
+    if (config.featureToggles.batchNotificationsJob) {
+      this._batchNotificationsJobs(queueManager)
+    }
+
     this._billingJobs(queueManager)
     this._gaugingStationJobs(queueManager)
   }

--- a/test/lib/queue-manager/start-up-jobs-service.test.js
+++ b/test/lib/queue-manager/start-up-jobs-service.test.js
@@ -1,9 +1,13 @@
 'use strict'
 
 // Test framework dependencies
-const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { experiment, test, beforeEach, afterEach } = (exports.lab = require('@hapi/lab').script())
 const { expect } = require('@hapi/code')
 const sandbox = require('sinon').createSandbox()
+const Sinon = require('sinon')
+
+// Things to stub
+const config = require('../../../config')
 
 // Thing under test
 const { StartUpJobsService } = require('../../../src/lib/queue-manager/start-up-jobs-service')
@@ -15,6 +19,10 @@ experiment('lib/queue-manager/start-up-jobs-service', () => {
     queueManager = {
       add: sandbox.spy()
     }
+
+    Sinon.stub(config, 'featureToggles').value({
+      batchNotificationsJob: true
+    })
   })
 
   afterEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

We are moving the notification logic in the service repo. As part of this code migration we need to disable the old batch notification job.

This change adds a feature toggle 'ENABLE_BATCH_NOTIFICATIONS_JOB'. This will default to true and be on by default.