### PR TITLE
Update returns for company endpoint for quarterly

### DIFF
--- a/src/modules/companies/controller.js
+++ b/src/modules/companies/controller.js
@@ -21,6 +21,7 @@ const rowMapper = ret => {
     returnId: ret.return_id,
     startDate: ret.start_date,
     endDate: ret.end_date,
+    dueDate: ret.due_date,
     frequency: ret.returns_frequency,
     returnRequirement: ret.return_requirement,
     status: ret.status,
@@ -44,11 +45,11 @@ const getReturns = async (request, h) => {
   // Get returns matching the documents and other filter params supplied
   // in request GET params
   const returnsFilter = returnsHelper.createReturnsFilter(request, documents)
-  const columms = [
-    'return_id', 'licence_ref', 'start_date', 'end_date',
+  const columns = [
+    'return_id', 'licence_ref', 'start_date', 'end_date', 'due_date',
     'returns_frequency', 'return_requirement', 'status', 'metadata'
   ]
-  const returns = await returnsConnector.returns.findAll(returnsFilter, null, columms)
+  const returns = await returnsConnector.returns.findAll(returnsFilter, null, columns)
 
   // Map returns
   return returns.map(rowMapper)

--- a/src/modules/companies/routes.js
+++ b/src/modules/companies/routes.js
@@ -17,9 +17,6 @@ module.exports = {
           entityId: Joi.string().guid().required()
         }),
         query: Joi.object().keys({
-          startDate: Joi.string().isoDate(),
-          endDate: Joi.string().isoDate(),
-          isSummer: Joi.boolean(),
           status: Joi.string().valid(...statuses),
           excludeNaldReturns: Joi.boolean().default(true)
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4796

We are updating the service to allow customers to upload returns quarterly (four times a year instead of just once).

The current logic is tied to displaying the link and generating the CSVs for the cycle you are currently in. To enable quarterly, we have to break that tie-in and move to a more flexible "I have a due return; give me the CSV!"

We've already made a change to allow the link always to be displayed (if you have bulk uploads enabled and have due returns) in [Always display bulk upload link on external site](https://github.com/DEFRA/water-abstraction-ui/pull/2677).

This change supports our changes to the [CSV template generation](https://github.com/DEFRA/water-abstraction-ui/pull/2679). The logic in the UI calls the `/water/1.0/company/{entityId}/returns` endpoint to fetch the returns for the current 'company'.

The CSV template will be grouped by due date, but to do that, the endpoint needs to start returning it.