### PR TITLE
Remove charge categories sync job

### DIFF
--- a/src/lib/queue-manager/start-up-jobs-service.js
+++ b/src/lib/queue-manager/start-up-jobs-service.js
@@ -10,7 +10,6 @@ const sendMessage = require('../../modules/batch-notifications/lib/jobs/send-mes
 
 // Billing
 const customerFileRefresh = require('../../modules/billing//jobs/customer-file-refresh')
-const syncChargeCategories = require('../../modules/billing/jobs/sync-charge-categories')
 
 // Gauging Stations
 const syncGaugingStations = require('../../modules/gauging-stations/jobs/sync-gauging-stations')
@@ -35,7 +34,6 @@ class StartUpJobsService {
 
   static async _billingJobs (queueManager) {
     queueManager.add(customerFileRefresh.jobName)
-    queueManager.add(syncChargeCategories.jobName)
   }
 
   static async _gaugingStationJobs (queueManager) {


### PR DESCRIPTION
A CSV file (`billing-metadata/charge-categories.csv``) containing a list of charge categories is held in the `wabs3-maintenance`` bucket.

Every 6 hours, a Bullmq job checks for changes and either inserts or updates the changes.

But it is pointless!

The file has never changed since it was first dropped. Also, because it sits in the `production` bucket, we couldn't upload a different one without a Normal RfC. This means we'd need to wait 10 business days for the changes to appear.

If the data is managed using a seed file and/or migrations, the job and all associated code would be unnecessary. We'd also be able to release the changes under a Standard RfC, which means the changes could appear as quickly as the next day.

_They are_ now managed by a seed process in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), so now is as good a time as any to get rid of it!