### PR TITLE
Remove date filter on internal search for returns

### DIFF
--- a/src/modules/internal-search/lib/search-returns.js
+++ b/src/modules/internal-search/lib/search-returns.js
@@ -103,10 +103,7 @@ const findRecentReturnsByFormatId = async (formatId) => {
   const filter = {
     regime: 'water',
     licence_type: 'abstraction',
-    return_requirement: formatId,
-    start_date: {
-      $gte: '2008-04-01'
-    }
+    return_requirement: formatId
   }
   const sort = {
     end_date: -1

--- a/test/modules/internal-search/lib/search-returns.test.js
+++ b/test/modules/internal-search/lib/search-returns.test.js
@@ -132,7 +132,6 @@ experiment('findRecentReturnsByFormatId', () => {
     expect(filter.regime).to.equal('water')
     expect(filter.licence_type).to.equal('abstraction')
     expect(filter.return_requirement).to.equal(formatId)
-    expect(filter.start_date).to.equal({ $gte: '2008-04-01' })
     expect(sort).to.equal({ end_date: -1 })
     expect(columns).to.include([
       'return_id', 'licence_ref', 'return_requirement',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5085

While testing another feature of the service, it was noted that the way we create return requirements differs from NALD's approach (NALD now uses unique references, whereas we didn't!)

One of the things that highlighted this was multiple results appearing in the internal search. Users were accustomed to seeing only a single result.

There _are_ return requirements with duplicate references that we have imported from NALD, but they only apply to much older ones (pre-2008-04-01). We couldn't understand why searches for these returned no results until we found this filter.

Perhaps, knowing that WRLS was not originally importing old return submission data, it was felt there was no need to include them. But now _all_ NALD returns data has been imported into WRLS, and we are taking over the 'returns leg' from NALD, we need to remove this restriction on the internal search.