### PR TITLE
Add migration to add a pdf column to scheduled notification (#2723)

### DIFF
--- a/migrations/20250925134157-add-pdf-to-scheduled-notification.js
+++ b/migrations/20250925134157-add-pdf-to-scheduled-notification.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250925134157-add-pdf-to-scheduled-notification-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20250925134157-add-pdf-to-scheduled-notification-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20250925134157-add-pdf-to-scheduled-notification-down.sql
+++ b/migrations/sqls/20250925134157-add-pdf-to-scheduled-notification-down.sql
@@ -1,0 +1,3 @@
+/* Reverts the change by dropping the column */
+
+ALTER TABLE water.scheduled_notification DROP COLUMN pdf;

--- a/migrations/sqls/20250925134157-add-pdf-to-scheduled-notification-up.sql
+++ b/migrations/sqls/20250925134157-add-pdf-to-scheduled-notification-up.sql
@@ -1,0 +1,11 @@
+/*
+  The Return forms where not previously stored.
+
+  This migration adds the column to record the Return forms.
+
+  Notify states a 'precompiled letter must be a PDF file'
+
+  https://docs.notifications.service.gov.uk/node.html#send-a-precompiled-letter
+*/
+
+ALTER TABLE water.scheduled_notification ADD COLUMN pdf BYTEA DEFAULT NULL;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5280

The Return forms where not previously stored.

This migration adds the column to record PDFs sent via notify.

Notify states a 'precompiled letter must be a PDF file'

https://docs.notifications.service.gov.uk/node.html#send-a-precompiled-letter