### PR TITLE
Add `overall_status` and `status_counts` columns to events table

### DIFF
--- a/migrations/20251006130947-add-overall-status-to-events.js
+++ b/migrations/20251006130947-add-overall-status-to-events.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20251006130947-add-overall-status-to-events-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20251006130947-add-overall-status-to-events-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20251006130947-add-overall-status-to-events-down.sql
+++ b/migrations/sqls/20251006130947-add-overall-status-to-events-down.sql
@@ -1,0 +1,12 @@
+/*
+  Remove the overall_status and status_counts columns from the events table
+
+  https://eaflood.atlassian.net/browse/WATER-5306
+*/
+
+BEGIN;
+
+ALTER TABLE water.events DROP COLUMN overall_status;
+ALTER TABLE water.events DROP COLUMN status_counts;
+
+COMMIT;

--- a/migrations/sqls/20251006130947-add-overall-status-to-events-up.sql
+++ b/migrations/sqls/20251006130947-add-overall-status-to-events-up.sql
@@ -1,0 +1,43 @@
+/*
+  Add overall_status and status_counts columns to events table
+
+  https://eaflood.atlassian.net/browse/WATER-5306
+
+  The overall_status column is populated with the overall status of related notifications. This status is calculated
+  based on the statuses of all notifications associated with an event. It provides a quick reference to the overall
+  status of the event without needing to check each notification individually.
+
+  The status_counts column is a JSONB object that contains counts of each notification status type related to the event.
+*/
+
+BEGIN;
+
+ALTER TABLE water.events ADD COLUMN overall_status varchar(255);
+ALTER TABLE water.events ADD COLUMN status_counts jsonb;
+
+UPDATE water.events e
+SET
+  overall_status = os.overall_status,
+  status_counts = os.status_counts
+FROM (
+  SELECT
+    sn.event_id,
+    CASE
+      WHEN COUNT(*) FILTER (WHERE sn.status = 'returned') > 0 THEN 'returned'
+      WHEN COUNT(*) FILTER (WHERE sn.status = 'error') > 0 THEN 'error'
+      WHEN COUNT(*) FILTER (WHERE sn.status = 'pending') > 0 THEN 'pending'
+      ELSE 'sent'
+    END AS overall_status,
+    jsonb_build_object(
+      'returned', COUNT(*) FILTER (WHERE sn.status = 'returned'),
+      'error', COUNT(*) FILTER (WHERE sn.status = 'error'),
+      'pending', COUNT(*) FILTER (WHERE sn.status = 'pending'),
+      'sent', COUNT(*) FILTER (WHERE sn.status = 'sent')
+    ) AS status_counts
+  FROM water.scheduled_notification sn
+  GROUP BY sn.event_id
+) os
+WHERE e.type = 'notification'
+AND e.event_id = os.event_id;
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5306

The `overall_status` column is populated with the overall status of related notifications. This status is calculated based on the statuses of all notifications associated with an event. It provides a quick reference to the overall status of the event without needing to check each notification individually.

The statuses are calculated as follows:
- If one notification has a status of returned, then show RETURNED
- If no notifications are returned, but one has a status of error, then show ERROR
- If no notifications are returned or errored, but one has a status of pending, then show PENDING
- If no notifications are returned, errored, or pending, then show SENT

The `status_counts` column is a JSONB object that contains counts of each notification status type related to the event.