### PR TITLE
Actually stop charge categories sync job!

### DIFF
--- a/src/lib/queue-manager/job-registration-service.js
+++ b/src/lib/queue-manager/job-registration-service.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const billingApproveBatch = require('../../modules/billing/jobs/approve-batch')
-const billingChargeCategoriesSyncFromCsv = require('../../modules/billing/jobs/sync-charge-categories')
 const billingCreateBillRun = require('../../modules/billing/jobs/create-bill-run')
 const billingCreateCharge = require('../../modules/billing/jobs/create-charge')
 const billingCustomerFileRefresh = require('../../modules/billing/jobs/customer-file-refresh')
@@ -71,7 +70,6 @@ class JobRegistrationService {
   static _jobs () {
     return [
       billingApproveBatch,
-      billingChargeCategoriesSyncFromCsv,
       billingCreateBillRun,
       billingCreateCharge,
       billingCustomerFileRefresh,

--- a/src/modules/billing/jobs/sync-charge-categories.js
+++ b/src/modules/billing/jobs/sync-charge-categories.js
@@ -13,7 +13,6 @@ const JOB_NAME = 'billing.charge-categories.sync-from-csv'
 const csvKey = 'billing-metadata/charge-categories.csv'
 
 // Handy stuff
-const config = require('../../../../config')
 const applicationState = require('../../../lib/services/application-state')
 
 // Charge Categories Repo

--- a/src/modules/billing/jobs/sync-charge-categories.js
+++ b/src/modules/billing/jobs/sync-charge-categories.js
@@ -24,10 +24,7 @@ const createMessage = () => ([
   JOB_NAME,
   {},
   {
-    jobId: `${JOB_NAME}.${moment().format('YYYYMMDD')}`,
-    repeat: {
-      every: config.import.chargeCategoriesSyncFrequencyInMS
-    }
+    jobId: `${JOB_NAME}.${moment().format('YYYYMMDD')}`
   }
 ])
 

--- a/test/modules/billing/jobs/sync-charge-categories.test.js
+++ b/test/modules/billing/jobs/sync-charge-categories.test.js
@@ -64,7 +64,6 @@ experiment('modules/billing/jobs/sync-charge-categories', () => {
       expect(message[0]).to.equal('billing.charge-categories.sync-from-csv')
       expect(message[1]).to.equal({})
       expect(message[2].jobId).to.startWith('billing.charge-categories.sync-from-csv.20')
-      expect(message[2].repeat).to.exist()
     })
   })
 


### PR DESCRIPTION
In [Remove charge categories sync job](https://github.com/DEFRA/water-abstraction-service/pull/2687), we thought we'd stopped the charge categories sync job from running. As we highlighted in that change, we don't tend to remove code, because we are wary of how stuff is often reused in the legacy code, and deleting code can break things.

So, instead, we tend to remove things at the 'edges'. In #2687, we stopped starting the job when the app starts. We know it has config to automatically repeat the job, so we figured not starting it would mean it couldn't repeat. How wrong we were!

Looking at the logs in `pre`, it still seems to be running. So, in this change, we'll stop the job itself from registering and remove the repeat config.