### PR TITLE
Update unregister licence recording - Create table

### DIFF
--- a/migrations/20260625142542-create-licence-unregistrations-table.js
+++ b/migrations/20260625142542-create-licence-unregistrations-table.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260625142542-create-licence-unregistrations-table-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260625142542-create-licence-unregistrations-table-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20260625142542-create-licence-unregistrations-table-down.sql
+++ b/migrations/sqls/20260625142542-create-licence-unregistrations-table-down.sql
@@ -1,0 +1,2 @@
+/* Undo the migration by dropping the licence_unregistrations table */
+DROP TABLE IF EXISTS water.licence_unregistrations;

--- a/migrations/sqls/20260625142542-create-licence-unregistrations-table-up.sql
+++ b/migrations/sqls/20260625142542-create-licence-unregistrations-table-up.sql
@@ -1,0 +1,12 @@
+/* Create a new table in the water schema named licence_unregistrations */
+
+BEGIN;
+
+CREATE TABLE water.licence_unregistrations (
+  id uuid PRIMARY KEY DEFAULT public.gen_random_uuid(),
+  created_by uuid NOT NULL,
+  licence_id uuid NOT NULL,
+  created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5699

Create a new table in the `water` schema named `licence_unregistrations` with the following columns:
- `id`
- `licence_id` - ID of the licence being unregistered
- `created_at` - timestamp of when it happens
- `created_by` - User ID (the GUID, not the integer) of the user who unregistered the licence