### PR TITLE
Include returns for 'ended' licences in search

### DIFF
--- a/src/modules/internal-search/lib/search-returns.js
+++ b/src/modules/internal-search/lib/search-returns.js
@@ -25,8 +25,6 @@ const mapReturn = (row) => {
 /**
  * Given an array of returns, checks each licence number
  * exists in CRM
- * This is required because we currently only show current licences, and
- * therefore we only show returns related to current licences
  * @param {Array} returns
  * @return {Promise} resolves with list of returns filtered by whether
  *                   they exist in the CRM document headers
@@ -36,7 +34,8 @@ const filterReturnsByCRMDocument = async (returns) => {
   const filter = {
     system_external_id: {
       $in: licenceNumbers
-    }
+    },
+    includeExpired: true
   }
   const { data, error } = await documents.findMany(filter, null, null, ['system_external_id'])
 

--- a/test/modules/internal-search/lib/search-returns.test.js
+++ b/test/modules/internal-search/lib/search-returns.test.js
@@ -4,7 +4,6 @@ const { experiment, test, afterEach, beforeEach } = exports.lab = Lab.script()
 const { expect } = require('@hapi/code')
 
 const searchReturns = require('../../../../src/modules/internal-search/lib/search-returns')
-const documents = require('../../../../src/lib/connectors/crm/documents')
 const returnsService = require('../../../../src/lib/connectors/returns')
 
 // Test returns data
@@ -47,29 +46,6 @@ experiment('mapReturn', () => {
   test('It should map a row of data from the returns API to include the region name', async () => {
     const mapped = searchReturns.mapReturn(returns[0])
     expect(mapped.region).to.equal('Midlands')
-  })
-})
-
-experiment('filterReturnsByCRMDocument', () => {
-  let stub
-
-  afterEach(async () => {
-    stub.restore()
-  })
-
-  test('It should throw an error if API response contains error', async () => {
-    stub = sinon.stub(documents, 'findMany').resolves(errorResponse)
-    expect(searchReturns.filterReturnsByCRMDocument(returns)).to.reject()
-  })
-
-  test('It should filter returns for which a CRM document cannot be found', async () => {
-    stub = sinon.stub(documents, 'findMany').resolves({
-      data: [{
-        system_external_id: 'y'
-      }]
-    })
-    const result = await searchReturns.filterReturnsByCRMDocument(returns)
-    expect(result).to.equal([returns[1]])
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5127

Whilst testing WATER-5006, our QA team raised a concern that something was broken.

They were searching for a return reference they could see in a licence's returns, but the search was saying 'No results found'.

When we investigated, we found the legacy search has been written to exclude results from licences that have ended. It will only search for return references for 'current licences'.

We don't know what value there was in this in the first place. However, now that WRLS is responsible for managing returns, this quirk is not only confusing but could also block users from carrying out their duties.