### PR TITLE
Migrate `new_internal_user_email` status checks to system

### DIFF
--- a/src/modules/batch-notifications/lib/queries.js
+++ b/src/modules/batch-notifications/lib/queries.js
@@ -65,7 +65,6 @@ const getNotifyStatusChecks = async () => {
         'email_change_verification_code_email',
         'existing_user_verification_email',
         'expiry_notification_email',
-        'new_internal_user_email',
         'new_user_verification_email',
         'password_locked_email',
         'password_reset_email',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5660

Following moving the Send verification email process to the [system](https://github.com/DEFRA/water-abstraction-system) repo in PR https://github.com/DEFRA/water-abstraction-system/pull/3380. This PR will update the legacy notification status job to stop checking the Notify status of message_ref = ‘new_internal_user_email’ notifications.

This checking process is already carried out in the [system](https://github.com/DEFRA/water-abstraction-system) repo making the legacy one redundant.