### PR TITLE
Fix billing transactions for deleted licence

### DIFF
--- a/migrations/20250703121500-fix-deleted-licence-bill-transactions.js
+++ b/migrations/20250703121500-fix-deleted-licence-bill-transactions.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250703121500-fix-deleted-licence-bill-transactions-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250703121500-fix-deleted-licence-bill-transactions-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250703121500-fix-deleted-licence-bill-transactions-down.sql
+++ b/migrations/sqls/20250703121500-fix-deleted-licence-bill-transactions-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration being used to correct invalid data */

--- a/migrations/sqls/20250703121500-fix-deleted-licence-bill-transactions-up.sql
+++ b/migrations/sqls/20250703121500-fix-deleted-licence-bill-transactions-up.sql
@@ -1,0 +1,27 @@
+/*
+  Fix billing transactions for deleted licence
+
+  https://eaflood.atlassian.net/browse/WATER-4800
+
+  A while back we added a data fix migration:
+  [Fix bill history caused by edited licence in NALD](http://github.com/DEFRA/water-abstraction-service/pull/2676).
+
+  This was for a licence which was amended in NALD. The original licence number was mis-typed but rather than creating a
+  new licence record they amended the existing one. This led to two licence records being created in WRLS. The issue
+  was that bills had been raised against the record with the wrong licence ref.
+
+  Pull request #2676 was to link those bill and bill licences records to the correct licence record. Then the clean job
+  in [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) could safely remove the incorrect
+  one.
+
+  We thought it had, but we've since found the record is still in the table. It looked deleted because the search was
+  no longer finding it.
+
+  The thing blocking its deletion is that the wrong licence, is linked to a charge version, that is linked to a
+  charge element, that is linked to the bills that we moved. When we moved them, we overlooked this detail.
+
+  So, this fix updates the charge element ID in the billing transactions. Now the 'clean' can remove the charge element
+  record, then in turn the charge version and licence for the invalid record.
+ */
+
+UPDATE water.billing_transactions SET charge_element_id = 'eb118281-0f61-4209-af8c-4006e0861d4d' WHERE charge_element_id = '43e16b42-b91f-4583-bdcc-8451ead22d9a';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4800

A while back, we added a data fix migration: [Fix bill history caused by edited licence in NALD](http://github.com/DEFRA/water-abstraction-service/pull/2676).

This was for a licence which was amended in NALD. The original licence number was mis-typed, but rather than creating a new licence record, they amended the existing one. This led to two licence records being created in WRLS. The issue was that bills had been raised against the record with the wrong licence ref.

Pull request #2676 was to link those bill and bill licence records to the correct licence record. Then the clean job in [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) could safely remove the incorrect one.

We thought it had been, but we've since found that the record is still in the table. It appeared to be deleted because the search was no longer finding it.

The thing blocking its deletion is that the wrong licence is linked to a charge version, which is connected to a charge element, which is connected to the bills that we moved. When we moved them, we overlooked this detail.

So, this fix updates the charge element ID in the billing transactions. Now the 'clean' can remove the charge element record, then in turn the charge version and the licence for the invalid record.