### PR TITLE
Add migration to add a template id column to scheduled notification

### DIFF
--- a/migrations/20250925094115-add-template-id-to-scheduled-notification.js
+++ b/migrations/20250925094115-add-template-id-to-scheduled-notification.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250925094115-add-template-id-to-scheduled-notification-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250925094115-add-template-id-to-scheduled-notification-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250925094115-add-template-id-to-scheduled-notification-down.sql
+++ b/migrations/sqls/20250925094115-add-template-id-to-scheduled-notification-down.sql
@@ -1,0 +1,3 @@
+/* Reverts the change by dropping the column */
+
+ALTER TABLE water.scheduled_notification DROP COLUMN template_id;

--- a/migrations/sqls/20250925094115-add-template-id-to-scheduled-notification-up.sql
+++ b/migrations/sqls/20250925094115-add-template-id-to-scheduled-notification-up.sql
@@ -1,0 +1,9 @@
+/*
+  The Notify template ids where not previously stored.
+
+  This migration adds the column to record the Notify template id.
+
+  https://docs.notifications.service.gov.uk/node.html#templateid-required
+*/
+
+ALTER TABLE water.scheduled_notification ADD COLUMN template_id UUID DEFAULT NULL;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

The Notify template ids where not previously stored.

This migration adds the column to record the Notify template id.

https://docs.notifications.service.gov.uk/node.html#templateid-required