### PR TITLE
Migration fix for notifications with no msg type

### DIFF
--- a/migrations/20260703160310-fix-missing-method-type.js
+++ b/migrations/20260703160310-fix-missing-method-type.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260703160310-fix-missing-method-type-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260703160310-fix-missing-method-type-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20260703160310-fix-missing-method-type-down.sql
+++ b/migrations/sqls/20260703160310-fix-missing-method-type-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration fixing missing data */

--- a/migrations/sqls/20260703160310-fix-missing-method-type-up.sql
+++ b/migrations/sqls/20260703160310-fix-missing-method-type-up.sql
@@ -1,0 +1,36 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-5723
+
+  We've recently updated the view user pages and they now include the ability to view a users communications.
+
+  After going live, our QA team found a user where clicking their communications caused an error page to be shown. After
+  investigation, we found that this was due to a notification in the database that had no message type.
+
+  We've checked, and these seem to be the very early (2018) notifications sent to users, when there may have been a bug
+  or a design decision that meant the `message_type` was not set.
+
+  [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) assumes this field is always populated,
+  hence is erroring when trying to process these records.
+
+  Fortunately, we can determine what the `message_type` should be from the other details. This migration fixes these
+  records.
+*/
+BEGIN;
+
+UPDATE water.scheduled_notification sn
+SET
+  message_type = 'letter',
+  updated_at = NOW()
+WHERE
+  sn.message_type IS NULL
+  AND sn.recipient = 'n/a';
+
+UPDATE water.scheduled_notification sn
+SET
+  message_type = 'email',
+  updated_at = NOW()
+WHERE
+  sn.message_type IS NULL
+  AND sn.recipient LIKE '%@%';
+
+COMMIT;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5723

We've recently updated the view user pages, and they now include the ability to view a user's communications.

After going live, our QA team found a user whose communications caused an error page to appear. After investigation, we found this was due to a database notification with no message type.

We've checked, and these seem to be the very early (2018) notifications sent to users, when there may have been a bug or a design decision that caused the `message_type` to be unset.

[water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) assumes this field is always populated; hence, it errors when processing these records.

Fortunately, we can determine the `message_type` from the other details. This change adds a migration to fix these records.