### PR TITLE
Fix dependency issue following Node 24 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7003,9 +7003,10 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msgpackr": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
-      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
       }
@@ -12928,7 +12929,7 @@
         "glob": "^7.2.0",
         "ioredis": "^4.28.5",
         "lodash": "^4.17.21",
-        "msgpackr": "^1.4.6",
+        "msgpackr": "^1.12.1",
         "semver": "^7.3.7",
         "tslib": "^1.14.1",
         "uuid": "^8.3.2"
@@ -16466,9 +16467,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msgpackr": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
-      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
       "requires": {
         "msgpackr-extract": "^3.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "sinon": "^14.0.2",
     "standard": "^17.1.0"
   },
+  "overrides": {
+    "msgpackr": "^1.12.1"
+  },
   "allowScripts": {
     "aws-sdk@2.1693.0": true,
     "es5-ext@0.10.63": true,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5606

After updating to Node v24 the `service-background` was erroring and would not run. This was down to an out of date package.

### What was wrong
Node 24 made `Buffer.utf8Write` strictly validate its length argument against the buffer's bounds. The version of `msgpackr` that `bullmq@1.87.2` pulled in (1.10.1) called it with an unbounded length:

- `return target.utf8Write(string, position, 0xffffffff)`

When BullMQ tried to serialize/queue a job, Node 24 rejected that with `ERR_BUFFER_OUT_OF_BOUNDS`, crashing `service-background`. (On Node 22 the old, lax behavior tolerated it.)

### The fix
Patched `msgpackr` versions changed the call to a bounded length:

- `return target.utf8Write(string, position, target.byteLength - position)`

Since `msgpackr` is a transitive dependency, it was forced up via an npm overrides entry in package.json (bullmq accepts ^1.4.6, so 1.12.1 is compatible):

```
"overrides": {
  "msgpackr": "^1.12.1"
}
```

Then regenerated package-lock.json, ran npm ci inside the dev container, and restarted the service.