### PR TITLE
Migration - Add `created_by` to `licence_gauging_stations`

### DIFF
--- a/migrations/20250512143930-alter-licence-gauging-stations.js
+++ b/migrations/20250512143930-alter-licence-gauging-stations.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250512143930-alter-licence-gauging-stations-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250512143930-alter-licence-gauging-stations-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250512143930-alter-licence-gauging-stations-down.sql
+++ b/migrations/sqls/20250512143930-alter-licence-gauging-stations-down.sql
@@ -1,0 +1,7 @@
+/* revert changes made */
+
+BEGIN;
+
+ALTER TABLE water.licence_gauging_stations DROP COLUMN created_by;
+
+COMMIT;

--- a/migrations/sqls/20250512143930-alter-licence-gauging-stations-up.sql
+++ b/migrations/sqls/20250512143930-alter-licence-gauging-stations-up.sql
@@ -1,0 +1,11 @@
+/*
+  Adds a column to allow us to capture who created the record
+
+  We capture the user_id so we can link to the idm.users table
+*/
+
+BEGIN;
+
+ALTER TABLE water.licence_gauging_stations ADD created_by integer;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4999

As part of the work migrating the "Monitoring stations - Tag details page" we are now required to capture the user that created the Tag.

This PR will create a `created_by` column in the `water.licence_gauging_stations` table to enable us to capture the user ID.