### PR TITLE
Stop using NALD returns data in legacy service

### DIFF
--- a/src/modules/returns/lib/facade.js
+++ b/src/modules/returns/lib/facade.js
@@ -4,14 +4,7 @@
  * This layer gets return data, and depending on the date, either
  * loads data from the NALD import DB, or direct from the returns service
  */
-const moment = require('moment')
 const apiConnector = require('./api-connector')
-const naldConnector = require('../../import/lib/nald-returns-queries')
-const waterHelpers = require('@envage/water-abstraction-helpers')
-
-const { parseReturnId } = waterHelpers.returns
-const { mapUnit } = waterHelpers.returns.mappers
-const { naldToReturnLines } = require('./nald-returns-mapper')
 
 /**
  * Gets version and line data from the returns service
@@ -28,54 +21,12 @@ const getServiceData = async (returnId, versionNumber) => {
   return { version, versions, lines }
 }
 
-/**
- * Gets version and line data from the water.import schema in a format
- * similar to that stored in the return service
- * @param {Object} ret - the return record from the returns service
- * @return {Promise<Object>}
- */
-const getNaldData = async ret => {
-  const { return_id: returnId } = ret
-
-  // For older returns, synthesise data direct from the NALD import tables
-  const { regionCode, formatId, startDate, endDate } = parseReturnId(returnId)
-
-  // Get data from NALD import schema
-  const nilReturn = await naldConnector.isNilReturn(formatId, regionCode, startDate, endDate)
-  const naldLines = nilReturn ? [] : await naldConnector.getLines(formatId, regionCode, startDate, endDate)
-
-  const naldUnit = naldLines[0]?.UNIT_RET_FLAG ?? 'M'
-
-  const version = {
-    version_id: returnId,
-    return_id: returnId,
-    version_number: 1,
-    nil_return: nilReturn,
-    metadata: {
-      units: mapUnit(naldUnit)
-    },
-    current: true
-  }
-
-  return {
-    version,
-    versions: [version],
-    lines: naldToReturnLines(ret, naldLines)
-  }
-}
-
 const getReturnData = async (returnId, versionNumber) => {
   // Irrespective of whether service/NALD data, the return header is always loaded
   // from the returns service
   const ret = await apiConnector.fetchReturn(returnId)
 
-  // Whether to use new returns service - service is used for returns with
-  // end date on or after 31/10/2018
-  const isNew = moment(ret.end_date).isSameOrAfter('2018-10-31')
-
-  const data = isNew
-    ? await getServiceData(returnId, versionNumber)
-    : await getNaldData(ret)
+  const data = await getServiceData(returnId, versionNumber)
 
   return {
     ...data,

--- a/test/modules/returns/lib/facade.test.js
+++ b/test/modules/returns/lib/facade.test.js
@@ -3,7 +3,6 @@ const { expect } = require('@hapi/code')
 const sandbox = require('sinon').createSandbox()
 const facade = require('../../../../src/modules/returns/lib/facade')
 const apiConnector = require('../../../../src/modules/returns/lib/api-connector')
-const naldConnector = require('../../../../src/modules/import/lib/nald-returns-queries')
 
 const regionCode = '1'
 const formatId = '1234'
@@ -42,17 +41,6 @@ const createLines = () => ([
   }
 ])
 
-const createNaldLines = units => ([
-  {
-    UNIT_RET_FLAG: units,
-    RET_DATE: '20171130000000',
-    ARFL_ARTY_ID: 'format_1',
-    ARFL_DATE_FROM: '20171101000000',
-    RET_QTY: 100.13,
-    RET_QTY_USABILITY: 'M'
-  }
-])
-
 experiment('modules/returns/lib/facade', () => {
   let data, result
 
@@ -61,8 +49,6 @@ experiment('modules/returns/lib/facade', () => {
     sandbox.stub(apiConnector, 'fetchVersion')
     sandbox.stub(apiConnector, 'fetchAllVersions')
     sandbox.stub(apiConnector, 'fetchLines')
-    sandbox.stub(naldConnector, 'isNilReturn')
-    sandbox.stub(naldConnector, 'getLines')
   })
 
   afterEach(async () => {
@@ -147,134 +133,6 @@ experiment('modules/returns/lib/facade', () => {
         expect(result.version).to.equal(undefined)
         expect(result.versions).to.equal([])
         expect(result.lines).to.equal([])
-      })
-    })
-
-    experiment('when the return is a non-nil, metric, NALD return', () => {
-      beforeEach(async () => {
-        data = {
-          versionNumber: 1,
-          returnId: createReturnId('2018-10-30'),
-          return: createReturn('2018-10-30'),
-          lines: createNaldLines('M')
-        }
-
-        apiConnector.fetchReturn.resolves(data.return)
-        naldConnector.isNilReturn.resolves(false)
-        naldConnector.getLines.resolves(data.lines)
-
-        result = await facade.getReturnData(data.returnId, data.versionNumber)
-      })
-
-      test('naldConnector.isNilReturn is called with the correct parameters', async () => {
-        const { args } = naldConnector.isNilReturn.lastCall
-        expect(args[0]).to.equal(formatId)
-        expect(args[1]).to.equal(regionCode)
-        expect(args[2]).to.equal(startDate)
-        expect(args[3]).to.equal('2018-10-30')
-      })
-
-      test('naldConnector.getLines is called with the correct parameters', async () => {
-        const { args } = naldConnector.getLines.lastCall
-        expect(args[0]).to.equal(formatId)
-        expect(args[1]).to.equal(regionCode)
-        expect(args[2]).to.equal(startDate)
-        expect(args[3]).to.equal('2018-10-30')
-      })
-
-      test('the function resolves with the collected data', async () => {
-        expect(result.return).to.equal(data.return)
-        expect(result.version).to.be.an.object()
-        expect(result.versions).to.be.an.array().length(1)
-        expect(result.lines).to.be.an.array().length(1)
-      })
-
-      test('the version number is always 1', async () => {
-        expect(result.version.version_number).to.equal(1)
-      })
-
-      test('the version nil_return flag is false', async () => {
-        expect(result.version.nil_return).to.be.false()
-      })
-
-      test('the version units are read from the first return line', async () => {
-        expect(result.version.metadata.units).to.equal('m³')
-      })
-
-      test('the version current version flag is set to true', async () => {
-        expect(result.version.current).to.equal(true)
-      })
-
-      test('the line has the correct units', async () => {
-        expect(result.lines[0].unit).to.equal('m³')
-        expect(result.lines[0].user_unit).to.equal('m³')
-      })
-
-      test('the line has the correct dates', async () => {
-        expect(result.lines[0].start_date).to.equal('2017-11-01')
-        expect(result.lines[0].end_date).to.equal('2017-11-30')
-      })
-
-      test('the line has the correct quantity', async () => {
-        expect(result.lines[0].quantity).to.equal(data.lines[0].RET_QTY)
-      })
-
-      test('the line has the correct reading type', async () => {
-        expect(result.lines[0].reading_type).to.equal('measured')
-      })
-    })
-
-    experiment('when the return is a nil NALD return', () => {
-      beforeEach(async () => {
-        data = {
-          versionNumber: 1,
-          returnId: createReturnId('2018-10-30'),
-          return: createReturn('2018-10-30'),
-          lines: createNaldLines('M')
-        }
-
-        apiConnector.fetchReturn.resolves(data.return)
-        naldConnector.isNilReturn.resolves(true)
-        naldConnector.getLines.resolves(data.lines)
-
-        result = await facade.getReturnData(data.returnId, data.versionNumber)
-      })
-
-      test('the version number is always 1', async () => {
-        expect(result.version.version_number).to.equal(1)
-      })
-
-      test('the version nil_return flag is true', async () => {
-        expect(result.version.nil_return).to.be.true()
-      })
-
-      test('the lines array is empty', async () => {
-        expect(result.lines).to.equal([])
-      })
-    })
-    experiment('when the return is a non-nil, gallons, NALD return', () => {
-      beforeEach(async () => {
-        data = {
-          versionNumber: 1,
-          returnId: createReturnId('2018-10-30'),
-          return: createReturn('2018-10-30'),
-          lines: createNaldLines('I')
-        }
-
-        apiConnector.fetchReturn.resolves(data.return)
-        naldConnector.isNilReturn.resolves(false)
-        naldConnector.getLines.resolves(data.lines)
-
-        result = await facade.getReturnData(data.returnId, data.versionNumber)
-      })
-
-      test('the version units are read from the first return line', async () => {
-        expect(result.version.metadata.units).to.equal('gal')
-      })
-
-      test('the line has the correct units', async () => {
-        expect(result.lines[0].unit).to.equal('m³')
-        expect(result.lines[0].user_unit).to.equal('gal')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5693

We've been looking into discrepancies in returns data between NALD and WRLS. Whilst testing the fixes for the first tranche of issues, we observed a discrepancy between the legacy external UI and the internal system UI.

If the return log ends after 2018-10-31 and the sum of its lines is 0:

- The legacy external UI will display this as a Nil return
- The system internal UI will display the return as found, with the 0 line quantities

When the returns leg transferred from NALD to WRLS, and we were required to import the NALD submission data, our instructions were to import 0 quantities as-is, and the fact that someone recorded a 0 indicated it was not a Nil return.

This is confirmed by the fact that the legacy service behaves in this way when viewing a return with only 0 quantities with an end date after 2018-10-31.

What changed

`facade.getReturnData()` used to branch on the return's end date: for returns ending before 2018-10-31 it synthesised version/line data from the NALD import tables (`getNaldData`), inferring `nil_return` from `naldConnector.isNilReturn` rather than from the actual line quantities. For returns on or after that date it fetched the real submission data from the returns service.

That NALD branch, and the `moment`/`nald-returns-queries`/`nald-returns-mapper` dependencies it pulled in, have been removed. `getReturnData()` now always loads from the returns service, so the internal UI reflects the submitted 0 quantities as-found, the same as the legacy external UI, instead of recomputing a Nil return from the NALD import data.

Updated `test/modules/returns/lib/facade.test.js` to match: removed the NALD-path experiments and the `naldConnector` stub, keeping only the returns-service coverage.

---------

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>