### PR TITLE
Update notification messageStatuses to include pending

### DIFF
--- a/src/lib/models/scheduled-notification.js
+++ b/src/lib/models/scheduled-notification.js
@@ -161,7 +161,7 @@ class ScheduledNotification extends Model {
    * Convert model to JSON
    * @return {Object}
    */
-  toJSON() {
+  toJSON () {
     return {
       ...super.toJSON(),
       displayStatus: this.displayStatus,

--- a/src/lib/models/scheduled-notification.js
+++ b/src/lib/models/scheduled-notification.js
@@ -7,6 +7,7 @@ const validators = require('./validators')
 
 const messageStatuses = {
   draft: 'draft',
+  pending: 'pending',
   sending: 'sending',
   sent: 'sent',
   error: 'error'
@@ -39,6 +40,7 @@ const displayStatuses = {
 const statusMap = new Map()
   .set(messageStatuses.draft, displayStatuses.pending)
   .set(messageStatuses.sending, displayStatuses.pending)
+  .set(messageStatuses.pending, displayStatuses.pending)
   .set(messageStatuses.sent, displayStatuses.sent)
   .set(messageStatuses.error, displayStatuses.error)
 
@@ -159,7 +161,7 @@ class ScheduledNotification extends Model {
    * Convert model to JSON
    * @return {Object}
    */
-  toJSON () {
+  toJSON() {
     return {
       ...super.toJSON(),
       displayStatus: this.displayStatus,

--- a/src/lib/queue-manager/start-up-jobs-service.js
+++ b/src/lib/queue-manager/start-up-jobs-service.js
@@ -18,27 +18,27 @@ const syncLicenceGaugingStationsFromDigitise = require('../../modules/gauging-st
 const syncLicenceVersionPurposeConditionsFromDigitise = require('../../modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise')
 
 class StartUpJobsService {
-  static go (queueManager) {
-    if (config.featureToggles.batchNotificationsJob) {
-      this._batchNotificationsJobs(queueManager)
-    }
+  static go(queueManager) {
+    this._batchNotificationsJobs(queueManager)
 
     this._billingJobs(queueManager)
     this._gaugingStationJobs(queueManager)
   }
 
-  static async _batchNotificationsJobs (queueManager) {
-    queueManager.add(checkStatus.jobName)
+  static async _batchNotificationsJobs(queueManager) {
+    if (config.featureToggles.batchNotificationsJob) {
+      queueManager.add(checkStatus.jobName)
+    }
     queueManager.add(refreshEvent.jobName)
     queueManager.add(sendMessage.jobName)
   }
 
-  static async _billingJobs (queueManager) {
+  static async _billingJobs(queueManager) {
     queueManager.add(customerFileRefresh.jobName)
     queueManager.add(syncChargeCategories.jobName)
   }
 
-  static async _gaugingStationJobs (queueManager) {
+  static async _gaugingStationJobs(queueManager) {
     queueManager.add(syncGaugingStations.jobName)
     queueManager.add(syncLicenceGaugingStationsFromDigitise.jobName)
     queueManager.add(syncLicenceVersionPurposeConditionsFromDigitise.jobName)

--- a/src/lib/queue-manager/start-up-jobs-service.js
+++ b/src/lib/queue-manager/start-up-jobs-service.js
@@ -18,14 +18,14 @@ const syncLicenceGaugingStationsFromDigitise = require('../../modules/gauging-st
 const syncLicenceVersionPurposeConditionsFromDigitise = require('../../modules/gauging-stations/jobs/sync-licence-version-purpose-conditions-from-digitise')
 
 class StartUpJobsService {
-  static go(queueManager) {
+  static go (queueManager) {
     this._batchNotificationsJobs(queueManager)
 
     this._billingJobs(queueManager)
     this._gaugingStationJobs(queueManager)
   }
 
-  static async _batchNotificationsJobs(queueManager) {
+  static async _batchNotificationsJobs (queueManager) {
     if (config.featureToggles.batchNotificationsJob) {
       queueManager.add(checkStatus.jobName)
     }
@@ -33,12 +33,12 @@ class StartUpJobsService {
     queueManager.add(sendMessage.jobName)
   }
 
-  static async _billingJobs(queueManager) {
+  static async _billingJobs (queueManager) {
     queueManager.add(customerFileRefresh.jobName)
     queueManager.add(syncChargeCategories.jobName)
   }
 
-  static async _gaugingStationJobs(queueManager) {
+  static async _gaugingStationJobs (queueManager) {
     queueManager.add(syncGaugingStations.jobName)
     queueManager.add(syncLicenceGaugingStationsFromDigitise.jobName)
     queueManager.add(syncLicenceVersionPurposeConditionsFromDigitise.jobName)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4961

We had an assumption that using a status of 'sending' for a scheduled notification did not conflict with the existing legacy code.

This is not the case.

To avoid interacting with the legacy notification status update mechanism we have introduced a new status for scheduled notifications which is 'pending'.

This is, for all intents and purposes, the same as sending (without the legacy code attempting to update the status).

The legacy code report will be updated to allow this new 'pending' status.

We also previously added a feature toggle to turn off the whole batch notification jobs when instead we should have only toggle the notification check status.

This change update the toggle to only 'turn off' the check status logic.