### PR TITLE
Exclude not-ended rtns from generated CSV template

### DIFF
--- a/src/modules/companies/routes.js
+++ b/src/modules/companies/routes.js
@@ -17,6 +17,9 @@ module.exports = {
           entityId: Joi.string().guid().required()
         }),
         query: Joi.object().keys({
+          startDate: Joi.string().isoDate(),
+          endDate: Joi.string().isoDate(),
+          isSummer: Joi.boolean(),
           status: Joi.string().valid(...statuses),
           excludeNaldReturns: Joi.boolean().default(true)
         })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4796

We are updating the service to allow customers to upload returns quarterly (four times a year instead of just once).

In [Update returns for company endpoint for quarterly](https://github.com/DEFRA/water-abstraction-service/pull/2692), we made a change to the API endpoint that supplies the returns data for CSV templates generated for users, to support the change [in the water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui/pull/2679).

However, during testing, we discovered that returns which show as `NOT DUE YET` in the internal UI and aren't even listed in the external UI are included in the CSV templates generated.

These need to be excluded. This change reinstates the filters we previously removed, including the 'end date' filter, which the API endpoint utilises to apply a 'less than or equal to' clause to the query it executes.

> We add them all back in to be on the safe side!