### PR TITLE
Add missed rtn invite alternate due dates

### DIFF
--- a/migrations/20260602212056-update-missing-return-log-due-dates.js
+++ b/migrations/20260602212056-update-missing-return-log-due-dates.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260602212056-update-missing-return-log-due-dates-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260602212056-update-missing-return-log-due-dates-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20260602212056-update-missing-return-log-due-dates-down.sql
+++ b/migrations/sqls/20260602212056-update-missing-return-log-due-dates-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration being used to correct missing data */

--- a/migrations/sqls/20260602212056-update-missing-return-log-due-dates-up.sql
+++ b/migrations/sqls/20260602212056-update-missing-return-log-due-dates-up.sql
@@ -1,0 +1,60 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-5659
+
+  Our users identified an issue with our returns notice 'fallback' logic.
+
+  When we send a returns invitation, if the email to the primary user fails, we automatically generate another notice to
+  the licence holder's address. That part is working fine.
+
+  When we then get confirmation from [GOV.UK Notify](https://www.notifications.service.gov.uk/) that the letter has been
+  'received' (meaning successfully sent to their mail provider), not only do we update the notification status, but we
+  should be setting the 'due date' on the associated return logs.
+
+  It is this part that had the bug. We fixed it in [Fix not setting due date for alt. returns
+  notices](https://github.com/DEFRA/water-abstraction-system/pull/3363).
+
+  But there are now several return logs missing a due date. This migration sets the missing due date for the affected
+  return logs.
+
+  Note - We have to wrap the query in an anonymous code block because we depend on a table in another schema but when
+  this is run in CI that schema does not exist.
+*/
+
+DO $$
+BEGIN
+  IF EXISTS
+    (
+      SELECT
+        1
+      FROM
+        information_schema.tables
+      WHERE
+        table_schema = 'returns'
+        AND table_name = 'returns'
+    )
+  THEN
+    WITH notification_due_dates AS (
+      SELECT
+        logs.return_log_id::uuid,
+        sn.due_date
+      FROM
+        water.scheduled_notification sn
+      CROSS JOIN LATERAL
+        jsonb_array_elements_text(sn.return_log_ids) AS logs(return_log_id)
+      WHERE
+        sn.message_ref = 'returns invitation alternate'
+        AND sn.status = 'sent'
+        AND sn.notify_status = 'received'
+        AND sn.due_date IS NOT NULL
+    )
+    UPDATE "returns"."returns" r
+    SET
+      due_date = ndd.due_date
+    FROM
+      notification_due_dates ndd
+    WHERE
+      r.id = ndd.return_log_id
+      AND r.due_date IS NULL;
+  END IF;
+END
+$$;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5659

Our users identified an issue with our returns notice 'fallback' logic.

When we send a returns invitation, if the email to the primary user fails, we automatically generate another notice to the licence holder's address. That part is working fine.

When we then get confirmation from [GOV.UK Notify](https://www.notifications.service.gov.uk/) that the letter has been 'received' (meaning successfully sent to their mail provider), not only do we update the notification status, but we should be setting the 'due date' on the associated return logs.

It is this part that had the bug. We fixed it in [Fix not setting due date for alt. returns notices](https://github.com/DEFRA/water-abstraction-system/pull/3363).

But there are now several return logs missing a due date. This change adds a migration to set the missing due date for the affected return logs.