### PR TITLE
Delete 'changed' imported ret. req. purposes

### DIFF
--- a/migrations/20260730141324-delete-changed-ret-req-purposes.js
+++ b/migrations/20260730141324-delete-changed-ret-req-purposes.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+let Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, _seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260730141324-delete-changed-ret-req-purposes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20260730141324-delete-changed-ret-req-purposes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  version: 1
+}

--- a/migrations/sqls/20260730141324-delete-changed-ret-req-purposes-down.sql
+++ b/migrations/sqls/20260730141324-delete-changed-ret-req-purposes-down.sql
@@ -1,0 +1,1 @@
+/* No down script due to migration deleting data that shouldn't exist */

--- a/migrations/sqls/20260730141324-delete-changed-ret-req-purposes-up.sql
+++ b/migrations/sqls/20260730141324-delete-changed-ret-req-purposes-up.sql
@@ -12,44 +12,60 @@
   This migration deletes return requirement purposes that were imported from NALD, but now no longer exist.
 */
 
-WITH parsed_ids AS (
-  SELECT
-    split_part(rrp.external_id, ':', 1) AS region_code,
-    split_part(rrp.external_id, ':', 2) AS format_id,
-    split_part(rrp.external_id, ':', 3) AS primary_purpose_code,
-    split_part(rrp.external_id, ':', 4) AS secondary_purpose_code,
-    split_part(rrp.external_id, ':', 5) AS purpose_code,
-    rrp.*
-  FROM
-    water.return_requirement_purposes rrp
-  WHERE
-    rrp.external_id IS NOT NULL
-),
-to_be_deleted_records AS (
-  SELECT
-    pi.*
-  FROM
-    parsed_ids pi
-  WHERE
-    NOT EXISTS (
+DO $$
+BEGIN
+  IF EXISTS
+    (
       SELECT
         1
       FROM
-        "import"."NALD_RET_FMT_PURPOSES" nrfp
+        information_schema.tables
       WHERE
-        nrfp."FGAC_REGION_CODE" = pi.region_code
-        AND nrfp."ARTY_ID" = pi.format_id
-        AND nrfp."APUR_APPR_CODE" = pi.primary_purpose_code
-        AND nrfp."APUR_APSE_CODE" = pi.secondary_purpose_code
-        AND nrfp."APUR_APUS_CODE" = pi.purpose_code
+        table_schema = 'import'
+        AND table_name = 'NALD_RET_FMT_PURPOSES'
     )
-)
-DELETE FROM
-  water.return_requirement_purposes rrp
-WHERE
-  rrp.return_requirement_purpose_id IN (
-    SELECT
-      tbdr.return_requirement_purpose_id
-    FROM
-      to_be_deleted_records tbdr
-  );
+  THEN
+    WITH parsed_ids AS (
+      SELECT
+        split_part(rrp.external_id, ':', 1) AS region_code,
+        split_part(rrp.external_id, ':', 2) AS format_id,
+        split_part(rrp.external_id, ':', 3) AS primary_purpose_code,
+        split_part(rrp.external_id, ':', 4) AS secondary_purpose_code,
+        split_part(rrp.external_id, ':', 5) AS purpose_code,
+        rrp.*
+      FROM
+        water.return_requirement_purposes rrp
+      WHERE
+        rrp.external_id IS NOT NULL
+    ),
+    to_be_deleted_records AS (
+      SELECT
+        pi.*
+      FROM
+        parsed_ids pi
+      WHERE
+        NOT EXISTS (
+          SELECT
+            1
+          FROM
+            "import"."NALD_RET_FMT_PURPOSES" nrfp
+          WHERE
+            nrfp."FGAC_REGION_CODE" = pi.region_code
+            AND nrfp."ARTY_ID" = pi.format_id
+            AND nrfp."APUR_APPR_CODE" = pi.primary_purpose_code
+            AND nrfp."APUR_APSE_CODE" = pi.secondary_purpose_code
+            AND nrfp."APUR_APUS_CODE" = pi.purpose_code
+        )
+    )
+    DELETE FROM
+      water.return_requirement_purposes rrp
+    WHERE
+      rrp.return_requirement_purpose_id IN (
+        SELECT
+          tbdr.return_requirement_purpose_id
+        FROM
+          to_be_deleted_records tbdr
+      );
+  END IF;
+END
+$$;

--- a/migrations/sqls/20260730141324-delete-changed-ret-req-purposes-up.sql
+++ b/migrations/sqls/20260730141324-delete-changed-ret-req-purposes-up.sql
@@ -1,0 +1,55 @@
+/*
+  https://eaflood.atlassian.net/browse/WATER-5760
+
+  The business spotted a return requirement purpose in an RDP report they did not believe should exist.
+
+  We tracked it down to the fact they had amended the return requirement purpose in NALD. This caused the legacy import to believe it was a 'new' return requirement purpose and it was imported into the service.
+
+  That import was switched off last year when we took over returns from NALD.
+
+  But the RDP reports are based on our data so we need to clean this up.
+
+  This migration deletes return requirement purposes that were imported from NALD, but now no longer exist.
+*/
+
+WITH parsed_ids AS (
+  SELECT
+    split_part(rrp.external_id, ':', 1) AS region_code,
+    split_part(rrp.external_id, ':', 2) AS format_id,
+    split_part(rrp.external_id, ':', 3) AS primary_purpose_code,
+    split_part(rrp.external_id, ':', 4) AS secondary_purpose_code,
+    split_part(rrp.external_id, ':', 5) AS purpose_code,
+    rrp.*
+  FROM
+    water.return_requirement_purposes rrp
+  WHERE
+    rrp.external_id IS NOT NULL
+),
+to_be_deleted_records AS (
+  SELECT
+    pi.*
+  FROM
+    parsed_ids pi
+  WHERE
+    NOT EXISTS (
+      SELECT
+        1
+      FROM
+        "import"."NALD_RET_FMT_PURPOSES" nrfp
+      WHERE
+        nrfp."FGAC_REGION_CODE" = pi.region_code
+        AND nrfp."ARTY_ID" = pi.format_id
+        AND nrfp."APUR_APPR_CODE" = pi.primary_purpose_code
+        AND nrfp."APUR_APSE_CODE" = pi.secondary_purpose_code
+        AND nrfp."APUR_APUS_CODE" = pi.purpose_code
+    )
+)
+DELETE FROM
+  water.return_requirement_purposes rrp
+WHERE
+  rrp.return_requirement_purpose_id IN (
+    SELECT
+      tbdr.return_requirement_purpose_id
+    FROM
+      to_be_deleted_records tbdr
+  );


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5760

**The issue**

When running the new RDP returns report (Lakehouse reports), Billing & Data spotted a return requirement purpose that did not appear in the equivalent NALD BOXI report.

They initially queried if there was a problem with RDP or its data.

RDP asked us to check the data in WRLS, and we confirmed the record exists.

So, then the question became why, when it does not exist in NALD?

In this specific case, B&D highlighted that the mod log indicated a change had been made to the return version. They wondered whether something had gone wrong when the 'returns' switched from NALD to WRLS, and if these corrections had been missed. They also worried about the magnitude of the issue.

**The reason**

The service has been importing return versions and their associated data from NALD since 2020-11-04. When 'returns' switched from NALD to WRLS, some changes were made to identify or derive extra information that would be used going forward. But in the main, the big change was to switch it off.

The import from NALD has always had to deal with the fact that NALD does not have unique record IDs. This means that to know whether it is dealing with a new or existing record, it has to generate composite keys.

The problem with return requirement purposes is that there isn't much to make a composite key from! Though NALD no longer manages returns data, here is an example that exists today.

|ARTY_ID |APUR_APPR_CODE|APUR_APSE_CODE|APUR_APUS_CODE|PURP_ALIAS               |PURP_ALIAS_WELSH|FGAC_REGION_CODE|SOURCE_CODE|BATCH_RUN_DATE|
|--------|--------------|--------------|--------------|-------------------------|----------------|----------------|-----------|--------------|
|10054909|W             |PWU           |140           |Private Water Undertaking|null            |2               |null       |null          |
|10054909|A             |AGR           |140           |null                     |null            |2               |null       |null          |

WRLS always uses the region code, then the 'main' ID, which in this case is ARTY_ID (format ID). It can't use fields that could be null or too long. That leaves the primary and secondary purpose codes. So, from these records it created:

- `2:10054909:W:PWU:140`
- `2:10054909:A:AGR:140`

The issue is that when the requirement purpose was amended in NALD for `AN/033/0019/017`, the legacy import saw this as a new record, not an amendment. Hence, the additional record was created.

**The fix**

Now that we know this, we have identified 171 return requirement purposes that were imported from NALD but that no longer exist, either because they were deleted or changed. There is no impact from deleting these, and we can do that as a one-off data fix.