### PR TITLE
Data fix for invalid start date in ret. req. record

### DIFF
--- a/migrations/20260618075441-fix-invalid-ret-req-start-date.js
+++ b/migrations/20260618075441-fix-invalid-ret-req-start-date.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260618075441-fix-invalid-ret-req-start-date-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260618075441-fix-invalid-ret-req-start-date-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20260618075441-fix-invalid-ret-req-start-date-down.sql
+++ b/migrations/sqls/20260618075441-fix-invalid-ret-req-start-date-down.sql
@@ -1,0 +1,7 @@
+/* Revert the data fix */
+
+UPDATE water.return_requirements rr
+SET
+  abstraction_period_start_day = 31
+WHERE
+  rr.external_id = '1:7998';

--- a/migrations/sqls/20260618075441-fix-invalid-ret-req-start-date-up.sql
+++ b/migrations/sqls/20260618075441-fix-invalid-ret-req-start-date-up.sql
@@ -12,12 +12,12 @@
 
   There are only 30 days in April, so when RDP tries to ingest the record, it throws an error.
 
-  We've checked the DB, both start and end date, and fortunately this is the only example of an invalid date.
+  We've checked the DB, both start and end dates, and fortunately, this is the only example of an invalid date.
 
   This script fixes the record.
 
-  > NOTE: We use the external_id rather than return_requirement_id because this record was imported across a range of
-  > environments, and therefore it will be different in each, whereas external_id will be consistent.
+  > NOTE: We use the external_id rather than return_requirement_id because this record was imported across multiple
+  > environments, so it will differ in each, whereas external_id will be consistent.
 */
 
 UPDATE water.return_requirements rr

--- a/migrations/sqls/20260618075441-fix-invalid-ret-req-start-date-up.sql
+++ b/migrations/sqls/20260618075441-fix-invalid-ret-req-start-date-up.sql
@@ -1,0 +1,27 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-5688
+
+  The RDP team brought a query to us. They had found an example of a return log where the return requirement it was
+  linked to did not exist.
+
+  When we checked the replica, we found it did. So, they dug a little deeper and found that RDP was not importing the
+  record because it had an invalid abstraction start date
+
+  - day = 31
+  - month = 4
+
+  There are only 30 days in April, so when RDP tries to ingest the record, it throws an error.
+
+  We've checked the DB, both start and end date, and fortunately this is the only example of an invalid date.
+
+  This script fixes the record.
+
+  > NOTE: We use the external_id rather than return_requirement_id because this record was imported across a range of
+  > environments, and therefore it will be different in each, whereas external_id will be consistent.
+*/
+
+UPDATE water.return_requirements rr
+SET
+  abstraction_period_start_day = 30
+WHERE
+  rr.external_id = '1:7998';


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5688

The RDP team brought a query to us. They had found an example of a return log where the return requirement it was linked to did not exist.

When we checked the replica, we found it did. So, they dug a little deeper and found that RDP was not importing the record because it had an invalid abstraction start date

- day = 31
- month = 4

There are only 30 days in April, so when RDP tries to ingest the record, it throws an error.

We've checked the DB, both start and end dates, and fortunately, this is the only example of an invalid date.

This change adds a migration script to fix the record.

> NOTE: We use the external_id rather than return_requirement_id because this record was imported across multiple environments, so it will differ in each, whereas external_id will be consistent.