### PR TITLE
Add return at date column to scheduled notifications table

### DIFF
--- a/migrations/20251001100750-add-returned-at-to-scheduled-notification.js
+++ b/migrations/20251001100750-add-returned-at-to-scheduled-notification.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20251001100750-add-returned-at-to-scheduled-notification-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20251001100750-add-returned-at-to-scheduled-notification-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20251001100750-add-returned-at-to-scheduled-notification-down.sql
+++ b/migrations/sqls/20251001100750-add-returned-at-to-scheduled-notification-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.scheduled_notification DROP COLUMN returned_at;

--- a/migrations/sqls/20251001100750-add-returned-at-to-scheduled-notification-up.sql
+++ b/migrations/sqls/20251001100750-add-returned-at-to-scheduled-notification-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE water.scheduled_notification ADD COLUMN returned_at date DEFAULT NULL;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5296

As part of the work to send out letters to licence holders we need a way to be able to know when a letter has been returned. GovNotify allows you to set up a callback url: https://docs.notifications.service.gov.uk/node.html#returned-letters 

When this happens we want to be able to register when we were notified that the letter was returned so this PR adds a column that we will use to register when the most recent letter for a notification was returned. 