### PR TITLE
Use internal copy of return ID regex instead of water-abstraction-helpers

### DIFF
--- a/src/lib/models/validators.js
+++ b/src/lib/models/validators.js
@@ -6,7 +6,7 @@ const Joi = require('joi')
 const assert = (value, schema) => Joi.assert(value, schema)
 
 const dateRegex = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/
-const { returnIDRegex } = require('@envage/water-abstraction-helpers').returns
+const { returnIDRegex } = require('../return-id')
 
 const VALID_DATE = Joi.string().regex(dateRegex).required()
 const VALID_NULLABLE_DATE = VALID_DATE.allow(null)

--- a/src/lib/return-id.js
+++ b/src/lib/return-id.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/**
+ * Internal copy of the return ID regex and parser.
+ *
+ * This is intentionally not sourced from @envage/water-abstraction-helpers -
+ * that package cannot be released for security reasons, so changes to the
+ * regex (eg. allowing new region codes) must be duplicated here. This
+ * mirrors the approach taken in water-abstraction-ui, which also keeps its
+ * own local copy rather than depending on the helpers package.
+ */
+const returnIDRegex = /^v1:[1-9]:[^:]+:[0-9]+:[0-9]{4}-[0-9]{2}-[0-9]{2}:[0-9]{4}-[0-9]{2}-[0-9]{2}$/
+
+/**
+ * Parses a return ID into constituent variables
+ * @param {String} returnId
+ * @return {Object}
+ */
+const parseReturnId = returnId => {
+  const [versionStr, regionCode, licenceNumber, formatId, startDate, endDate] = returnId.split(':')
+  const version = parseFloat(versionStr.replace('v', ''))
+  return { version, regionCode, licenceNumber, formatId, startDate, endDate }
+}
+
+exports.returnIDRegex = returnIDRegex
+exports.parseReturnId = parseReturnId

--- a/src/modules/batch-notifications/config/paper-returns/index.js
+++ b/src/modules/batch-notifications/config/paper-returns/index.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 
 const eventHelpers = require('../../lib/event-helpers')
-const { returnIDRegex } = require('@envage/water-abstraction-helpers').returns
+const { returnIDRegex } = require('../../../../lib/return-id')
 const { getRecipients } = require('./lib/get-recipients')
 
 const OPTIONAL_NULLABLE_STRING = Joi.string().allow(null).optional()

--- a/src/modules/returns/lib/csv-adapter/validator.js
+++ b/src/modules/returns/lib/csv-adapter/validator.js
@@ -2,8 +2,7 @@
 
 const { flatten, times } = require('lodash')
 
-const waterHelpers = require('@envage/water-abstraction-helpers')
-const { returnIDRegex, parseReturnId } = waterHelpers.returns
+const { returnIDRegex, parseReturnId } = require('../../../../lib/return-id')
 
 const dateParser = require('./date-parser')
 const csvParser = require('./csv-parser')

--- a/src/modules/returns/schema.js
+++ b/src/modules/returns/schema.js
@@ -9,8 +9,7 @@ const statuses = ['due', 'completed', 'received', 'void']
 const units = ['m³', 'l', 'Ml', 'gal']
 const userTypes = ['internal', 'external']
 
-const waterHelpers = require('@envage/water-abstraction-helpers')
-const { returnIDRegex } = waterHelpers.returns
+const { returnIDRegex } = require('../../lib/return-id')
 
 const userSchema = Joi.object().required().keys({
   email: Joi.string().required(),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5765

- water-abstraction-helpers cannot be released for security reasons, so the region-9 fix to `returnIDRegex` can't reach this service via a package bump
- Adds `src/lib/return-id.js` as a single internal source of truth for `returnIDRegex` / `parseReturnId`, and points the service's four usages at it instead of `@envage/water-abstraction-helpers`
- Mirrors the approach water-abstraction-ui already uses (its own local copy of the regex, not sourced from the helpers package)

Generated with [Claude Code](https://claude.com/claude-code)